### PR TITLE
fix: correct ** overflow behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "assert_cmd",
  "brush-core",
  "brush-parser",
+ "lazy_static",
  "libfuzzer-sys",
  "tokio",
 ]

--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -210,7 +210,7 @@ async fn apply_binary_op(
     match op {
         ast::BinaryOperator::Power => {
             if right >= 0 {
-                Ok(left.wrapping_pow(right as u32))
+                Ok(wrapping_pow_u64(left, right as u64))
             } else {
                 Err(EvalError::NegativeExponent)
             }
@@ -325,4 +325,22 @@ fn bool_to_i64(value: bool) -> i64 {
     } else {
         0
     }
+}
+
+// N.B. We implement our own version of wrapping_pow that takes a 64-bit exponent.
+// This seems to be the best way to guarantee that we handle overflow cases
+// with exponents correctly.
+fn wrapping_pow_u64(mut base: i64, mut exponent: u64) -> i64 {
+    let mut result: i64 = 1;
+
+    while exponent > 0 {
+        if exponent % 2 == 1 {
+            result = result.wrapping_mul(base);
+        }
+
+        base = base.wrapping_mul(base);
+        exponent /= 2;
+    }
+
+    result
 }

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -461,6 +461,10 @@ impl ExecuteInPipeline for ast::Command {
         &self,
         pipeline_context: &mut PipelineExecutionContext,
     ) -> Result<SpawnResult, error::Error> {
+        if pipeline_context.shell.options.do_not_execute_commands {
+            return Ok(SpawnResult::ImmediateExit(0));
+        }
+
         match self {
             ast::Command::Simple(simple) => simple.execute_in_pipeline(pipeline_context).await,
             ast::Command::Compound(compound, redirects) => {

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -32,5 +32,5 @@ mod users;
 mod variables;
 
 pub use error::Error;
-pub use interp::ExecutionResult;
+pub use interp::{ExecutionParameters, ExecutionResult};
 pub use shell::{CreateOptions, Shell};

--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -6,7 +6,6 @@ use crate::CreateOptions;
 pub struct RuntimeOptions {
     //
     // Single-character options.
-    //
     /// -a
     pub export_variables_on_modification: bool,
     /// -b
@@ -48,7 +47,6 @@ pub struct RuntimeOptions {
 
     //
     // Options set through -o.
-    //
     /// 'emacs'
     pub emacs_mode: bool,
     /// 'history'
@@ -64,7 +62,6 @@ pub struct RuntimeOptions {
 
     //
     // Options set through shopt.
-    //
     /// `assoc_expand_once`
     pub assoc_expand_once: bool,
     /// 'autocd'
@@ -174,7 +171,6 @@ pub struct RuntimeOptions {
 
     //
     // Options set by the shell.
-    //
     /// Whether or not the shell is interactive.
     pub interactive: bool,
     /// Whether or not the shell is reading commands from standard input.
@@ -193,6 +189,7 @@ impl RuntimeOptions {
         // There's a set of options enabled by default for all shells.
         let mut options = Self {
             interactive: create_options.interactive,
+            do_not_execute_commands: create_options.do_not_execute_commands,
             enable_command_history: create_options.interactive,
             enable_job_control: create_options.interactive,
             read_commands_from_stdin: create_options.read_commands_from_stdin,

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -31,6 +31,10 @@ struct CommandLineArgs {
     #[clap(short = 'l', long = "login")]
     login: bool,
 
+    /// Do not execute commands.
+    #[clap(short = 'n')]
+    do_not_execute_commands: bool,
+
     /// Don't use readline for input.
     #[clap(long = "noediting")]
     no_editing: bool,
@@ -240,6 +244,7 @@ async fn run(
         shell: brush_core::CreateOptions {
             disabled_shopt_options: args.disabled_shopt_options,
             enabled_shopt_options: args.enabled_shopt_options,
+            do_not_execute_commands: args.do_not_execute_commands,
             login: args.login || argv0.as_ref().map_or(false, |a0| a0.starts_with('-')),
             interactive,
             no_editing: args.no_editing,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,6 +18,7 @@ cargo-fuzz = true
 [dependencies]
 anyhow = "1.0.86"
 assert_cmd = "=2.0.13"
+lazy_static = "1.5.0"
 libfuzzer-sys = "0.4"
 tokio = { version = "1.37.0", features = ["rt"] }
 
@@ -29,8 +30,8 @@ path = "../brush-parser"
 features = ["fuzz-testing"]
 
 [[bin]]
-name = "fuzz_target"
-path = "fuzz_targets/fuzz_target.rs"
+name = "fuzz_parse"
+path = "fuzz_targets/fuzz_parse.rs"
 test = false
 doc = false
 bench = false


### PR DESCRIPTION
Correct overflow behavior for exponentiation (required working around lack of `pow` function that takes a `u64` as the exponent).

Also adds `-n` behavior to the shell.