### PR TITLE
fix: correct multiple issues with process substitution + redirection

### DIFF
--- a/brush-shell/tests/cases/builtins/read.yaml
+++ b/brush-shell/tests/cases/builtins/read.yaml
@@ -26,7 +26,6 @@ cases:
       echo "myvar: ${myvar}"
 
   - name: "read from process substitution"
-    known_failure: true
     stdin: |
       read myvar < <(echo hello)
       echo "myvar: ${myvar}"

--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -29,6 +29,30 @@ cases:
     stdin: |
       echo hi >&2
 
+  - name: "Process substitution: basic"
+    stdin: |
+      shopt -u -o posix
+      echo <(:) >(:)
+      echo <(:) <(:)
+      echo >(:) >(:)
+
+  - name: "Process substitution: not in simple commands"
+    known_failure: true # Known to fail because we are only handling them in simple commands now
+    stdin: |
+      shopt -u -o posix
+      for f in <(echo hi); do echo $f; done
+
+  - name: "Process substitution: input redirection"
+    stdin: |
+      shopt -u -o posix
+      cat < <(echo hi)
+
+  - name: "Process substitution: output redirection"
+    stdin: |
+      shopt -u -o posix
+      echo hi > >(wc -l)
+      echo hi >> >(wc -l)
+
   - name: "Process substitution: input"
     stdin: |
       shopt -u -o posix
@@ -43,7 +67,6 @@ cases:
       ls -d . non-existent-dir &>>/dev/null
 
   - name: "Process substitution: input + output"
-    known_failure: true
     stdin: |
       shopt -u -o posix
       cp <(echo hi) >(cat)


### PR DESCRIPTION
The prior implementation of process substitution (e.g., `<(command args)`) was a bit confused. This isn't perfect, but should be significantly more accurate. With these changes, `brush`:

* Supports use of `<(command ...)` or `>(command ...)` for any argument to a simple command.
* Supports use of `<(command ...)` or `>(command ...)` as the filename for input or output redirection anywhere those redirections are supported.
* When executing a process substitution command in a subshell, does not synchronously wait for it. (This resolves a known issue with `>(command ...)`.

Also adds more test cases to capture this issue, what's working now, and what is better understood to still differ in behavior. (Notably, bash appears to accept process substitutions in a wider variety of places in its grammar. Perhaps not usefully in some cases, but we added a test case for completeness nonetheless.)

Fixes #144 (thanks to @39555 for finding and reporting it!)