### PR TITLE
feat: enable fuzz-testing arithmetic eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,9 @@ name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arrayvec"
@@ -298,6 +301,7 @@ name = "brush-parser"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "assert_matches",
  "criterion",
  "indenter",
@@ -731,6 +735,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::arithmetic::Evaluatable;
 use crate::env::{EnvironmentLookup, EnvironmentScope, ShellEnvironment};
 use crate::files::PathExt;
 use crate::interp::{Execute, ExecutionParameters, ExecutionResult};
@@ -19,7 +20,6 @@ use crate::{
 pub struct Shell {
     //
     // Core state required by specification
-    //
     /// Trap handler configuration for the shell.
     pub traps: traps::TrapHandlerConfig,
     /// Manages files opened and accessible via redirection operators.
@@ -39,7 +39,6 @@ pub struct Shell {
 
     //
     // Additional state
-    //
     /// The status of the last completed command.
     pub last_exit_status: u8,
 
@@ -983,6 +982,15 @@ impl Shell {
         }
 
         Ok(())
+    }
+
+    /// Evaluate the given arithmetic expression, returning the result.
+    pub async fn eval_arithmetic(
+        &mut self,
+        expr: brush_parser::ast::ArithmeticExpr,
+    ) -> Result<i64, error::Error> {
+        let result = expr.eval(self).await?;
+        Ok(result)
     }
 }
 

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -14,7 +14,11 @@ rust-version.workspace = true
 [lib]
 bench = false
 
+[features]
+fuzz-testing = ["dep:arbitrary"]
+
 [dependencies]
+arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
 indenter = "0.3.3"
 peg = "0.8.3"
 thiserror = "1.0.61"

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -9,6 +9,7 @@ const DISPLAY_INDENT: &str = "    ";
 
 /// Represents a complete shell program.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct Program {
     /// A sequence of complete shell commands.
     pub complete_commands: Vec<CompleteCommand>,
@@ -31,6 +32,7 @@ pub type CompleteCommandItem = CompoundListItem;
 
 /// Indicates whether the preceding command is executed synchronously or asynchronously.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum SeparatorOperator {
     /// The preceding command is executed asynchronously.
     Async,
@@ -49,6 +51,7 @@ impl Display for SeparatorOperator {
 
 /// Represents a sequence of command pipelines connected by boolean operators.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct AndOrList {
     /// The first command pipeline.
     pub first: Pipeline,
@@ -70,6 +73,7 @@ impl Display for AndOrList {
 /// Represents a boolean operator used to connect command pipelines, along with the
 /// succeeding pipeline.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum AndOr {
     /// Boolean AND operator; the embedded pipeline is only to be executed if the
     /// preceding command has succeeded.
@@ -91,6 +95,7 @@ impl Display for AndOr {
 /// A pipeline of commands, where each command's output is passed as standard input
 /// to the command that follows it.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct Pipeline {
     /// Indicates whether the result of the overall pipeline should be the logical
     /// negation of the result of the pipeline.
@@ -117,6 +122,7 @@ impl Display for Pipeline {
 
 /// Represents a shell command.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum Command {
     /// A simple command, directly invoking an external command, a built-in command,
     /// a shell function, or similar.
@@ -150,6 +156,7 @@ impl Display for Command {
 
 /// Represents a compound command, potentially made up of multiple nested commands.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum CompoundCommand {
     /// An arithmetic command, evaluating an arithmetic expression.
     Arithmetic(ArithmeticCommand),
@@ -200,6 +207,7 @@ impl Display for CompoundCommand {
 
 /// An arithmetic command, evaluating an arithmetic expression.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct ArithmeticCommand {
     /// The raw, unparsed and unexpanded arithmetic expression.
     pub expr: UnexpandedArithmeticExpr,
@@ -213,6 +221,7 @@ impl Display for ArithmeticCommand {
 
 /// A subshell, which executes commands in a subshell.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct SubshellCommand(pub CompoundList);
 
 impl Display for SubshellCommand {
@@ -225,6 +234,7 @@ impl Display for SubshellCommand {
 
 /// A for clause, which loops over a set of values.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct ForClauseCommand {
     /// The name of the iterator variable.
     pub variable_name: String,
@@ -256,6 +266,7 @@ impl Display for ForClauseCommand {
 
 /// An arithmetic for clause, which loops until an arithmetic condition is reached.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct ArithmeticForClauseCommand {
     /// Optionally, the initializer expression evaluated before the first iteration of the loop.
     pub initializer: Option<UnexpandedArithmeticExpr>,
@@ -296,6 +307,7 @@ impl Display for ArithmeticForClauseCommand {
 /// A case clause, which selects a command based on a value and a set of
 /// pattern-based filters.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct CaseClauseCommand {
     /// The value being matched on.
     pub value: Word,
@@ -316,6 +328,7 @@ impl Display for CaseClauseCommand {
 
 /// A sequence of commands.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct CompoundList(pub Vec<CompoundListItem>);
 
 impl Display for CompoundList {
@@ -342,6 +355,7 @@ impl Display for CompoundList {
 
 /// An element of a compound command list.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct CompoundListItem(pub AndOrList, pub SeparatorOperator);
 
 impl Display for CompoundListItem {
@@ -354,6 +368,7 @@ impl Display for CompoundListItem {
 
 /// An if clause, which conditionally executes a command.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct IfClauseCommand {
     /// The command whose execution result is inspected.
     pub condition: CompoundList,
@@ -386,6 +401,7 @@ impl Display for IfClauseCommand {
 
 /// Represents the `else` clause of a conditional command.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct ElseClause {
     /// If present, the condition that must be met for this `else` clause to be executed.
     pub condition: Option<CompoundList>,
@@ -412,6 +428,7 @@ impl Display for ElseClause {
 
 /// An individual matching case item in a case clause.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct CaseItem {
     /// The patterns that select this case branch.
     pub patterns: Vec<Word>,
@@ -440,6 +457,7 @@ impl Display for CaseItem {
 
 /// A while or until clause, whose looping is controlled by a condition.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct WhileOrUntilClauseCommand(pub CompoundList, pub DoGroupCommand);
 
 impl Display for WhileOrUntilClauseCommand {
@@ -450,6 +468,7 @@ impl Display for WhileOrUntilClauseCommand {
 
 /// Encapsulates the definition of a shell function.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct FunctionDefinition {
     /// The name of the function.
     pub fname: String,
@@ -469,6 +488,7 @@ impl Display for FunctionDefinition {
 
 /// Encapsulates the body of a function definition.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct FunctionBody(pub CompoundCommand, pub Option<RedirectList>);
 
 impl Display for FunctionBody {
@@ -484,6 +504,7 @@ impl Display for FunctionBody {
 
 /// A brace group, which groups commands together.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct BraceGroupCommand(pub CompoundList);
 
 impl Display for BraceGroupCommand {
@@ -499,6 +520,7 @@ impl Display for BraceGroupCommand {
 
 /// A do group, which groups commands together.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct DoGroupCommand(pub CompoundList);
 
 impl Display for DoGroupCommand {
@@ -512,6 +534,7 @@ impl Display for DoGroupCommand {
 
 /// Represents the invocation of a simple command.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct SimpleCommand {
     /// Optionally, a prefix to the command.
     pub prefix: Option<CommandPrefix>,
@@ -557,6 +580,7 @@ impl Display for SimpleCommand {
 
 /// Represents a prefix to a simple command.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct CommandPrefix(pub Vec<CommandPrefixOrSuffixItem>);
 
 impl Display for CommandPrefix {
@@ -574,6 +598,7 @@ impl Display for CommandPrefix {
 
 /// Represents a suffix to a simple command; a word argument, declaration, or I/O redirection.
 #[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct CommandSuffix(pub Vec<CommandPrefixOrSuffixItem>);
 
 impl Display for CommandSuffix {
@@ -591,6 +616,7 @@ impl Display for CommandSuffix {
 
 /// A prefix or suffix for a simple command.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum CommandPrefixOrSuffixItem {
     /// An I/O redirection.
     IoRedirect(IoRedirect),
@@ -612,6 +638,7 @@ impl Display for CommandPrefixOrSuffixItem {
 
 /// Encapsulates an assignment declaration.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct Assignment {
     /// Name being assigned to.
     pub name: AssignmentName,
@@ -633,6 +660,7 @@ impl Display for Assignment {
 
 /// The target of an assignment.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum AssignmentName {
     /// A named variable.
     VariableName(String),
@@ -653,6 +681,7 @@ impl Display for AssignmentName {
 
 /// A value being assigned to a variable.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum AssignmentValue {
     /// A scalar (word) value.
     Scalar(Word),
@@ -683,6 +712,7 @@ impl Display for AssignmentValue {
 
 /// A list of I/O redirections to be applied to a command.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct RedirectList(pub Vec<IoRedirect>);
 
 impl Display for RedirectList {
@@ -696,6 +726,7 @@ impl Display for RedirectList {
 
 /// An I/O redirection.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum IoRedirect {
     /// Redirection to a file.
     File(Option<u32>, IoFileRedirectKind, IoFileRedirectTarget),
@@ -761,6 +792,7 @@ impl Display for IoRedirect {
 
 /// Kind of file I/O redirection.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum IoFileRedirectKind {
     /// Read (`<`).
     Read,
@@ -794,6 +826,7 @@ impl Display for IoFileRedirectKind {
 
 /// Target for an I/O file redirection.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum IoFileRedirectTarget {
     /// Path to a file.
     Filename(Word),
@@ -818,6 +851,7 @@ impl Display for IoFileRedirectTarget {
 
 /// Represents an I/O here document.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct IoHereDocument {
     /// Whether to remove leading tabs from the here document.
     pub remove_tabs: bool,
@@ -865,6 +899,7 @@ impl Display for TestExpr {
 
 /// An extended test expression.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum ExtendedTestExpr {
     /// Logical AND operation on two nested expressions.
     And(Box<ExtendedTestExpr>, Box<ExtendedTestExpr>),
@@ -907,6 +942,7 @@ impl Display for ExtendedTestExpr {
 
 /// A unary predicate usable in an extended test expression.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum UnaryPredicate {
     /// Computes if the operand is a path to an existing file.
     FileExists,
@@ -994,6 +1030,7 @@ impl Display for UnaryPredicate {
 
 /// A binary predicate usable in an extended test expression.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum BinaryPredicate {
     /// Computes if two files refer to the same device and inode numbers.
     FilesReferToSameDeviceAndInodeNumbers,
@@ -1051,6 +1088,7 @@ impl Display for BinaryPredicate {
 
 /// Represents a shell word.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct Word {
     /// Raw text of the word.
     pub value: String,
@@ -1091,6 +1129,7 @@ impl Word {
 
 /// Encapsulates an unparsed arithmetic expression.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct UnexpandedArithmeticExpr {
     /// The raw text of the expression.
     pub value: String,
@@ -1127,6 +1166,55 @@ pub enum ArithmeticExpr {
     UnaryAssignment(UnaryAssignmentOperator, ArithmeticTarget),
 }
 
+#[cfg(feature = "fuzz-testing")]
+impl<'a> arbitrary::Arbitrary<'a> for ArithmeticExpr {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let variant = u.choose(&[
+            "Literal",
+            "Reference",
+            "UnaryOp",
+            "BinaryOp",
+            "Conditional",
+            "Assignment",
+            "BinaryAssignment",
+            "UnaryAssignment",
+        ])?;
+
+        match *variant {
+            "Literal" => Ok(ArithmeticExpr::Literal(i64::arbitrary(u)?)),
+            "Reference" => Ok(ArithmeticExpr::Reference(ArithmeticTarget::arbitrary(u)?)),
+            "UnaryOp" => Ok(ArithmeticExpr::UnaryOp(
+                UnaryOperator::arbitrary(u)?,
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+            )),
+            "BinaryOp" => Ok(ArithmeticExpr::BinaryOp(
+                BinaryOperator::arbitrary(u)?,
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+            )),
+            "Conditional" => Ok(ArithmeticExpr::Conditional(
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+            )),
+            "Assignment" => Ok(ArithmeticExpr::Assignment(
+                ArithmeticTarget::arbitrary(u)?,
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+            )),
+            "BinaryAssignment" => Ok(ArithmeticExpr::BinaryAssignment(
+                BinaryOperator::arbitrary(u)?,
+                ArithmeticTarget::arbitrary(u)?,
+                Box::new(ArithmeticExpr::arbitrary(u)?),
+            )),
+            "UnaryAssignment" => Ok(ArithmeticExpr::UnaryAssignment(
+                UnaryAssignmentOperator::arbitrary(u)?,
+                ArithmeticTarget::arbitrary(u)?,
+            )),
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl Display for ArithmeticExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1159,6 +1247,7 @@ impl Display for ArithmeticExpr {
 
 /// A binary arithmetic operator.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum BinaryOperator {
     /// Exponentiation (e.g., `x ** y`).
     Power,
@@ -1231,6 +1320,7 @@ impl Display for BinaryOperator {
 
 /// A unary arithmetic operator.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum UnaryOperator {
     /// Unary plus (e.g., `+x`).
     UnaryPlus,
@@ -1255,6 +1345,7 @@ impl Display for UnaryOperator {
 
 /// A unary arithmetic assignment operator.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum UnaryAssignmentOperator {
     /// Prefix increment (e.g., `++x`).
     PrefixIncrement,
@@ -1279,6 +1370,7 @@ impl Display for UnaryAssignmentOperator {
 
 /// Identifies the target of an arithmetic assignment expression.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum ArithmeticTarget {
     /// A named variable.
     Variable(String),

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -18,6 +18,7 @@ pub(crate) enum TokenEndReason {
 
 /// Represents a position in a source shell script.
 #[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct SourcePosition {
     /// The 0-based index of the character in the input stream.
     pub index: i32,
@@ -35,6 +36,7 @@ impl Display for SourcePosition {
 
 /// Represents the location of a token in its source shell script.
 #[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub struct TokenLocation {
     /// The start position of the token.
     pub start: SourcePosition,
@@ -44,6 +46,7 @@ pub struct TokenLocation {
 
 /// Represents a token extracted from a shell script.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 pub enum Token {
     /// An operator token.
     Operator(String, TokenLocation),

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,10 +26,18 @@ path = "../brush-core"
 
 [dependencies.brush-parser]
 path = "../brush-parser"
+features = ["fuzz-testing"]
 
 [[bin]]
 name = "fuzz_target"
 path = "fuzz_targets/fuzz_target.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_arithmetic"
+path = "fuzz_targets/fuzz_arithmetic.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -1,0 +1,78 @@
+#![no_main]
+
+use anyhow::Result;
+use brush_parser::ast;
+use libfuzzer_sys::fuzz_target;
+
+async fn eval_arithmetic_async(input: ast::ArithmeticExpr) -> Result<()> {
+    //
+    // Turn it back into a string so we can pass it in on the command-line.
+    //
+    let input_str = input.to_string();
+
+    //
+    // Instantiate a brush shell with defaults, then try to evaluate the expression.
+    //
+    let options = brush_core::CreateOptions::default();
+    let mut shell = brush_core::Shell::new(&options).await?;
+    let parsed_expr = brush_parser::arithmetic::parse(input_str.as_str()).ok();
+    let our_eval_result = if let Some(parsed_expr) = parsed_expr {
+        shell.eval_arithmetic(parsed_expr).await.ok()
+    } else {
+        None
+    };
+
+    //
+    // Now run it under 'bash'
+    //
+    let mut oracle_cmd = std::process::Command::new("bash");
+    oracle_cmd
+        .arg("--noprofile")
+        .arg("--norc")
+        .arg("-O")
+        .arg("extglob")
+        .arg("-t");
+
+    let mut oracle_cmd = assert_cmd::Command::from_std(oracle_cmd);
+
+    const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
+    oracle_cmd.timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_IN_SECONDS));
+
+    let input = std::format!("echo \"$(( {input} ))\"\n");
+    oracle_cmd.write_stdin(input.as_bytes());
+
+    let oracle_result = oracle_cmd.output()?;
+    let oracle_eval_result = if oracle_result.status.success() {
+        let oracle_output = std::str::from_utf8(&oracle_result.stdout)?;
+        oracle_output.trim().parse::<i64>().ok()
+    } else {
+        None
+    };
+
+    //
+    // Compare results.
+    //
+    if our_eval_result != oracle_eval_result {
+        Err(anyhow::anyhow!(
+            "Mismatched eval results: {oracle_eval_result:?} from oracle vs. {our_eval_result:?} from our test (expr: '{input}', oracle result: {oracle_result:?})"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fuzz_target!(|input: ast::ArithmeticExpr| {
+    let s = input.to_string();
+    let s = s.trim();
+
+    // For now, intentionally ignore known problematic cases without actually running them.
+    if s.contains("+ 0")
+        || s.is_empty()
+        || s.contains(|c: char| c.is_ascii_control() || !c.is_ascii())
+    {
+        return;
+    }
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(eval_arithmetic_async(input)).unwrap();
+});


### PR DESCRIPTION
This paves the way to using fuzz testing for arithmetic evaluation, as well as broader testing with structured brush ASTs.