### PR TITLE
fix: correct completion fallback logic when spec matches but 0 results

### DIFF
--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -473,20 +473,25 @@ impl builtins::Command for CompGenCommand {
 /// Set programmable command completion options.
 #[derive(Parser)]
 pub(crate) struct CompOptCommand {
+    /// Update the default completion settings.
     #[arg(short = 'D')]
     update_default: bool,
 
+    /// Update the completion settings for empty lines.
     #[arg(short = 'E')]
     update_empty: bool,
 
+    /// Update the completion settings for the initial word of the input line.
     #[arg(short = 'I')]
     update_initial_word: bool,
 
+    /// Enable the specified option for selected completion scenarios.
     #[arg(short = 'o')]
     enabled_options: Vec<CompleteOption>,
     #[arg(long = concat!("+o"), hide = true)]
     disabled_options: Vec<CompleteOption>,
 
+    /// If specified, scopes updates to completions of the named commands.
     names: Vec<String>,
 }
 

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -839,18 +839,14 @@ impl Config {
 
         // Try to generate completions.
         if let Some(spec) = found_spec {
-            let result = spec
-                .to_owned()
+            spec.to_owned()
                 .get_completions(shell, &context)
                 .await
-                .unwrap_or_else(|_err| Answer::Candidates(vec![], ProcessingOptions::default()));
-
-            if !matches!(&result, Answer::Candidates(candidates, _) if candidates.is_empty()) {
-                return result;
-            }
+                .unwrap_or_else(|_err| Answer::Candidates(vec![], ProcessingOptions::default()))
+        } else {
+            // If we didn't find a spec, then fall back to basic completion.
+            get_completions_using_basic_lookup(shell, &context)
         }
-
-        get_completions_using_basic_lookup(shell, &context)
     }
 }
 


### PR DESCRIPTION
When a completion spec is found to match the current completion scenario but not completions result, then the correct behavior appears to be to present zero completions. This fixes completion of `cd <path_to_dir_that_contains_no_child_dirs>`.