### PR TITLE
fix: resolve assorted arithmetic eval issues

### DIFF
--- a/brush-parser/src/arithmetic.rs
+++ b/brush-parser/src/arithmetic.rs
@@ -68,7 +68,7 @@ peg::parser! {
             x:(@) _ "%" _ y:@ { ast::ArithmeticExpr::BinaryOp(ast::BinaryOperator::Modulo, Box::new(x), Box::new(y)) }
             x:(@) _ "/" _ y:@ { ast::ArithmeticExpr::BinaryOp(ast::BinaryOperator::Divide, Box::new(x), Box::new(y)) }
             --
-            x:(@) _ "**" _ y:@ { ast::ArithmeticExpr::BinaryOp(ast::BinaryOperator::Power, Box::new(x), Box::new(y)) }
+            x:@ _ "**" _ y:(@) { ast::ArithmeticExpr::BinaryOp(ast::BinaryOperator::Power, Box::new(x), Box::new(y)) }
             --
             "!" x:(@) { ast::ArithmeticExpr::UnaryOp(ast::UnaryOperator::LogicalNot, Box::new(x)) }
             "~" x:(@) { ast::ArithmeticExpr::UnaryOp(ast::UnaryOperator::BitwiseNot, Box::new(x)) }
@@ -96,14 +96,14 @@ peg::parser! {
             }
 
         rule variable_name() -> &'input str =
-            $(['a'..='z' | 'A'..='Z' | '_']+)
+            $(['a'..='z' | 'A'..='Z' | '_'](['a'..='z' | 'A'..='Z' | '_' | '0'..='9']*))
 
         rule _() -> () = quiet!{[' ' | '\t' | '\n' | '\r']*} {}
 
         rule literal_number() -> i64 =
             // TODO: handle binary?
-            "0" ['x' | 'X'] s:$(['0'..='9']*) {? i64::from_str_radix(s, 16).or(Err("i64")) } /
-            s:$("0" ['0'..='9']*) {? i64::from_str_radix(s, 8).or(Err("i64")) } /
+            "0" ['x' | 'X'] s:$(['0'..='9' | 'a'..='f' | 'A'..='F']*) {? i64::from_str_radix(s, 16).or(Err("i64")) } /
+            s:$("0" ['0'..='8']*) {? i64::from_str_radix(s, 8).or(Err("i64")) } /
             s:$(['1'..='9'] ['0'..='9']*) {? s.parse().or(Err("i64")) }
     }
 }

--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -708,8 +708,13 @@ peg::parser! {
         rule array_element() -> &'input String =
             linebreak() [Token::Word(e, _)] linebreak() { e }
 
+        // N.B. An I/O number must be a string of only digits, and it must be
+        // followed by a '<' or '>' character (but not consume them).
         rule io_number() -> u32 =
-            w:[Token::Word(_, _)] {? w.to_str().parse().or(Err("io_number u32")) }
+            [Token::Word(w, _) if w.chars().all(|c: char| c.is_ascii_digit())]
+            &([Token::Operator(o, _) if o.starts_with('<') || o.starts_with('>')]) {
+                w.parse().unwrap()
+            }
 
         //
         // Helpers

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -38,7 +38,7 @@ async fn eval_arithmetic_async(input: ast::ArithmeticExpr) -> Result<()> {
     const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
     oracle_cmd.timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_IN_SECONDS));
 
-    let input = std::format!("echo \"$(( {input} ))\"\n");
+    let input = std::format!("echo \"$(( {input_str} ))\"\n");
     oracle_cmd.write_stdin(input.as_bytes());
 
     let oracle_result = oracle_cmd.output()?;
@@ -54,7 +54,7 @@ async fn eval_arithmetic_async(input: ast::ArithmeticExpr) -> Result<()> {
     //
     if our_eval_result != oracle_eval_result {
         Err(anyhow::anyhow!(
-            "Mismatched eval results: {oracle_eval_result:?} from oracle vs. {our_eval_result:?} from our test (expr: '{input}', oracle result: {oracle_result:?})"
+            "Mismatched eval results: {oracle_eval_result:?} from oracle vs. {our_eval_result:?} from our test (expr: '{input_str}', oracle result: {oracle_result:?})"
         ))
     } else {
         Ok(())
@@ -69,6 +69,8 @@ fuzz_target!(|input: ast::ArithmeticExpr| {
     if s.contains("+ 0")
         || s.is_empty()
         || s.contains(|c: char| c.is_ascii_control() || !c.is_ascii())
+        || s.contains("$[")
+    // old deprecated form of arithmetic expansion
     {
         return;
     }


### PR DESCRIPTION
Fixes a handful of arithmetic evaluation issues discovered through compat fuzz-testing:

* Detect exponentiation with a negative exponent.
* Use `wrapping_` operators rather than panicking on overflow.
* Correct association of exponentiation operator (e.g., is `x ** y ** z` the same as `(x ** y) ** z` or `x ** (y ** z)`).
* Fix parsing of hex values.