### PR TITLE
feat: rework here doc files

### DIFF
--- a/brush-core/src/builtins/exec.rs
+++ b/brush-core/src/builtins/exec.rs
@@ -39,7 +39,7 @@ impl builtin::Command for ExecCommand {
             argv0 = Cow::Owned(std::format!("-{argv0}"));
         }
 
-        let (mut cmd, here_doc) = commands::compose_std_command(
+        let mut cmd = commands::compose_std_command(
             context.shell,
             &self.args[0],
             argv0.as_str(),
@@ -47,10 +47,6 @@ impl builtin::Command for ExecCommand {
             context.open_files.clone(),
             self.empty_environment,
         )?;
-
-        if here_doc.is_some() {
-            return error::unimp("exec with here doc");
-        }
 
         let exec_error = cmd.exec();
 

--- a/brush-shell/tests/cases/builtins/read.yaml
+++ b/brush-shell/tests/cases/builtins/read.yaml
@@ -21,7 +21,6 @@ cases:
       (echo "a b") | while read -a arr; do declare -p arr; done
 
   - name: "read from here string"
-    known_failure: true
     stdin: |
       read myvar <<< "hello"
       echo "myvar: ${myvar}"
@@ -30,10 +29,4 @@ cases:
     known_failure: true
     stdin: |
       read myvar < <(echo hello)
-      echo "myvar: ${myvar}"
-
-  - name: "read from command substitution"
-    known_failure: true
-    stdin: |
-      read myvar <<< "$(echo hello)"
       echo "myvar: ${myvar}"

--- a/brush-shell/tests/cases/here.yaml
+++ b/brush-shell/tests/cases/here.yaml
@@ -11,6 +11,23 @@ cases:
           echo "This is after"
     args: ["./script.sh"]
 
+  - name: "Here doc with expansions"
+    known_failure: true
+    stdin: |
+      cat <<END-MARKER
+      Something here...
+      ...and here.
+      $(echo "This is after")
+      END-MARKER
+
+  - name: "Here doc with tab removal"
+    known_failure: true
+    stdin: |
+      cat <<-END-MARKER
+      	Something here...
+      	...and here.
+      	END-MARKER
+
   - name: "Basic here string"
     stdin: |
       shopt -ou posix


### PR DESCRIPTION
Prior to this change, here-documents and here-strings require special handling at command execution time. With this change, we back them with pipes that we write contents into (and then close).

There's risk that the internal pipe buffers fill up before the reading command is executed; to mitigate this, we call `fcntl` to adjust the buffers. That, in turn, brings along a new risk that a very large here-document or here-string will result in a pipe with a very large buffer. We accept that consequence for now, in return for allowing them to be used with a wider variety of commands (e.g., built-in commands). Notably, they can now be used with `read` and we can remove `known_failure` from the corresponding test.