### PR TITLE
fix: realign newline parsing with spec

### DIFF
--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -53,7 +53,8 @@ impl<R: std::io::BufRead> Parser<R> {
     ///
     /// # Arguments
     ///
-    /// * `stop_on_unescaped_newline` - Whether or not to stop parsing when an unescaped newline is encountered.
+    /// * `stop_on_unescaped_newline` - Whether or not to stop parsing when an unescaped newline is
+    ///   encountered.
     pub fn parse(
         &mut self,
         stop_on_unescaped_newline: bool,
@@ -620,13 +621,11 @@ peg::parser! {
             word()
 
         rule newline_list() -> () =
-            newline()* {}
+            newline()+ {}
 
-        // N.B. We don't need to add a '?' to the invocation of the newline_list()
-        // rule because it already allows 0 newlines.
         rule linebreak() -> () =
             quiet! {
-                newline_list() {}
+                newline()* {}
             }
 
         rule separator_op() -> ast::SeparatorOperator =

--- a/brush-shell/tests/cases/compound_cmds/subshell.yaml
+++ b/brush-shell/tests/cases/compound_cmds/subshell.yaml
@@ -4,6 +4,11 @@ cases:
     stdin: |
       (echo hi)
 
+  - name: "Subshells in sequence"
+    ignore_stderr: true
+    stdin: |
+      (echo hi)(echo there)
+
   - name: "Subshell env usage"
     stdin: |
       (subshell_var=value && echo "subshell_var: ${subshell_var}")


### PR DESCRIPTION
Correct parsing of newlines so that they are strictly required in certain cases of the grammar.

This specifically fixes the case of parsing `(subshell_command)(subshell_command)`. This syntax should not be considered valid, but brush was previously allowing it. This change also adds a test case to confirm.