### PR TITLE
feat: start using cargo-fuzz for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +267,18 @@ dependencies = [
  "tracing",
  "uzers",
  "whoami",
+]
+
+[[package]]
+name = "brush-fuzz"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "brush-core",
+ "brush-parser",
+ "libfuzzer-sys",
+ "tokio",
 ]
 
 [[package]]
@@ -415,6 +433,11 @@ name = "cc"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1213,6 +1236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1276,17 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
-members = ["brush-shell", "brush-parser", "brush-core", "brush-interactive"]
-default-members = ["brush-shell", "brush-parser", "brush-core", "brush-interactive"]
+members = ["brush-shell", "brush-parser", "brush-core", "brush-interactive", "fuzz"]
+default-members = ["brush-shell"]
 
 [workspace.package]
 authors = ["reuben olinsky"]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "brush-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+anyhow = "1.0.86"
+assert_cmd = "=2.0.13"
+libfuzzer-sys = "0.4"
+tokio = { version = "1.37.0", features = ["rt"] }
+
+[dependencies.brush-core]
+path = "../brush-core"
+
+[dependencies.brush-parser]
+path = "../brush-parser"
+
+[[bin]]
+name = "fuzz_target"
+path = "fuzz_targets/fuzz_target.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_target.rs
+++ b/fuzz/fuzz_targets/fuzz_target.rs
@@ -1,0 +1,67 @@
+#![no_main]
+
+use anyhow::Result;
+use libfuzzer_sys::fuzz_target;
+
+async fn run_async(input: String) -> Result<()> {
+    //
+    // Instantiate a brush shell with defaults, then try to parse the input.
+    //
+    let options = brush_core::CreateOptions::default();
+    let shell = brush_core::Shell::new(&options).await?;
+    let our_parse_result = shell.parse_string(input.clone());
+
+    //
+    // Now run it under 'bash -n -t' as a crude way to see if it's at least valid syntax.
+    //
+    let mut oracle_cmd = std::process::Command::new("bash");
+    oracle_cmd
+        .arg("--noprofile")
+        .arg("--norc")
+        .arg("-O")
+        .arg("extglob")
+        .arg("-n")
+        .arg("-t");
+
+    let mut oracle_cmd = assert_cmd::Command::from_std(oracle_cmd);
+
+    const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
+    oracle_cmd.timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_IN_SECONDS));
+
+    let mut input = input;
+    input.push('\n');
+    oracle_cmd.write_stdin(input.as_bytes());
+
+    let oracle_result = oracle_cmd.output()?;
+
+    //
+    // Compare results.
+    //
+    if our_parse_result.is_ok() != oracle_result.status.success() {
+        Err(anyhow::anyhow!(
+            "Mismatched parse results: {oracle_result:?} vs {our_parse_result:?}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fuzz_target!(|input: String| {
+    // Ignore known problematic cases without actually running them.
+    if input.is_empty()
+        || input.contains(|c: char| c.is_ascii_control() || !c.is_ascii()) // non-ascii chars (or control sequences)
+        || input.contains("!") // history expansions
+        || (input.contains("[") && !input.contains("]")) // ???
+        || input.contains("<<") // weirdness with here docs
+        || input.ends_with('\\') // unterminated trailing escape char?
+        || input.contains("|&")
+    // unimplemented bash-ism
+    {
+        return;
+    }
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(run_async(input));
+
+    result.unwrap();
+});


### PR DESCRIPTION
Initial cargo-fuzz fuzzing target useful for testing tokenizing (and possibly parsing). Thus far has caught ~5 errors in the tokenizer, but needs hand-holding to run.