### PR TITLE
feat: include more details in version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,10 +348,12 @@ dependencies = [
  "brush-parser",
  "clap",
  "colored",
+ "const_format",
  "descape",
  "diff",
  "dir-cmp",
  "expectrl",
+ "git-version",
  "glob",
  "indent",
  "junit-report",
@@ -579,6 +581,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72b06487a0d4683349ad74d62e87ad639b09667082b3c495c5b6bab7d84b3da"
 dependencies = [
  "windows 0.44.0",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1007,6 +1029,26 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "glob"
@@ -2257,6 +2299,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/brush-core/src/builtins/help.rs
+++ b/brush-core/src/builtins/help.rs
@@ -22,8 +22,6 @@ pub(crate) struct HelpCommand {
     topic_patterns: Vec<String>,
 }
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 #[async_trait::async_trait]
 impl builtin::Command for HelpCommand {
     async fn execute(
@@ -48,7 +46,9 @@ impl HelpCommand {
     ) -> Result<(), crate::error::Error> {
         const COLUMN_COUNT: usize = 3;
 
-        writeln!(context.stdout(), "brush version {VERSION}\n")?;
+        if let Some(display_str) = &context.shell.shell_product_display_str {
+            writeln!(context.stdout(), "{display_str}\n")?;
+        }
 
         writeln!(
             context.stdout(),
@@ -62,7 +62,8 @@ impl HelpCommand {
             for j in 0..COLUMN_COUNT {
                 if let Some((name, builtin)) = builtins.get(i + j * items_per_column) {
                     let prefix = if builtin.disabled { "*" } else { " " };
-                    write!(context.stdout(), "  {prefix}{name:<20}")?; // adjust 20 to the desired column width
+                    write!(context.stdout(), "  {prefix}{name:<20}")?; // adjust 20 to the desired
+                                                                       // column width
                 }
             }
             writeln!(context.stdout())?;

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -51,6 +51,9 @@ pub struct Shell {
     /// Shell name
     pub shell_name: Option<String>,
 
+    /// Detailed display string for the shell
+    pub shell_product_display_str: Option<String>,
+
     /// Script call stack.
     pub script_call_stack: VecDeque<String>,
 
@@ -84,6 +87,7 @@ impl Clone for Shell {
             last_exit_status: self.last_exit_status,
             positional_parameters: self.positional_parameters.clone(),
             shell_name: self.shell_name.clone(),
+            shell_product_display_str: self.shell_product_display_str.clone(),
             function_call_stack: self.function_call_stack.clone(),
             script_call_stack: self.script_call_stack.clone(),
             directory_stack: self.directory_stack.clone(),
@@ -122,6 +126,8 @@ pub struct CreateOptions {
     pub read_commands_from_stdin: bool,
     /// The name of the shell.
     pub shell_name: Option<String>,
+    /// Optionally provides a display string describing the version and variant of the shell.
+    pub shell_product_display_str: Option<String>,
     /// Whether to run in maximal POSIX sh compatibility mode.
     pub sh_mode: bool,
     /// Whether to print verbose output.
@@ -163,6 +169,7 @@ impl Shell {
             last_exit_status: 0,
             positional_parameters: vec![],
             shell_name: options.shell_name.clone(),
+            shell_product_display_str: options.shell_product_display_str.clone(),
             function_call_stack: VecDeque::new(),
             script_call_stack: VecDeque::new(),
             directory_stack: vec![],

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -30,6 +30,8 @@ brush-parser = { version = "^0.2.2", path = "../brush-parser" }
 brush-core = { version = "^0.2.2", path = "../brush-core" }
 # N.B. Pin to 4.4.18 for now to keep to 1.72.0 as MSRV; 4.5.x requires a later version.
 clap = { version = "=4.4.18", features = ["derive", "wrap_help"] }
+const_format = "0.2.32"
+git-version = "0.3.9"
 tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -2,6 +2,8 @@
 
 #![deny(missing_docs)]
 
+mod productinfo;
+
 use std::{collections::HashSet, io::IsTerminal, path::Path};
 
 use clap::{builder::styling, Parser};
@@ -9,7 +11,12 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 /// Parsed command-line arguments for the brush shell.
 #[derive(Parser)]
-#[clap(version, about, disable_help_flag = true, disable_version_flag = true, styles = brush_help_styles())]
+#[clap(name = productinfo::PRODUCT_NAME,
+       version = const_format::concatcp!(productinfo::PRODUCT_VERSION, " (", productinfo::PRODUCT_GIT_VERSION, ")"),
+       about,
+       disable_help_flag = true,
+       disable_version_flag = true,
+       styles = brush_help_styles())]
 struct CommandLineArgs {
     /// Display usage information.
     #[clap(long = "help", action = clap::ArgAction::HelpLong)]
@@ -254,6 +261,7 @@ async fn run(
             print_commands_and_arguments: args.print_commands_and_arguments,
             read_commands_from_stdin,
             shell_name: argv0,
+            shell_product_display_str: Some(productinfo::get_product_display_str()),
             sh_mode: args.sh_mode,
             verbose: args.verbose,
         },

--- a/brush-shell/src/productinfo.rs
+++ b/brush-shell/src/productinfo.rs
@@ -1,0 +1,27 @@
+//! Information about this shell project.
+
+/// The formal name of this product.
+pub const PRODUCT_NAME: &str = "brush";
+
+const PRODUCT_HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
+const PRODUCT_REPO: &str = env!("CARGO_PKG_REPOSITORY");
+
+/// The URI to display as the product's homepage.
+#[allow(clippy::const_is_empty)]
+pub const PRODUCT_DISPLAY_URI: &str = if !PRODUCT_HOMEPAGE.is_empty() {
+    PRODUCT_HOMEPAGE
+} else {
+    PRODUCT_REPO
+};
+
+/// The version of the product, in string form.
+pub const PRODUCT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Info regarding the specific version of sources used to build this product.
+pub const PRODUCT_GIT_VERSION: &str = git_version::git_version!();
+
+pub(crate) fn get_product_display_str() -> String {
+    std::format!(
+        "{PRODUCT_NAME} version {PRODUCT_VERSION} ({PRODUCT_GIT_VERSION}) - {PRODUCT_DISPLAY_URI}"
+    )
+}

--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,7 @@ version = 2
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["Apache-2.0", "BSD-3-Clause", "BSL-1.0", "MIT", "Unicode-DFS-2016"]
+allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSL-1.0", "MIT", "Unicode-DFS-2016", "Zlib"]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.


### PR DESCRIPTION
Include git commit source info in the version displayed by brush; this will help track down which version of sources the binary came from.