### PR TITLE
chore: extract InteractiveShell as trait + refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -132,19 +132,20 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
 dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -180,7 +181,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -191,7 +192,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -202,17 +203,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -290,6 +291,7 @@ dependencies = [
 name = "brush-interactive"
 version = "0.2.7"
 dependencies = [
+ "async-trait",
  "brush-core",
  "brush-parser",
  "brush-rustyline-fork",
@@ -348,6 +350,7 @@ dependencies = [
  "brush-core",
  "brush-interactive",
  "brush-parser",
+ "cfg-if",
  "clap",
  "colored",
  "const_format",
@@ -389,9 +392,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -429,7 +432,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -446,12 +449,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -507,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -526,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -546,7 +550,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -631,15 +635,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
 dependencies = [
  "cfg-if",
 ]
@@ -743,7 +747,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -754,7 +758,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -794,7 +798,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -907,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fd-lock"
@@ -936,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1006,7 +1010,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1052,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "git-version"
@@ -1073,7 +1077,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1084,9 +1088,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1137,6 +1141,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1213,9 +1223,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1241,9 +1251,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1269,11 +1279,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -1319,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1346,9 +1356,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1409,20 +1419,20 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1510,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -1615,9 +1625,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1628,15 +1638,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -1769,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1876,9 +1886,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rgb"
-version = "0.8.47"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12bc8d2f72df26a5d3178022df33720fbede0d31d82c7291662eff89836994d"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]
@@ -1897,9 +1907,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -1916,7 +1926,7 @@ checksum = "e5af959c8bf6af1aff6d2b463a57f71aae53d1332da58419e30ad8dc7011d951"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1957,14 +1967,14 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -1993,6 +2003,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2047,9 +2063,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "symbolic-common"
-version = "12.10.0"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16629323a4ec5268ad23a575110a724ad4544aae623451de600c747bf87b36cf"
+checksum = "9c1db5ac243c7d7f8439eb3b8f0357888b37cf3732957e91383b0ad61756374e"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2059,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.10.0"
+version = "12.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c043a45f08f41187414592b3ceb53fb0687da57209cc77401767fb69d5b596"
+checksum = "ea26e430c27d4a8a5dea4c4b81440606c7c1a415bd611451ef6af8c81416afc3"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -2081,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2092,15 +2108,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2145,7 +2161,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2223,7 +2239,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2245,7 +2261,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2303,9 +2319,9 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2409,34 +2425,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2444,28 +2461,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2587,7 +2604,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2598,7 +2615,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2844,5 +2861,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1.82"
 brush-parser = { version = "^0.2.6", path = "../brush-parser" }
 cached = "0.53.0"
 cfg-if = "1.0.0"
-clap = { version = "4.5.11", features = ["derive", "wrap_help"] }
+clap = { version = "4.5.17", features = ["derive", "wrap_help"] }
 fancy-regex = "0.13.0"
 futures = "0.3.30"
 itertools = "0.13.0"
@@ -32,11 +32,7 @@ thiserror = "1.0.62"
 tracing = "0.1.40"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-tokio = { version = "1.40.0", features = [
-    "io-util",
-    "macros",
-    "rt",
-] }
+tokio = { version = "1.40.0", features = ["io-util", "macros", "rt"] }
 
 [target.'cfg(any(windows, unix))'.dependencies]
 hostname = "0.4.0"
@@ -56,7 +52,13 @@ whoami = "1.5.2"
 
 [target.'cfg(unix)'.dependencies]
 command-fds = "0.3.0"
-nix = { version = "0.29.0", features = ["fs", "process", "signal", "term", "user"] }
+nix = { version = "0.29.0", features = [
+    "fs",
+    "process",
+    "signal",
+    "term",
+    "user",
+] }
 uzers = "0.12.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -99,6 +99,18 @@ impl Clone for Shell {
     }
 }
 
+impl AsRef<Shell> for Shell {
+    fn as_ref(&self) -> &Shell {
+        self
+    }
+}
+
+impl AsMut<Shell> for Shell {
+    fn as_mut(&mut self) -> &mut Shell {
+        self
+    }
+}
+
 /// Options for creating a new shell.
 #[derive(Debug, Default)]
 pub struct CreateOptions {

--- a/brush-interactive/Cargo.toml
+++ b/brush-interactive/Cargo.toml
@@ -14,17 +14,22 @@ rust-version.workspace = true
 [lib]
 bench = false
 
+[features]
+basic = []
+rustyline = ["dep:rustyline"]
+
 [lints]
 workspace = true
 
 [dependencies]
+async-trait = "0.1.82"
 brush-parser = { version = "^0.2.6", path = "../brush-parser" }
 brush-core = { version = "^0.2.7", path = "../brush-core" }
+rustyline = { package = "brush-rustyline-fork", version = "14.0.1", optional = true, features = [
+    "derive",
+] }
 thiserror = "1.0.62"
 tracing = "0.1.40"
 
 [target.'cfg(any(windows, unix))'.dependencies]
-rustyline = { package = "brush-rustyline-fork", version = "14.0.1", features = [
-    "derive",
-] }
 tokio = { version = "1.40.0", features = ["macros", "signal"] }

--- a/brush-interactive/src/basic_shell.rs
+++ b/brush-interactive/src/basic_shell.rs
@@ -1,112 +1,57 @@
 use std::io::Write;
 
+use crate::{
+    interactive_shell::{InteractiveShell, ReadResult},
+    ShellError,
+};
+
 /// Represents a minimal shell capable of taking commands from standard input
 /// and reporting results to standard output and standard error streams.
-pub struct InteractiveShell {
+pub struct BasicShell {
     shell: brush_core::Shell,
 }
 
-impl InteractiveShell {
+impl BasicShell {
     /// Returns a new interactive shell instance, created with the provided options.
     ///
     /// # Arguments
     ///
     /// * `options` - Options for creating the interactive shell.
-    pub async fn new(options: &crate::Options) -> Result<InteractiveShell, ShellError> {
+    pub async fn new(options: &crate::Options) -> Result<Self, ShellError> {
         let shell = brush_core::Shell::new(&options.shell).await?;
-        Ok(InteractiveShell { shell })
+        Ok(Self { shell })
     }
+}
 
+impl InteractiveShell for BasicShell {
     /// Returns an immutable reference to the inner shell object.
-    pub fn shell(&self) -> &brush_core::Shell {
-        &self.shell
+    fn shell(&self) -> impl AsRef<brush_core::Shell> {
+        self.shell.as_ref()
     }
 
     /// Returns a mutable reference to the inner shell object.
-    pub fn shell_mut(&mut self) -> &mut brush_core::Shell {
-        &mut self.shell
+    fn shell_mut(&mut self) -> impl AsMut<brush_core::Shell> {
+        self.shell.as_mut()
     }
 
-    /// Runs the interactive shell loop, reading commands from standard input and writing
-    /// results to standard output and standard error. Continues until the shell
-    /// normally exits or until a fatal error occurs.
-    pub async fn run_interactively(&mut self) -> Result<(), ShellError> {
-        loop {
-            // Check for any completed jobs.
-            self.shell_mut().check_for_completed_jobs()?;
-
-            let result = self.run_interactively_once().await;
-            match result {
-                Ok(Some(brush_core::ExecutionResult {
-                    exit_shell,
-                    return_from_function_or_script,
-                    ..
-                })) => {
-                    if exit_shell {
-                        break;
-                    }
-
-                    if return_from_function_or_script {
-                        tracing::error!("return from non-function/script");
-                    }
-                }
-                Ok(None) => {
-                    break;
-                }
-                Err(e) => {
-                    // Report the error, but continue to execute.
-                    tracing::error!("error: {:#}", e);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn run_interactively_once(
-        &mut self,
-    ) -> Result<Option<brush_core::ExecutionResult>, ShellError> {
-        // Compose the prompt.
-        let prompt = self.shell_mut().compose_prompt().await?;
-
-        match self.readline(prompt.as_str()) {
-            Some(read_result) => {
-                let params = self.shell().default_exec_params();
-                match self.shell_mut().run_string(read_result, &params).await {
-                    Ok(result) => Ok(Some(result)),
-                    Err(e) => Err(e.into()),
-                }
-            }
-            None => Ok(None),
-        }
-    }
-
-    fn readline(&mut self, prompt: &str) -> Option<String> {
-        let _ = print!("{prompt}");
+    fn read_line(&mut self, prompt: &str) -> Result<ReadResult, ShellError> {
+        print!("{prompt}");
         let _ = std::io::stdout().flush();
 
         let mut buffer = String::new();
         let stdin = std::io::stdin(); // We get `Stdin` here.
         if let Ok(bytes_read) = stdin.read_line(&mut buffer) {
             if bytes_read > 0 {
-                Some(buffer)
+                Ok(ReadResult::Input(buffer))
             } else {
-                None
+                Ok(ReadResult::Eof)
             }
         } else {
-            None
+            Err(ShellError::InputError)
         }
     }
-}
 
-/// Represents an error encountered while running or otherwise managing an interactive shell.
-#[derive(thiserror::Error, Debug)]
-pub enum ShellError {
-    /// An error occurred with the embedded shell.
-    #[error("{0}")]
-    ShellError(#[from] brush_core::Error),
-
-    /// A generic I/O error occurred.
-    #[error("I/O error: {0}")]
-    IoError(#[from] std::io::Error),
+    fn update_history(&mut self) -> Result<(), ShellError> {
+        Ok(())
+    }
 }

--- a/brush-interactive/src/error.rs
+++ b/brush-interactive/src/error.rs
@@ -1,0 +1,21 @@
+/// Represents an error encountered while running or otherwise managing an interactive shell.
+#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::enum_variant_names)]
+#[derive(thiserror::Error, Debug)]
+pub enum ShellError {
+    /// An error occurred with the embedded shell.
+    #[error("{0}")]
+    ShellError(#[from] brush_core::Error),
+
+    /// A generic I/O error occurred.
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    /// An error occurred while reading input.
+    #[error("input error occurred")]
+    InputError,
+
+    /// The requested input backend type is not supported.
+    #[error("requested input backend type not supported")]
+    InputBackendNotSupported,
+}

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -1,110 +1,50 @@
-use rustyline::validate::ValidationResult;
-use std::{
-    borrow::Cow,
-    io::Write,
-    path::{Path, PathBuf},
-};
+use crate::ShellError;
+use std::io::Write;
 
-type Editor = rustyline::Editor<EditorHelper, rustyline::history::FileHistory>;
-
-/// Represents an interactive shell capable of taking commands from standard input
-/// and reporting results to standard output and standard error streams.
-pub struct InteractiveShell {
-    /// The `rustyline` editor.
-    editor: Editor,
-    /// Optional path to the history file used for the shell.
-    history_file_path: Option<PathBuf>,
+/// Result of a read operation.
+pub enum ReadResult {
+    /// The user entered a line of input.
+    Input(String),
+    /// End of input was reached.
+    Eof,
+    /// The user interrupted the input operation.
+    Interrupted,
 }
 
-/// Represents an error encountered while running or otherwise managing an interactive shell.
-#[derive(thiserror::Error, Debug)]
-pub enum ShellError {
-    /// An error occurred with the embedded shell.
-    #[error("{0}")]
-    ShellError(#[from] brush_core::Error),
-
-    /// A generic I/O error occurred.
-    #[error("I/O error: {0}")]
-    IoError(#[from] std::io::Error),
-
-    /// An error occurred while reading input.
-    #[error("input error: {0}")]
-    ReadlineError(#[from] rustyline::error::ReadlineError),
-}
-
-enum InteractiveExecutionResult {
+/// Result of an interactive execution.
+pub enum InteractiveExecutionResult {
+    /// The command was executed and returned the given result.
     Executed(brush_core::ExecutionResult),
+    /// The command failed to execute.
     Failed(brush_core::Error),
+    /// End of input was reached.
     Eof,
 }
 
-impl InteractiveShell {
-    /// Returns a new interactive shell instance, created with the provided options.
+/// Represents a shell capable of taking commands from standard input.
+#[async_trait::async_trait]
+pub trait InteractiveShell {
+    /// Returns an immutable reference to the inner shell object.
+    fn shell(&self) -> impl AsRef<brush_core::Shell> + Send;
+
+    /// Returns a mutable reference to the inner shell object.
+    fn shell_mut(&mut self) -> impl AsMut<brush_core::Shell> + Send;
+
+    /// Reads a line of input, using the given prompt.
     ///
     /// # Arguments
     ///
-    /// * `options` - Options for creating the interactive shell.
-    pub async fn new(options: &crate::Options) -> Result<InteractiveShell, ShellError> {
-        // Set up shell first. Its initialization may influence how the
-        // editor needs to operate.
-        let shell = brush_core::Shell::new(&options.shell).await?;
-        let history_file_path = shell.get_history_file_path();
+    /// * `prompt` - The prompt to display to the user.
+    fn read_line(&mut self, prompt: &str) -> Result<ReadResult, ShellError>;
 
-        let mut editor = Self::new_editor(options, shell)?;
-        if let Some(history_file_path) = &history_file_path {
-            // If the history file doesn't already exist, then make a best-effort attempt.
-            // to create it.
-            if !history_file_path.exists() {
-                let _ = std::fs::File::create(history_file_path);
-            }
-
-            // Make a best effort attempt to load the history file.
-            let _ = editor.load_history(history_file_path);
-        }
-
-        Ok(InteractiveShell {
-            editor,
-            history_file_path,
-        })
-    }
-
-    /// Returns an immutable reference to the inner shell object.
-    pub fn shell(&self) -> &brush_core::Shell {
-        &self.editor.helper().unwrap().shell
-    }
-
-    /// Returns a mutable reference to the inner shell object.
-    pub fn shell_mut(&mut self) -> &mut brush_core::Shell {
-        &mut self.editor.helper_mut().unwrap().shell
-    }
-
-    fn new_editor(
-        options: &crate::Options,
-        shell: brush_core::Shell,
-    ) -> Result<Editor, ShellError> {
-        let config = rustyline::config::Builder::new()
-            .max_history_size(1000)?
-            .history_ignore_dups(true)?
-            .auto_add_history(true)
-            .bell_style(rustyline::config::BellStyle::None)
-            .completion_type(rustyline::config::CompletionType::List)
-            .bracketed_paste(!options.disable_bracketed_paste)
-            .build();
-
-        let mut editor = rustyline::Editor::with_config(config)?;
-        editor.set_helper(Some(EditorHelper::new(shell)));
-
-        Ok(editor)
-    }
+    /// Update history, if relevant.
+    fn update_history(&mut self) -> Result<(), ShellError>;
 
     /// Runs the interactive shell loop, reading commands from standard input and writing
     /// results to standard output and standard error. Continues until the shell
     /// normally exits or until a fatal error occurs.
-    pub async fn run_interactively(&mut self) -> Result<(), ShellError> {
+    async fn run_interactively(&mut self) -> Result<(), ShellError> {
         loop {
-            // Check for any completed jobs.
-            self.shell_mut().check_for_completed_jobs()?;
-
             let result = self.run_interactively_once().await?;
             match result {
                 InteractiveExecutionResult::Executed(brush_core::ExecutionResult {
@@ -130,251 +70,62 @@ impl InteractiveShell {
             }
         }
 
-        if self.shell().options.interactive {
-            writeln!(self.shell().stderr(), "exit")?;
+        if self.shell().as_ref().options.interactive {
+            writeln!(self.shell().as_ref().stderr(), "exit")?;
         }
 
-        if let Some(history_file_path) = &self.history_file_path {
-            let history_result = if self.shell().options.append_to_history_file {
-                self.editor.append_history(history_file_path)
-            } else {
-                self.editor.save_history(history_file_path)
-            };
-
-            if let Err(e) = history_result {
-                // N.B. This seems like the sort of thing that's worth being noisy about,
-                // but bash doesn't do that -- and probably for a reason.
-                tracing::debug!(
-                    "couldn't save history to {}: {e}",
-                    history_file_path.display()
-                );
-            }
+        if let Err(e) = self.update_history() {
+            // N.B. This seems like the sort of thing that's worth being noisy about,
+            // but bash doesn't do that -- and probably for a reason.
+            tracing::debug!("couldn't save history: {e}");
         }
 
         Ok(())
     }
 
+    /// Runs the interactive shell loop once, reading a single command from standard input.
     async fn run_interactively_once(&mut self) -> Result<InteractiveExecutionResult, ShellError> {
+        let mut shell_mut = self.shell_mut();
+
+        // Check for any completed jobs.
+        shell_mut.as_mut().check_for_completed_jobs()?;
+
         // If there's a variable called PROMPT_COMMAND, then run it first.
-        if let Some((_, prompt_cmd)) = self.shell().env.get("PROMPT_COMMAND") {
+        if let Some((_, prompt_cmd)) = shell_mut.as_mut().env.get("PROMPT_COMMAND") {
             let prompt_cmd = prompt_cmd.value().to_cow_string().to_string();
 
             // Save (and later restore) the last exit status.
-            let prev_last_result = self.shell().last_exit_status;
+            let prev_last_result = shell_mut.as_mut().last_exit_status;
 
-            let params = self.shell().default_exec_params();
+            let params = shell_mut.as_mut().default_exec_params();
 
-            self.shell_mut().run_string(prompt_cmd, &params).await?;
+            shell_mut.as_mut().run_string(prompt_cmd, &params).await?;
 
-            self.shell_mut().last_exit_status = prev_last_result;
+            shell_mut.as_mut().last_exit_status = prev_last_result;
         }
 
         // Now that we've done that, compose the prompt.
-        let prompt = self.shell_mut().compose_prompt().await?;
+        let prompt = shell_mut.as_mut().compose_prompt().await?;
 
-        match self.editor.readline(&prompt) {
-            Ok(read_result) => {
-                let params = self.shell().default_exec_params();
-                match self.shell_mut().run_string(read_result, &params).await {
+        drop(shell_mut);
+
+        match self.read_line(prompt.as_str())? {
+            ReadResult::Input(read_result) => {
+                let mut shell_mut = self.shell_mut();
+                let params = shell_mut.as_mut().default_exec_params();
+                match shell_mut.as_mut().run_string(read_result, &params).await {
                     Ok(result) => Ok(InteractiveExecutionResult::Executed(result)),
                     Err(e) => Ok(InteractiveExecutionResult::Failed(e)),
                 }
             }
-            Err(rustyline::error::ReadlineError::Eof) => Ok(InteractiveExecutionResult::Eof),
-            Err(rustyline::error::ReadlineError::Interrupted) => {
-                self.shell_mut().last_exit_status = 130;
+            ReadResult::Eof => Ok(InteractiveExecutionResult::Eof),
+            ReadResult::Interrupted => {
+                let mut shell_mut = self.shell_mut();
+                shell_mut.as_mut().last_exit_status = 130;
                 Ok(InteractiveExecutionResult::Executed(
                     brush_core::ExecutionResult::new(130),
                 ))
             }
-            Err(e) => Err(e.into()),
         }
     }
-}
-
-//
-// N.B. For now, we disable hinting on Windows because it sometimes results
-// in prompt/input rendering errors.
-//
-#[cfg(unix)]
-#[derive(rustyline::Helper, rustyline::Hinter)]
-pub(crate) struct EditorHelper {
-    pub shell: brush_core::Shell,
-
-    #[rustyline(Hinter)]
-    hinter: rustyline::hint::HistoryHinter,
-}
-
-#[cfg(windows)]
-#[derive(rustyline::Helper)]
-pub(crate) struct EditorHelper {
-    pub shell: brush_core::Shell,
-}
-
-impl EditorHelper {
-    #[cfg(unix)]
-    pub(crate) fn new(shell: brush_core::Shell) -> Self {
-        Self {
-            shell,
-            hinter: rustyline::hint::HistoryHinter::new(),
-        }
-    }
-
-    #[cfg(windows)]
-    pub(crate) fn new(shell: brush_core::Shell) -> Self {
-        Self { shell }
-    }
-
-    fn get_completion_candidate_display_str(
-        mut s: &str,
-        options: &brush_core::completion::ProcessingOptions,
-    ) -> String {
-        let s_without_trailing_space = s.trim_end();
-        let s_without_final_slash = s_without_trailing_space
-            .strip_suffix(std::path::MAIN_SEPARATOR)
-            .unwrap_or(s);
-
-        if options.treat_as_filenames {
-            if let Some(slash_index) = s_without_final_slash.rfind(std::path::MAIN_SEPARATOR) {
-                s = &s[slash_index + 1..];
-            }
-        }
-
-        s.to_owned()
-    }
-
-    async fn complete_async(
-        &mut self,
-        line: &str,
-        pos: usize,
-    ) -> rustyline::Result<(usize, Vec<rustyline::completion::Pair>)> {
-        let working_dir = self.shell.working_dir.clone();
-
-        // Intentionally ignore any errors that arise.
-        let completion_future = self.shell.get_completions(line, pos);
-        tokio::pin!(completion_future);
-
-        // Wait for the completions to come back or interruption, whichever happens first.
-        let result = loop {
-            tokio::select! {
-                result = &mut completion_future => {
-                    break result;
-                }
-                _ = tokio::signal::ctrl_c() => {
-                },
-            }
-        };
-
-        let mut completions = result.unwrap_or_else(|_| brush_core::completion::Completions {
-            start: pos,
-            candidates: vec![],
-            options: brush_core::completion::ProcessingOptions::default(),
-        });
-
-        let completing_end_of_line = pos == line.len();
-        if completions.options.treat_as_filenames {
-            for candidate in &mut completions.candidates {
-                // Check if it's a directory.
-                if !candidate.ends_with(std::path::MAIN_SEPARATOR) {
-                    let candidate_path = Path::new(candidate);
-                    let abs_candidate_path = if candidate_path.is_absolute() {
-                        PathBuf::from(candidate_path)
-                    } else {
-                        working_dir.join(candidate_path)
-                    };
-
-                    if abs_candidate_path.is_dir() {
-                        candidate.push(std::path::MAIN_SEPARATOR);
-                    }
-                }
-            }
-        }
-        if completions.options.no_autoquote_filenames {
-            tracing::debug!(target: "completion", "don't autoquote filenames");
-        }
-        if completing_end_of_line && !completions.options.no_trailing_space_at_end_of_line {
-            for candidate in &mut completions.candidates {
-                if !completions.options.treat_as_filenames
-                    || !candidate.ends_with(std::path::MAIN_SEPARATOR)
-                {
-                    candidate.push(' ');
-                }
-            }
-        }
-
-        let options = completions.options;
-        let candidates = completions
-            .candidates
-            .into_iter()
-            .map(|c| rustyline::completion::Pair {
-                display: Self::get_completion_candidate_display_str(c.as_str(), &options),
-                replacement: c,
-            })
-            .collect();
-
-        Ok((completions.start, candidates))
-    }
-}
-
-impl rustyline::highlight::Highlighter for EditorHelper {
-    // Display hints with low intensity
-    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
-        Cow::Owned("\x1b[2m".to_owned() + hint + "\x1b[m")
-    }
-
-    // Color names that seem to be dirs.
-    fn highlight_candidate<'c>(
-        &self,
-        candidate: &'c str, // FIXME should be Completer::Candidate
-        _completion: rustyline::CompletionType,
-    ) -> Cow<'c, str> {
-        if let Some(candidate_without_suffix) = candidate.strip_suffix(std::path::MAIN_SEPARATOR) {
-            Cow::Owned("\x1b[1;34m".to_owned() + candidate_without_suffix + "\x1b[0m/")
-        } else {
-            Cow::Borrowed(candidate)
-        }
-    }
-}
-
-impl rustyline::completion::Completer for EditorHelper {
-    type Candidate = rustyline::completion::Pair;
-
-    fn complete(
-        &mut self,
-        line: &str,
-        pos: usize,
-        _ctx: &rustyline::Context<'_>,
-    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.complete_async(line, pos))
-        })
-    }
-}
-
-impl rustyline::validate::Validator for EditorHelper {
-    fn validate(
-        &self,
-        ctx: &mut rustyline::validate::ValidationContext,
-    ) -> rustyline::Result<rustyline::validate::ValidationResult> {
-        let line = ctx.input();
-
-        let parse_result = self.shell.parse_string(line.to_owned());
-
-        let validation_result = match parse_result {
-            Err(brush_parser::ParseError::Tokenizing { inner, position: _ })
-                if inner.is_incomplete() =>
-            {
-                ValidationResult::Incomplete
-            }
-            Err(brush_parser::ParseError::ParsingAtEndOfInput) => ValidationResult::Incomplete,
-            _ => ValidationResult::Valid(None),
-        };
-
-        Ok(validation_result)
-    }
-}
-
-#[cfg(windows)]
-impl rustyline::hint::Hinter for EditorHelper {
-    type Hint = String;
 }

--- a/brush-interactive/src/lib.rs
+++ b/brush-interactive/src/lib.rs
@@ -2,15 +2,23 @@
 
 #![deny(missing_docs)]
 
-#[cfg(any(unix, windows))]
-mod interactive_shell;
-#[cfg(any(unix, windows))]
-pub use interactive_shell::{InteractiveShell, ShellError};
+mod error;
+pub use error::ShellError;
 
-#[cfg(not(any(unix, windows)))]
-mod basic_shell;
-#[cfg(not(any(unix, windows)))]
-pub use basic_shell::{InteractiveShell, ShellError};
+mod interactive_shell;
+pub use interactive_shell::{InteractiveExecutionResult, InteractiveShell, ReadResult};
 
 mod options;
 pub use options::Options;
+
+// Rustyline-based shell
+#[cfg(feature = "rustyline")]
+mod rustyline_shell;
+#[cfg(feature = "rustyline")]
+pub use rustyline_shell::RustylineShell;
+
+// Basic shell
+#[cfg(feature = "basic")]
+mod basic_shell;
+#[cfg(feature = "basic")]
+pub use basic_shell::BasicShell;

--- a/brush-interactive/src/rustyline_shell.rs
+++ b/brush-interactive/src/rustyline_shell.rs
@@ -1,0 +1,292 @@
+use rustyline::validate::ValidationResult;
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    error::ShellError,
+    interactive_shell::{InteractiveShell, ReadResult},
+};
+
+type Editor = rustyline::Editor<EditorHelper, rustyline::history::FileHistory>;
+
+/// Represents an interactive shell capable of taking commands from standard input
+/// and reporting results to standard output and standard error streams.
+pub struct RustylineShell {
+    /// The `rustyline` editor.
+    editor: Editor,
+    /// Optional path to the history file used for the shell.
+    history_file_path: Option<PathBuf>,
+}
+
+impl RustylineShell {
+    /// Returns a new interactive shell instance, created with the provided options.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Options for creating the interactive shell.
+    pub async fn new(options: &crate::Options) -> Result<RustylineShell, ShellError> {
+        // Set up shell first. Its initialization may influence how the
+        // editor needs to operate.
+        let shell = brush_core::Shell::new(&options.shell).await?;
+        let history_file_path = shell.get_history_file_path();
+
+        let mut editor = Self::new_editor(options, shell).map_err(|_err| ShellError::InputError)?;
+        if let Some(history_file_path) = &history_file_path {
+            // If the history file doesn't already exist, then make a best-effort attempt.
+            // to create it.
+            if !history_file_path.exists() {
+                let _ = std::fs::File::create(history_file_path);
+            }
+
+            // Make a best effort attempt to load the history file.
+            let _ = editor.load_history(history_file_path);
+        }
+
+        Ok(RustylineShell {
+            editor,
+            history_file_path,
+        })
+    }
+
+    fn new_editor(options: &crate::Options, shell: brush_core::Shell) -> rustyline::Result<Editor> {
+        let config = rustyline::config::Builder::new()
+            .max_history_size(1000)?
+            .history_ignore_dups(true)?
+            .auto_add_history(true)
+            .bell_style(rustyline::config::BellStyle::None)
+            .completion_type(rustyline::config::CompletionType::List)
+            .bracketed_paste(!options.disable_bracketed_paste)
+            .build();
+
+        let mut editor = rustyline::Editor::with_config(config)?;
+        editor.set_helper(Some(EditorHelper::new(shell)));
+
+        Ok(editor)
+    }
+}
+
+impl InteractiveShell for RustylineShell {
+    /// Returns an immutable reference to the inner shell object.
+    fn shell(&self) -> impl AsRef<brush_core::Shell> {
+        &self.editor.helper().unwrap().shell
+    }
+
+    /// Returns a mutable reference to the inner shell object.
+    fn shell_mut(&mut self) -> impl AsMut<brush_core::Shell> {
+        &mut self.editor.helper_mut().unwrap().shell
+    }
+
+    fn read_line(&mut self, prompt: &str) -> Result<ReadResult, ShellError> {
+        match self.editor.readline(prompt) {
+            Ok(s) => Ok(ReadResult::Input(s)),
+            Err(rustyline::error::ReadlineError::Eof) => Ok(ReadResult::Eof),
+            Err(rustyline::error::ReadlineError::Interrupted) => Ok(ReadResult::Interrupted),
+            Err(_err) => Err(ShellError::InputError),
+        }
+    }
+
+    fn update_history(&mut self) -> Result<(), ShellError> {
+        if let Some(history_file_path) = &self.history_file_path {
+            if self.shell().as_ref().options.append_to_history_file {
+                self.editor
+                    .append_history(history_file_path)
+                    .map_err(|_err| ShellError::InputError)
+            } else {
+                self.editor
+                    .save_history(history_file_path)
+                    .map_err(|_err| ShellError::InputError)
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+//
+// N.B. For now, we disable hinting on Windows because it sometimes results
+// in prompt/input rendering errors.
+//
+#[cfg(unix)]
+#[derive(rustyline::Helper, rustyline::Hinter)]
+pub(crate) struct EditorHelper {
+    pub shell: brush_core::Shell,
+
+    #[rustyline(Hinter)]
+    hinter: rustyline::hint::HistoryHinter,
+}
+
+#[cfg(windows)]
+#[derive(rustyline::Helper)]
+pub(crate) struct EditorHelper {
+    pub shell: brush_core::Shell,
+}
+
+impl EditorHelper {
+    #[cfg(unix)]
+    pub(crate) fn new(shell: brush_core::Shell) -> Self {
+        Self {
+            shell,
+            hinter: rustyline::hint::HistoryHinter::new(),
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn new(shell: brush_core::Shell) -> Self {
+        Self { shell }
+    }
+
+    fn get_completion_candidate_display_str(
+        mut s: &str,
+        options: &brush_core::completion::ProcessingOptions,
+    ) -> String {
+        let s_without_trailing_space = s.trim_end();
+        let s_without_final_slash = s_without_trailing_space
+            .strip_suffix(std::path::MAIN_SEPARATOR)
+            .unwrap_or(s);
+
+        if options.treat_as_filenames {
+            if let Some(slash_index) = s_without_final_slash.rfind(std::path::MAIN_SEPARATOR) {
+                s = &s[slash_index + 1..];
+            }
+        }
+
+        s.to_owned()
+    }
+
+    async fn complete_async(
+        &mut self,
+        line: &str,
+        pos: usize,
+    ) -> rustyline::Result<(usize, Vec<rustyline::completion::Pair>)> {
+        let working_dir = self.shell.working_dir.clone();
+
+        // Intentionally ignore any errors that arise.
+        let completion_future = self.shell.get_completions(line, pos);
+        tokio::pin!(completion_future);
+
+        // Wait for the completions to come back or interruption, whichever happens first.
+        let result = loop {
+            tokio::select! {
+                result = &mut completion_future => {
+                    break result;
+                }
+                _ = tokio::signal::ctrl_c() => {
+                },
+            }
+        };
+
+        let mut completions = result.unwrap_or_else(|_| brush_core::completion::Completions {
+            start: pos,
+            candidates: vec![],
+            options: brush_core::completion::ProcessingOptions::default(),
+        });
+
+        let completing_end_of_line = pos == line.len();
+        if completions.options.treat_as_filenames {
+            for candidate in &mut completions.candidates {
+                // Check if it's a directory.
+                if !candidate.ends_with(std::path::MAIN_SEPARATOR) {
+                    let candidate_path = Path::new(candidate);
+                    let abs_candidate_path = if candidate_path.is_absolute() {
+                        PathBuf::from(candidate_path)
+                    } else {
+                        working_dir.join(candidate_path)
+                    };
+
+                    if abs_candidate_path.is_dir() {
+                        candidate.push(std::path::MAIN_SEPARATOR);
+                    }
+                }
+            }
+        }
+        if completions.options.no_autoquote_filenames {
+            tracing::debug!(target: "completion", "don't autoquote filenames");
+        }
+        if completing_end_of_line && !completions.options.no_trailing_space_at_end_of_line {
+            for candidate in &mut completions.candidates {
+                if !completions.options.treat_as_filenames
+                    || !candidate.ends_with(std::path::MAIN_SEPARATOR)
+                {
+                    candidate.push(' ');
+                }
+            }
+        }
+
+        let options = completions.options;
+        let candidates = completions
+            .candidates
+            .into_iter()
+            .map(|c| rustyline::completion::Pair {
+                display: Self::get_completion_candidate_display_str(c.as_str(), &options),
+                replacement: c,
+            })
+            .collect();
+
+        Ok((completions.start, candidates))
+    }
+}
+
+impl rustyline::highlight::Highlighter for EditorHelper {
+    // Display hints with low intensity
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Cow::Owned("\x1b[2m".to_owned() + hint + "\x1b[m")
+    }
+
+    // Color names that seem to be dirs.
+    fn highlight_candidate<'c>(
+        &self,
+        candidate: &'c str, // FIXME should be Completer::Candidate
+        _completion: rustyline::CompletionType,
+    ) -> Cow<'c, str> {
+        if let Some(candidate_without_suffix) = candidate.strip_suffix(std::path::MAIN_SEPARATOR) {
+            Cow::Owned("\x1b[1;34m".to_owned() + candidate_without_suffix + "\x1b[0m/")
+        } else {
+            Cow::Borrowed(candidate)
+        }
+    }
+}
+
+impl rustyline::completion::Completer for EditorHelper {
+    type Candidate = rustyline::completion::Pair;
+
+    fn complete(
+        &mut self,
+        line: &str,
+        pos: usize,
+        _ctx: &rustyline::Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(self.complete_async(line, pos))
+        })
+    }
+}
+
+impl rustyline::validate::Validator for EditorHelper {
+    fn validate(
+        &self,
+        ctx: &mut rustyline::validate::ValidationContext,
+    ) -> rustyline::Result<rustyline::validate::ValidationResult> {
+        let line = ctx.input();
+
+        let parse_result = self.shell.parse_string(line.to_owned());
+
+        let validation_result = match parse_result {
+            Err(brush_parser::ParseError::Tokenizing { inner, position: _ })
+                if inner.is_incomplete() =>
+            {
+                ValidationResult::Incomplete
+            }
+            Err(brush_parser::ParseError::ParsingAtEndOfInput) => ValidationResult::Incomplete,
+            _ => ValidationResult::Valid(None),
+        };
+
+        Ok(validation_result)
+    }
+}
+
+#[cfg(windows)]
+impl rustyline::hint::Hinter for EditorHelper {
+    type Hint = String;
+}

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -26,10 +26,10 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1.82"
-brush-interactive = { version = "^0.2.7", path = "../brush-interactive" }
 brush-parser = { version = "^0.2.6", path = "../brush-parser" }
 brush-core = { version = "^0.2.7", path = "../brush-core" }
-clap = { version = "4.5.11", features = ["derive", "wrap_help"] }
+cfg-if = "1.0.0"
+clap = { version = "4.5.17", features = ["derive", "wrap_help"] }
 const_format = "0.2.33"
 git-version = "0.3.9"
 lazy_static = "1.5.0"
@@ -37,10 +37,16 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
 [target.'cfg(not(any(windows, unix)))'.dependencies]
+brush-interactive = { version = "^0.2.7", path = "../brush-interactive", features = [
+    "basic",
+] }
 tokio = { version = "1.40.0", features = ["rt", "sync"] }
 
 [target.'cfg(any(windows, unix))'.dependencies]
-tokio = { version = "1.39.3", features = ["rt", "rt-multi-thread", "sync"] }
+brush-interactive = { version = "^0.2.7", path = "../brush-interactive", features = [
+    "rustyline",
+] }
+tokio = { version = "1.40.0", features = ["rt", "rt-multi-thread", "sync"] }
 
 [dev-dependencies]
 anyhow = "1.0.87"

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -18,6 +18,12 @@ const VERSION: &str = const_format::concatcp!(
     ")"
 );
 
+#[derive(Clone, clap::ValueEnum)]
+pub enum InputBackend {
+    Rustyline,
+    Basic,
+}
+
 /// Parsed command-line arguments for the brush shell.
 #[derive(Parser)]
 #[clap(name = productinfo::PRODUCT_NAME,
@@ -98,6 +104,10 @@ pub struct CommandLineArgs {
     /// Disable bracketed paste.
     #[clap(long = "disable-bracketed-paste")]
     pub disable_bracketed_paste: bool,
+
+    /// Input backend.
+    #[clap(long = "input-backend")]
+    pub input_backend: Option<InputBackend>,
 
     /// Enable debug logging for classes of tracing events.
     #[clap(long = "log-enable", value_name = "EVENT")]

--- a/brush-shell/src/brushctl.rs
+++ b/brush-shell/src/brushctl.rs
@@ -1,11 +1,10 @@
-use brush_interactive::InteractiveShell;
 use clap::{Parser, Subcommand};
 use std::io::Write;
 
 use crate::events;
 
-pub(crate) fn register(shell: &mut InteractiveShell) {
-    shell.shell_mut().builtins.insert(
+pub(crate) fn register(shell: &mut brush_core::Shell) {
+    shell.builtins.insert(
         "brushctl".into(),
         brush_core::builtins::builtin::<BrushCtlCommand>(),
     );

--- a/brush-shell/src/shell_factory.rs
+++ b/brush-shell/src/shell_factory.rs
@@ -1,0 +1,101 @@
+#[async_trait::async_trait]
+pub(crate) trait ShellFactory {
+    type ShellType: brush_interactive::InteractiveShell + Send;
+
+    async fn create(
+        &self,
+        options: &brush_interactive::Options,
+    ) -> Result<Self::ShellType, brush_interactive::ShellError>;
+}
+
+pub(crate) struct StubShell;
+
+#[allow(clippy::panic)]
+impl brush_interactive::InteractiveShell for StubShell {
+    #[allow(unreachable_code)]
+    fn shell(&self) -> impl AsRef<brush_core::Shell> + Send {
+        panic!("No interactive shell implementation available");
+        self
+    }
+
+    #[allow(unreachable_code)]
+    fn shell_mut(&mut self) -> impl AsMut<brush_core::Shell> + Send {
+        panic!("No interactive shell implementation available");
+        self
+    }
+
+    fn read_line(
+        &mut self,
+        _prompt: &str,
+    ) -> Result<brush_interactive::ReadResult, brush_interactive::ShellError> {
+        Err(brush_interactive::ShellError::InputBackendNotSupported)
+    }
+
+    fn update_history(&mut self) -> Result<(), brush_interactive::ShellError> {
+        Err(brush_interactive::ShellError::InputBackendNotSupported)
+    }
+}
+
+#[allow(clippy::panic)]
+impl AsRef<brush_core::Shell> for StubShell {
+    fn as_ref(&self) -> &brush_core::Shell {
+        panic!("No interactive shell implementation available")
+    }
+}
+
+#[allow(clippy::panic)]
+impl AsMut<brush_core::Shell> for StubShell {
+    fn as_mut(&mut self) -> &mut brush_core::Shell {
+        panic!("No interactive shell implementation available")
+    }
+}
+
+pub(crate) struct RustylineShellFactory;
+
+#[async_trait::async_trait]
+impl ShellFactory for RustylineShellFactory {
+    #[cfg(any(windows, unix))]
+    type ShellType = brush_interactive::RustylineShell;
+    #[cfg(not(any(windows, unix)))]
+    type ShellType = StubShell;
+
+    #[allow(unused)]
+    async fn create(
+        &self,
+        options: &brush_interactive::Options,
+    ) -> Result<Self::ShellType, brush_interactive::ShellError> {
+        #[cfg(any(windows, unix))]
+        {
+            brush_interactive::RustylineShell::new(options).await
+        }
+        #[cfg(not(any(windows, unix)))]
+        {
+            Err(brush_interactive::ShellError::InputBackendNotSupported)
+        }
+    }
+}
+
+pub(crate) struct BasicShellFactory;
+
+#[async_trait::async_trait]
+impl ShellFactory for BasicShellFactory {
+    #[cfg(not(any(windows, unix)))]
+    type ShellType = brush_interactive::BasicShell;
+    #[cfg(any(windows, unix))]
+    type ShellType = StubShell;
+
+    #[allow(unused)]
+    async fn create(
+        &self,
+        options: &brush_interactive::Options,
+    ) -> Result<Self::ShellType, brush_interactive::ShellError> {
+        #[cfg(not(any(windows, unix)))]
+        {
+            brush_interactive::BasicShell::new(options).await
+        }
+        #[cfg(any(windows, unix))]
+        {
+            Err(brush_interactive::ShellError::InputBackendNotSupported)
+        }
+    }
+}

--- a/brush-shell/tests/cases/builtins/unalias.yaml
+++ b/brush-shell/tests/cases/builtins/unalias.yaml
@@ -1,0 +1,18 @@
+name: "Builtins: unalias"
+cases:
+  - name: "Unalias basic usage"
+    args: ["-i"]
+    env:
+      PS1: "$ "
+    ignore_stderr: true
+    stdin: |
+      alias echo='echo prefixed'
+      echo 'something'
+      unalias echo
+      echo 'something'
+
+  - name: "Unalias non-existent alias"
+    args: ["-i"]
+    ignore_stderr: true
+    stdin: |
+      unalias not_an_alias

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,6 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1.0.87"
 brush-shell = { version = "^0.2.7", path = "../brush-shell" }
-clap = { version = "4.5.11", features = ["derive"] }
+clap = { version = "4.5.17", features = ["derive"] }
 clap_mangen = "0.2.23"
 clap-markdown = "0.1.4"


### PR DESCRIPTION
Extracts out `InteractiveShell` as a trait, albeit with a few default implementations. (That may be addressed in the future.)

This is intended to pave the way to allow for swapping things out for an alternate implementation experimentally.