### PR TITLE
fix: ensure brush-core builds outside workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "brush-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "brush-interactive"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "brush-core",
  "brush-parser",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "brush-parser"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "brush-shell"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brush-core"
 description = "Reusable core of a POSIX/bash shell (used by brush-shell)"
-version = "0.2.1"
+version = "0.2.2"
 categories.workspace = true
 edition.workspace = true
 keywords.workspace = true
@@ -19,7 +19,7 @@ workspace = true
 [dependencies]
 async-recursion = "1.1.0"
 async-trait = "0.1.80"
-brush-parser = { version = "^0.2.1", path = "../brush-parser" }
+brush-parser = { version = "^0.2.2", path = "../brush-parser" }
 cached = "0.51.3"
 # N.B. Pin to 4.4.18 for now to keep to 1.72.0 as MSRV; 4.5.x requires a later version.
 clap = { version = "=4.4.18", features = ["derive", "wrap_help"] }
@@ -47,7 +47,7 @@ whoami = "1.5.1"
 
 [target.'cfg(unix)'.dependencies]
 command-fds = "0.3.0"
-nix = { version = "0.29.0", features = ["fs", "process", "signal", "user"] }
+nix = { version = "0.29.0", features = ["fs", "process", "signal", "term", "user"] }
 procfs = "0.16.0"
 uzers = "0.12.0"
 

--- a/brush-interactive/Cargo.toml
+++ b/brush-interactive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brush-interactive"
 description = "Interactive layer of brush-shell"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true
@@ -18,8 +18,8 @@ bench = false
 workspace = true
 
 [dependencies]
-brush-parser = { version = "^0.2.1", path = "../brush-parser" }
-brush-core = { version = "^0.2.1", path = "../brush-core" }
+brush-parser = { version = "^0.2.2", path = "../brush-parser" }
+brush-core = { version = "^0.2.2", path = "../brush-core" }
 rustyline = { package = "brush-rustyline-fork", version = "14.0.1", features = [
     "derive",
 ] }

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brush-parser"
 description = "POSIX/bash shell tokenizer and parsers (used by brush-shell)"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brush-shell"
 description = "Rust-implemented shell focused on POSIX and bash compatibility"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true
@@ -25,9 +25,9 @@ harness = false
 workspace = true
 
 [dependencies]
-brush-interactive = { version = "^0.2.1", path = "../brush-interactive" }
-brush-parser = { version = "^0.2.1", path = "../brush-parser" }
-brush-core = { version = "^0.2.1", path = "../brush-core" }
+brush-interactive = { version = "^0.2.2", path = "../brush-interactive" }
+brush-parser = { version = "^0.2.2", path = "../brush-parser" }
+brush-core = { version = "^0.2.2", path = "../brush-core" }
 # N.B. Pin to 4.4.18 for now to keep to 1.72.0 as MSRV; 4.5.x requires a later version.
 clap = { version = "=4.4.18", features = ["derive", "wrap_help"] }
 tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread"] }


### PR DESCRIPTION
Add `term` feature to the `nix` package dependency of `brush-core`.