### PR TITLE
fix: Posix compliant argument parsing for `-c` mode

### DIFF
--- a/brush-core/src/builtins/echo.rs
+++ b/brush-core/src/builtins/echo.rs
@@ -26,6 +26,20 @@ pub(crate) struct EchoCommand {
 
 #[async_trait::async_trait]
 impl builtins::Command for EchoCommand {
+    /// Override the default [builtins::Command::new] function to handle clap's limitation related to `--`.
+    /// See [crate::builtins::parse_known] for more information
+    /// TODO: we can safely remove this after the issue is resolved
+    fn new<I>(args: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let (mut this, rest_args) = crate::builtins::try_parse_known::<EchoCommand>(args)?;
+        if let Some(args) = rest_args {
+            this.args.extend(args);
+        }
+        Ok(this)
+    }
+
     async fn execute(
         &self,
         context: commands::ExecutionContext<'_>,

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -114,9 +114,14 @@ pub struct CommandLineArgs {
     pub enabled_log_events: Vec<events::TraceEvent>,
 
     /// Path to script to execute.
+    // allow any string as command_name similar to sh
+    #[clap(allow_hyphen_values = true)]
     pub script_path: Option<String>,
 
     /// Arguments for script.
+    // `allow_hyphen_values`: do not strip `-` from flags
+    // `num_args=1..`: consume everything
+    #[clap(allow_hyphen_values = true, num_args=1..)]
     pub script_args: Vec<String>,
 }
 

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -27,7 +27,7 @@ impl CommandLineArgs {
     fn parse_from<'a>(itr: impl IntoIterator<Item = &'a String>) -> Self {
         let (mut this, script_args) = brush_core::builtins::parse_known::<CommandLineArgs, _>(itr);
         // if we have `--` and unparsed raw args than
-        script_args.map(|mut args| {
+        if let Some(mut args) = script_args {
             // if script_path has not been parsed yet
             // use the first script_args[0] (it is `--`)
             // as script_path
@@ -40,7 +40,7 @@ impl CommandLineArgs {
                 this.script_args
                     .extend(first.into_iter().chain(args).cloned());
             }
-        });
+        }
         this
     }
 }

--- a/brush-shell/tests/cases/arguments.yaml
+++ b/brush-shell/tests/cases/arguments.yaml
@@ -1,0 +1,83 @@
+name: "Argument handling tests"
+common_test_files:
+  - path: "script.sh"
+    contents: |
+      echo \"$0\" \"$1\" \"$2\" \"$@\"
+
+cases:
+  - name: "-c mode arguments without --"
+    args:
+      - "-c"
+      - 'echo \"$0\" \"$1\" \"$2\" \"$@\"'
+      - 1
+      - "-2"
+      - "3"
+
+  - name: "-c mode arguments with --"
+    args:
+      - "-c"
+      - 'echo \"$0\" \"$1\" \"$2\" \"$@\"'
+      - "--"
+      - 1
+      - 2
+      - 3
+
+  - name: "-c mode and arguments with +O"
+    args:
+      - "+O"
+      - "nullglob"
+      - "-c"
+      - 'echo \"$0\" \"$1\" \"$2\" \"$@\"'
+      - "--"
+      - 1
+      - 2
+      - 3
+
+  - name: "-c mode -- torture"
+    args:
+      - "-c"
+      - 'echo \"$0\" \"$1\" \"$2\" \"$@\"'
+      - --
+      - --
+      - -&-1
+      - --!
+      - "\"-2\""
+      - "''--''"
+      - 3--*
+
+  - name: "-c modeonly one --"
+    args:
+      - "-c"
+      - 'echo \"$0\" \"$1\" \"$2\" \"$@\"'
+      - --
+
+  - name: "script arguments without --"
+    args:
+      - script.sh
+      - -1
+      - -2
+      - -3
+
+  - name: "script arguments with --"
+    args:
+      - script.sh
+      - --
+      - --1
+      - -2
+      - 3
+
+  - name: "script -- torture"
+    args:
+      - script.sh
+      - --
+      - "--"
+      - --
+      - -!-1*
+      - "\"-2\""
+      - --
+      - 3--
+
+  - name: "script only one --"
+    args:
+      - script.sh
+      - --

--- a/brush-shell/tests/cases/builtins/echo.yaml
+++ b/brush-shell/tests/cases/builtins/echo.yaml
@@ -1,0 +1,7 @@
+name: "Builtins: echo"
+cases:
+  - name: "echo with only --"
+    stdin: echo --
+
+  - name: "echo with -- and args"
+    stdin: echo -- -1 --"aaa" ?^1as-


### PR DESCRIPTION
## Before

Brush misses `--` because of clap's approach to argument parsing. See: [clap-rs/clap/clap_builder/src/parser/parser.rs](https://github.com/clap-rs/clap/blob/edcaf8fcae5b747cee7e70f196d70a49ffcbdb84/clap_builder/src/parser/parser.rs#L103) `if arg_os.is_escape() { ...; continue } // means arg_os == '--'` and `--` is skipped.

But Posix can handle `--` as an operand or a command_name just fine.

```sh
cargo run -- -c 'echo $0: $1 $2 \"$@\"' --  -1 -2
#> CommandLineArgs.script_path = Some('-1')
#> CommandLineArgs.script_args = ['-2']
#> -1: -2 "-2"

bash -c 'echo $0: $1 $2 \"$@\"' --  -1 -2
#> --: -1 -2 "-1 -2"
```
```sh
cargo run -- -c 'echo $0: $1 $2 \"$@\"'  -1 -2
#> error: unexpected argument '-1' found

bash -c 'echo $0: $1 $2 \"$@\"'  -1 -2
#> -1: -2 "-2"
```

```sh
# cat script.sh
#> echo "$0: $1 $2 \"$@\""

cargo run -- script.sh --  -1 -2
#> CommandLineArgs.script_path = Some('script.sh')
#> CommandLineArgs.script_args = ['-1', '-2']
#> script.sh: -1 -2 "-1 -2"

bash script.sh -- -1 -2
#> script.sh: -- -1 "-- -1 -2"
```

```sh
cargo run -- script.sh -1 -2
#> error: unexpected argument '-1' found

bash script.sh  -1 -2
#> script.sh: -1 -2 "-1 -2"
```

## After This PR

```sh
cargo run -- -c 'echo $0: $1 $2 \"$@\"' --  -1 -2
#> --: -1 -2 "-1 -2"

bash -c 'echo $0: $1 $2 \"$@\"' --  -1 -2
#> --: -1 -2 "-1 -2"
```
```sh
cargo run -- -c 'echo $0: $1 $2 \"$@\"'  -1 -2
#> -1: -2 "-2"

bash -c 'echo $0: $1 $2 \"$@\"'  -1 -2
#> -1: -2 "-2"
```

```sh
cargo run -- script.sh --  -1 -2
#> script.sh: -- -1 "-- -1 -2"

bash script.sh -- -1 -2
#> script.sh: -- -1 "-- -1 -2"
```

```sh
cargo run -- script.sh -1 -2
#> script.sh: -1 -2 "-1 -2"

bash script.sh  -1 -2
#> script.sh: -1 -2 "-1 -2"
```

