### PR TITLE
fix: compgen -W expansion

### DIFF
--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -379,7 +379,7 @@ impl Spec {
             candidates.append(&mut expansions);
         }
         if let Some(word_list) = &self.word_list {
-            let mut words = split_string_using_ifs(word_list, shell);
+            let mut words = crate::expansion::full_expand_and_split_str(shell, word_list).await?;
             candidates.append(&mut words);
         }
         if let Some(function_name) = &self.function_name {
@@ -942,12 +942,4 @@ fn get_completions_using_basic_lookup(shell: &Shell, context: &Context) -> Answe
     }
 
     Answer::Candidates(candidates, ProcessingOptions::default())
-}
-
-fn split_string_using_ifs<S: AsRef<str>>(s: S, shell: &Shell) -> Vec<String> {
-    let ifs_chars: Vec<char> = shell.get_ifs().chars().collect();
-    s.as_ref()
-        .split(ifs_chars.as_slice())
-        .map(|s| s.to_owned())
-        .collect()
 }

--- a/brush-shell/tests/cases/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/builtins/compgen.yaml
@@ -49,3 +49,10 @@ cases:
       declare myvar2=11
 
       compgen -A variable myvar | sort
+
+  - name: "compgen -W"
+    stdin: |
+      echo "1. Basic compgen -W"
+      compgen -W "one two three" -- t | sort
+      echo "2. compgen -W with expansion"
+      myvar=value compgen -W '${myvar}'


### PR DESCRIPTION
With additional testing we see that the word string passed to 'compgen -W' is not only split but first expanded. Correcting that fixes completion of arguments to 'complete -p', among various other commands.