### PR TITLE
fix: do not invoke debug traps during completion funcs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     },
     "rust-analyzer.check.command": "clippy",
     "rewrap.wrappingColumn": 90,
-    "rust-analyzer.cargo.features": "all"
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.debug.openDebugPane": true
 }

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -506,7 +506,13 @@ impl Spec {
             args.push(preceding_token);
         }
 
+        // TODO: Find a more appropriate interlock here. For now we use the existing
+        // handler depth count to suppress any debug traps.
+        shell.traps.handler_depth += 1;
+
         let result = shell.invoke_function(function_name, &args).await?;
+
+        shell.traps.handler_depth -= 1;
 
         tracing::debug!("[called completion func '{function_name}' => {result}]");
 


### PR DESCRIPTION
Not the best implementation, but this seems to match what `bash` does and can speed up completion when using debug traps (such as the one that starship installs).