### PR TITLE
feat: set + validate intentional MSRV (1.72.0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,14 +169,21 @@ jobs:
   check:
     name: "Source code checks"
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Test latest stable as well as MSRV.
+        rust-version: ["stable", "1.72.0"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up rust toolchain
+      - name: Set up rust toolchain (${{ matrix.rust-version }})
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust-version }}
+          components: clippy, rustfmt
 
       - name: Enable cargo cache
         uses: Swatinem/rust-cache@v2
@@ -200,6 +207,7 @@ jobs:
           cargo deny check
 
       - name: Clippy check
+        if: matrix.rust-version == 'stable'
         run: cargo clippy --all-targets
 
   benchmark:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.14"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
 dependencies = [
  "anstyle",
  "bstr",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -480,22 +480,22 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clipboard-win"
@@ -666,7 +666,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.66",
 ]
 
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.5.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1930,6 +1930,12 @@ checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["cli", "shell", "sh", "bash", "script"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/reubeno/brush"
+rust-version = "1.72.0"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 bench = false
@@ -20,7 +21,8 @@ async-recursion = "1.1.0"
 async-trait = "0.1.80"
 brush-parser = { version = "0.1.0", path = "../brush-parser" }
 cached = "0.51.3"
-clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
+# N.B. Pin to 4.4.18 for now to keep to 1.72.0 as MSRV; 4.5.x requires a later version.
+clap = { version = "=4.4.18", features = ["derive", "wrap_help"] }
 fancy-regex = "0.13.0"
 futures = "0.3.30"
 hostname = "0.4.0"

--- a/brush-core/src/builtins/mod.rs
+++ b/brush-core/src/builtins/mod.rs
@@ -52,7 +52,7 @@ mod unimp;
 mod unset;
 mod wait;
 
-fn builtin<B: builtin::Command + Send>() -> builtin::Registration {
+fn builtin<B: builtin::Command + Send + Sync>() -> builtin::Registration {
     builtin::Registration {
         execute_func: exec_builtin::<B>,
         content_func: get_builtin_content::<B>,
@@ -62,7 +62,7 @@ fn builtin<B: builtin::Command + Send>() -> builtin::Registration {
     }
 }
 
-fn special_builtin<B: builtin::Command + Send>() -> builtin::Registration {
+fn special_builtin<B: builtin::Command + Send + Sync>() -> builtin::Registration {
     builtin::Registration {
         execute_func: exec_builtin::<B>,
         content_func: get_builtin_content::<B>,
@@ -72,7 +72,7 @@ fn special_builtin<B: builtin::Command + Send>() -> builtin::Registration {
     }
 }
 
-fn decl_builtin<B: builtin::DeclarationCommand + Send>() -> builtin::Registration {
+fn decl_builtin<B: builtin::DeclarationCommand + Send + Sync>() -> builtin::Registration {
     builtin::Registration {
         execute_func: exec_declaration_builtin::<B>,
         content_func: get_builtin_content::<B>,
@@ -82,7 +82,7 @@ fn decl_builtin<B: builtin::DeclarationCommand + Send>() -> builtin::Registratio
     }
 }
 
-fn special_decl_builtin<B: builtin::DeclarationCommand + Send>() -> builtin::Registration {
+fn special_decl_builtin<B: builtin::DeclarationCommand + Send + Sync>() -> builtin::Registration {
     builtin::Registration {
         execute_func: exec_declaration_builtin::<B>,
         content_func: get_builtin_content::<B>,
@@ -92,21 +92,21 @@ fn special_decl_builtin<B: builtin::DeclarationCommand + Send>() -> builtin::Reg
     }
 }
 
-fn get_builtin_content<T: builtin::Command + Send>(
+fn get_builtin_content<T: builtin::Command + Send + Sync>(
     name: &str,
     content_type: builtin::ContentType,
 ) -> Result<String, error::Error> {
     T::get_content(name, content_type)
 }
 
-fn exec_builtin<T: builtin::Command + Send>(
+fn exec_builtin<T: builtin::Command + Send + Sync>(
     context: commands::ExecutionContext<'_>,
     args: Vec<CommandArg>,
 ) -> BoxFuture<'_, Result<builtin::BuiltinResult, error::Error>> {
     Box::pin(async move { exec_builtin_impl::<T>(context, args).await })
 }
 
-async fn exec_builtin_impl<T: builtin::Command + Send>(
+async fn exec_builtin_impl<T: builtin::Command + Send + Sync>(
     context: commands::ExecutionContext<'_>,
     args: Vec<CommandArg>,
 ) -> Result<builtin::BuiltinResult, error::Error> {
@@ -131,14 +131,14 @@ async fn exec_builtin_impl<T: builtin::Command + Send>(
     })
 }
 
-fn exec_declaration_builtin<T: builtin::DeclarationCommand + Send>(
+fn exec_declaration_builtin<T: builtin::DeclarationCommand + Send + Sync>(
     context: commands::ExecutionContext<'_>,
     args: Vec<CommandArg>,
 ) -> BoxFuture<'_, Result<builtin::BuiltinResult, error::Error>> {
     Box::pin(async move { exec_declaration_builtin_impl::<T>(context, args).await })
 }
 
-async fn exec_declaration_builtin_impl<T: builtin::DeclarationCommand + Send>(
+async fn exec_declaration_builtin_impl<T: builtin::DeclarationCommand + Send + Sync>(
     context: commands::ExecutionContext<'_>,
     args: Vec<CommandArg>,
 ) -> Result<builtin::BuiltinResult, error::Error> {

--- a/brush-core/src/openfiles.rs
+++ b/brush-core/src/openfiles.rs
@@ -138,16 +138,19 @@ impl std::io::Read for OpenFile {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
             OpenFile::Stdin => std::io::stdin().read(buf),
-            OpenFile::Stdout => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
-                "stdout",
-            ))),
-            OpenFile::Stderr => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
-                "stderr",
-            ))),
+            OpenFile::Stdout => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                error::Error::OpenFileNotReadable("stdout"),
+            )),
+            OpenFile::Stderr => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                error::Error::OpenFileNotReadable("stderr"),
+            )),
             OpenFile::Null => Ok(0),
             OpenFile::File(f) => f.read(buf),
             OpenFile::PipeReader(reader) => reader.read(buf),
-            OpenFile::PipeWriter(_) => Err(std::io::Error::other(
+            OpenFile::PipeWriter(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
                 error::Error::OpenFileNotReadable("pipe writer"),
             )),
         }
@@ -157,14 +160,16 @@ impl std::io::Read for OpenFile {
 impl std::io::Write for OpenFile {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
-            OpenFile::Stdin => Err(std::io::Error::other(error::Error::OpenFileNotWritable(
-                "stdin",
-            ))),
+            OpenFile::Stdin => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                error::Error::OpenFileNotWritable("stdin"),
+            )),
             OpenFile::Stdout => std::io::stdout().write(buf),
             OpenFile::Stderr => std::io::stderr().write(buf),
             OpenFile::Null => Ok(buf.len()),
             OpenFile::File(f) => f.write(buf),
-            OpenFile::PipeReader(_) => Err(std::io::Error::other(
+            OpenFile::PipeReader(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
                 error::Error::OpenFileNotWritable("pipe reader"),
             )),
             OpenFile::PipeWriter(writer) => writer.write(buf),

--- a/brush-interactive/Cargo.toml
+++ b/brush-interactive/Cargo.toml
@@ -9,6 +9,7 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 bench = false

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -9,6 +9,7 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 bench = false

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -9,6 +9,7 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "brush"
@@ -27,14 +28,16 @@ workspace = true
 brush-interactive = { version = "0.1.0", path = "../brush-interactive" }
 brush-parser = { version = "0.1.0", path = "../brush-parser" }
 brush-core = { version = "0.1.0", path = "../brush-core" }
-clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
+# N.B. Pin to 4.4.18 for now to keep to 1.72.0 as MSRV; 4.5.x requires a later version.
+clap = { version = "=4.4.18", features = ["derive", "wrap_help"] }
 tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
 [dev-dependencies]
 anyhow = "1.0.86"
-assert_cmd = "2.0.14"
+# N.B. Pin to 2.0.13 for now to keep to 1.72.0 as MSRV; 2.0.14 requires a later version.
+assert_cmd = "=2.0.13"
 assert_fs = "1.1.1"
 colored = "2.1.0"
 descape = "1.1.2"

--- a/deny.toml
+++ b/deny.toml
@@ -77,7 +77,9 @@ deny = []
 #exact = true
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
-skip = []
+skip = [
+    { crate = "strsim", reason = "conflict between old version of clap and cached" }
+]
 skip-tree = [
     { crate = "windows-sys", reason = "several crates use outdated versions" },
     { crate = "nix", reason = "there are multiple versions floating" },


### PR DESCRIPTION
Picking 1.72.0 for now; this required removing usage of a few convenience functions that haven't been around too long, fixing a few minor compilation errors, and downgrading `clap`. When we're ready to move the MSRV higher, we can revert these changes.