### PR TITLE
fix: clippy and check warnings

### DIFF
--- a/brush-core/src/builtins/umask.rs
+++ b/brush-core/src/builtins/umask.rs
@@ -1,6 +1,7 @@
 use crate::{builtin, commands, error};
 use cfg_if::cfg_if;
 use clap::Parser;
+#[cfg(not(target_os = "linux"))]
 use nix::sys::stat::Mode;
 use std::io::Write;
 

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -58,6 +58,7 @@ impl ExecutionContext<'_> {
     }
 
     /// Returns the file descriptor with the given number.
+    #[allow(clippy::unwrap_in_result)]
     pub fn fd(&self, fd: u32) -> Option<openfiles::OpenFile> {
         self.open_files.files.get(&fd).map(|f| f.try_dup().unwrap())
     }

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -79,6 +79,7 @@ impl Pattern {
     /// * `enable_extended_globbing` - Whether or not to enable extended globbing (extglob).
     /// * `path_filter` - Optionally provides a function that filters paths after expansion.
     #[allow(clippy::too_many_lines)]
+    #[allow(clippy::unwrap_in_result)]
     pub(crate) fn expand<PF>(
         &self,
         working_dir: &Path,
@@ -309,7 +310,7 @@ impl Pattern {
 
 fn requires_expansion(s: &str) -> bool {
     // TODO: Make this more accurate.
-    s.contains(|c| matches!(c, '*' | '?' | '[' | ']' | '(' | ')'))
+    s.contains(['*', '?', '[', ']', '(', ')'])
 }
 
 fn escape_for_regex(s: &str) -> String {

--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -367,7 +367,7 @@ peg::parser! {
             left:word() (specific_word("==") / specific_word("=")) right:word()  { ast::ExtendedTestExpr::BinaryTest(ast::BinaryPredicate::StringExactlyMatchesPattern, ast::Word::from(left), ast::Word::from(right)) }
             left:word() specific_word("!=") right:word()  { ast::ExtendedTestExpr::BinaryTest(ast::BinaryPredicate::StringDoesNotExactlyMatchPattern, ast::Word::from(left), ast::Word::from(right)) }
             left:word() specific_word("=~") right:regex_word()  {
-                if right.value.starts_with(|c| matches!(c, '\'' | '\"')) {
+                if right.value.starts_with(['\'', '\"']) {
                     // TODO: Confirm it ends with that too?
                     ast::ExtendedTestExpr::BinaryTest(ast::BinaryPredicate::StringContainsSubstring, ast::Word::from(left), right)
                 } else {


### PR DESCRIPTION
These warnings haven't been failing PR checks since they're not treated as errors, but should be resolved nonetheless.