### PR TITLE
test: add more basic interactive tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "descape"
-version = "1.2.0"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded38a8c3b37dcea20252418a1ccaa59cd399da7488c34452144720872a1b80b"
+checksum = "7c1113b908df80c963b107424498e37fba986b424b605729d1492dfbe4b2a630"
 
 [[package]]
 name = "diff"
@@ -889,8 +889,7 @@ checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 [[package]]
 name = "expectrl"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede784925953fcab9a3351d5009bcb8d2b0c13e940924c88087e8e2ce0c4717a"
+source = "git+https://github.com/zhiburt/expectrl?rev=a0f4f7816b9a47a191dd858080e8fd80ff71cd96#a0f4f7816b9a47a191dd858080e8fd80ff71cd96"
 dependencies = [
  "conpty",
  "nix 0.26.4",

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -17,9 +17,13 @@ path = "src/main.rs"
 bench = false
 
 [[test]]
-name = "brush-integration-tests"
-path = "tests/integration_tests.rs"
+name = "brush-compat-tests"
+path = "tests/compat_tests.rs"
 harness = false
+
+[[test]]
+name = "brush-interactive-tests"
+path = "tests/interactive_tests.rs"
 
 [lints]
 workspace = true
@@ -53,10 +57,10 @@ anyhow = "1.0.89"
 assert_cmd = "2.0.15"
 assert_fs = "1.1.1"
 colored = "2.1.0"
-descape = "1.2.0"
+descape = "2.0.3"
 diff = "0.1.13"
 dir-cmp = "0.1.0"
-expectrl = "0.7.1"
+expectrl = { git = "https://github.com/zhiburt/expectrl", rev = "a0f4f7816b9a47a191dd858080e8fd80ff71cd96" }
 glob = "0.3.1"
 indent = "0.1.1"
 junit-report = "0.8.3"

--- a/brush-shell/tests/interactive_tests.rs
+++ b/brush-shell/tests/interactive_tests.rs
@@ -1,0 +1,137 @@
+#![allow(clippy::panic_in_result_fn)]
+
+use expectrl::{
+    process::unix::{PtyStream, UnixProcess},
+    repl::ReplSession,
+    Expect, Session,
+};
+
+#[test]
+fn run_suspend_and_fg() -> anyhow::Result<()> {
+    let mut session = start_shell_session()?;
+
+    // Ping localhost in a loop; wait for at least one response.
+    session.expect_prompt()?;
+    session.send_line("ping 127.0.0.1")?;
+    session.expect("bytes from")?;
+
+    // Suspend and resume a handful of times to make sure it pauses and
+    // resumes reliably.
+    for _ in 0..1 {
+        // Suspend.
+        session.suspend()?;
+        session.expect_prompt()?;
+
+        // Run `jobs` to see the suspended job.
+        let jobs_output = session.exec_output("jobs")?;
+        assert!(jobs_output.contains("ping 127.0.0.1"));
+
+        // Bring the job to the foreground.
+        session.send_line("fg")?;
+        session.expect("ping")?;
+    }
+
+    // Ctrl+C to cancel the ping.
+    session.interrupt()?;
+    session.expect("loss")?;
+    session.expect_prompt()?;
+
+    // Exit the shell.
+    session.exit()?;
+
+    Ok(())
+}
+
+#[test]
+fn run_in_bg_then_fg() -> anyhow::Result<()> {
+    let mut session = start_shell_session()?;
+
+    // Ping localhost in a loop; wait for at least one response.
+    session.expect_prompt()?;
+    session.send_line("ping 127.0.0.1")?;
+    session.expect("bytes from")?;
+
+    // Suspend and send to background.
+    session.suspend()?;
+    session.expect_prompt()?;
+
+    // Run `jobs` to see the suspended job.
+    let jobs_output = session.exec_output("jobs")?;
+    assert!(jobs_output.contains("ping 127.0.0.1"));
+
+    // Send the job to the background.
+    session.send_line("bg")?;
+    session.expect_prompt()?;
+
+    // Make sure ping is still running asynchronously.
+    session.expect("bytes from")?;
+
+    // Kill the job; make sure it's done.
+    session.send_line("kill %1")?;
+    session.expect_prompt()?;
+    session.send_line("wait")?;
+    session.expect_prompt()?;
+
+    // Make sure the jobs are gone.
+    let jobs_output = session.exec_output("jobs")?;
+    assert!(jobs_output.trim().is_empty());
+
+    // Exit the shell.
+    session.exit()?;
+
+    Ok(())
+}
+
+//
+// Helpers
+//
+
+// N.B. Uncomment the following line to enable logging of the session (along with a similar line
+// below). type ShellSession = ReplSession<Session<UnixProcess, LogStream<PtyStream,
+// std::io::Stdout>>>;
+type ShellSession = ReplSession<Session<UnixProcess, PtyStream>>;
+
+trait SessionExt {
+    fn suspend(&mut self) -> anyhow::Result<()>;
+    fn interrupt(&mut self) -> anyhow::Result<()>;
+    fn exec_output<S: AsRef<str>>(&mut self, cmd: S) -> anyhow::Result<String>;
+}
+
+impl SessionExt for ShellSession {
+    fn suspend(&mut self) -> anyhow::Result<()> {
+        // Send Ctrl+Z to suspend.
+        self.send(expectrl::ControlCode::Substitute)?;
+        Ok(())
+    }
+
+    fn interrupt(&mut self) -> anyhow::Result<()> {
+        // Send Ctrl+C to interrupt.
+        self.send(expectrl::ControlCode::EndOfText)?;
+        Ok(())
+    }
+
+    fn exec_output<S: AsRef<str>>(&mut self, cmd: S) -> anyhow::Result<String> {
+        let output = self.execute(cmd)?;
+        let output_str = String::from_utf8(output)?;
+        Ok(output_str)
+    }
+}
+
+fn start_shell_session() -> anyhow::Result<ShellSession> {
+    const DEFAULT_PROMPT: &str = "brush> ";
+    let shell_path = assert_cmd::cargo::cargo_bin("brush");
+
+    let mut cmd = std::process::Command::new(shell_path);
+    cmd.args(["--norc", "--noprofile", "--disable-bracketed-paste"]);
+    cmd.env("PS1", DEFAULT_PROMPT);
+    cmd.env("TERM", "dumb");
+
+    let session = expectrl::session::Session::spawn(cmd)?;
+
+    // N.B. Uncomment this line to enable logging of the session (along with a similar line above).
+    // let session = expectrl::session::log(session, std::io::stdout())?;
+
+    let session = expectrl::repl::ReplSession::new(session, DEFAULT_PROMPT);
+
+    Ok(session)
+}

--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,14 @@ version = 2
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["Apache-2.0", "BSD-2-Clause", "BSL-1.0", "MIT", "Unicode-DFS-2016", "Zlib"]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSL-1.0",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -92,7 +99,7 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/zhiburt/expectrl"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/docs/how-to/run-tests.md
+++ b/docs/how-to/run-tests.md
@@ -6,14 +6,14 @@ To run all workspace tests:
 cargo test --workspace
 ```
 
-To run just integration tests:
+To run just bash compatibility tests:
 
 ```bash
-cargo test --test brush-integration-tests
+cargo test --test brush-compat-tests
 ```
 
-To run a specific integration test case
+To run a specific compatibility test case
 
 ```bash
-cargo test --test brush-integration-tests -- '<name of test case>'
+cargo test --test brush-compat-tests -- '<name of test case>'
 ```


### PR DESCRIPTION
Update to the latest git commit of `expectrl` and implement a few basic interactive tests covering basic process management (e.g., fg, bg).