### PR TITLE
CI: build binaries for x86_64/linux and aarch64/linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,15 +20,15 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: "Build"
+  build_x86_64:
+    name: "Build (x86_64/Linux)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
@@ -41,6 +41,48 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: "Upload binaries"
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-x86_64-linux
+          path: target/release/brush
+
+  build_aarch64:
+    name: "Build (aarch64/Linux)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Enable cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.6.9
+
+      - name: Install native prerequisites
+        run: sudo apt-get update -y && sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install cross-compilation toolchain
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build
+        run: cross build --release --target=aarch64-unknown-linux-gnu
+
+      - name: "Upload binaries"
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-aarch64-linux
+          path: target/aarch64-unknown-linux-gnu/release/brush
+
   test:
     name: "Test"
     runs-on: ubuntu-latest
@@ -49,7 +91,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: llvm-tools-preview


### PR DESCRIPTION
Updates the PR/CI workflow to also build release binaries for aarch64 / Linux.