### PR TITLE
Implement more of compgen

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -82,6 +82,8 @@ enum TraceEvent {
     Expand,
     #[clap(name = "parse")]
     Parse,
+    #[clap(name = "pattern")]
+    Pattern,
     #[clap(name = "tokenize")]
     Tokenize,
 }
@@ -125,6 +127,7 @@ fn main() {
             TraceEvent::Complete => vec!["shell::completion", "shell::builtins::complete"],
             TraceEvent::Expand => vec![],
             TraceEvent::Parse => vec!["parse"],
+            TraceEvent::Pattern => vec!["shell::pattern"],
             TraceEvent::Tokenize => vec!["tokenize"],
         };
 

--- a/shell/src/builtins/help.rs
+++ b/shell/src/builtins/help.rs
@@ -1,8 +1,6 @@
 use crate::builtin::{BuiltinCommand, BuiltinExitCode};
 use clap::Parser;
-use itertools::Itertools;
 use std::io::Write;
-use std::iter::Iterator;
 
 #[derive(Parser)]
 pub(crate) struct HelpCommand {}
@@ -22,12 +20,7 @@ impl BuiltinCommand for HelpCommand {
             "The following commands are implemented as shell built-ins:"
         )?;
 
-        let builtin_names: Vec<_> = super::SPECIAL_BUILTINS
-            .iter()
-            .chain(super::BUILTINS.iter())
-            .map(|(name, _)| *name)
-            .sorted()
-            .collect();
+        let builtin_names: Vec<_> = crate::builtins::get_all_builtin_names();
 
         const COLUMN_COUNT: usize = 3;
 

--- a/shell/src/builtins/mod.rs
+++ b/shell/src/builtins/mod.rs
@@ -1,4 +1,5 @@
 use futures::future::BoxFuture;
+use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 
@@ -128,6 +129,15 @@ lazy_static::lazy_static! {
     pub(crate) static ref BUILTINS: HashMap<&'static str, BuiltinCommandExecuteFunc> = get_builtins(true);
     pub(crate) static ref POSIX_ONLY_BUILTINS: HashMap<&'static str, BuiltinCommandExecuteFunc> = get_builtins(false);
     pub(crate) static ref DECLARATION_BUILTINS: HashSet<&'static str> = get_declaration_builtin_names();
+}
+
+pub(crate) fn get_all_builtin_names() -> Vec<String> {
+    SPECIAL_BUILTINS
+        .iter()
+        .chain(BUILTINS.iter())
+        .map(|(name, _)| (*name).to_owned())
+        .sorted()
+        .collect::<Vec<_>>()
 }
 
 fn get_declaration_builtin_names() -> HashSet<&'static str> {

--- a/shell/src/patterns.rs
+++ b/shell/src/patterns.rs
@@ -75,6 +75,8 @@ impl Pattern {
             return Ok(vec![concatenated]);
         }
 
+        tracing::debug!("expanding pattern: {self:?}");
+
         let mut components: Vec<PatternWord> = vec![];
         for piece in &self.pieces {
             let mut split_result = piece
@@ -100,11 +102,9 @@ impl Pattern {
         }
 
         let is_absolute = if let Some(first_component) = components.first() {
-            if let Some(first_piece) = first_component.first() {
-                first_piece.as_str().starts_with(std::path::MAIN_SEPARATOR)
-            } else {
-                false
-            }
+            first_component
+                .iter()
+                .all(|piece| piece.as_str().is_empty())
         } else {
             false
         };
@@ -112,7 +112,8 @@ impl Pattern {
         let prefix_to_remove;
         let mut paths_so_far = if is_absolute {
             prefix_to_remove = None;
-            vec![PathBuf::new()]
+            // TODO: Figure out appropriate thing to do on non-Unix platforms.
+            vec![PathBuf::from("/")]
         } else {
             let mut working_dir_str = working_dir.to_string_lossy().to_string();
             working_dir_str.push(std::path::MAIN_SEPARATOR);
@@ -171,6 +172,8 @@ impl Pattern {
                 path_ref.to_string()
             })
             .collect();
+
+        tracing::debug!("  => results: {results:?}");
 
         Ok(results)
     }


### PR DESCRIPTION
Adds naive implementation for `file`, `alias`, `builtin`, and `function`. Future work should figure out how to reduce allocations in this code path, particularly for candidates that don't match filters.