### PR TITLE
fix: allow source to be used with process substitution

### DIFF
--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
 
     /// An error occurred while sourcing the indicated script file.
     #[error("failed to source file: {0}; {1}")]
-    FailedSourcingFile(PathBuf, std::io::Error),
+    FailedSourcingFile(PathBuf, Box<Error>),
 
     /// The shell failed to send a signal to a process.
     #[error("failed to send signal to process")]

--- a/brush-core/src/openfiles.rs
+++ b/brush-core/src/openfiles.rs
@@ -74,6 +74,14 @@ impl OpenFile {
         }
     }
 
+    pub(crate) fn is_dir(&self) -> bool {
+        match self {
+            OpenFile::Stdin | OpenFile::Stdout | OpenFile::Stderr | OpenFile::Null => false,
+            OpenFile::File(file) => file.metadata().map(|m| m.is_dir()).unwrap_or(false),
+            OpenFile::PipeReader(_) | OpenFile::PipeWriter(_) => false,
+        }
+    }
+
     pub(crate) fn is_term(&self) -> bool {
         match self {
             OpenFile::Stdin => std::io::stdin().is_terminal(),
@@ -119,6 +127,12 @@ impl OpenFile {
             OpenFile::PipeWriter(_) => (),
         }
         Ok(())
+    }
+}
+
+impl From<std::fs::File> for OpenFile {
+    fn from(file: std::fs::File) -> Self {
+        OpenFile::File(file)
     }
 }
 

--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -42,6 +42,11 @@ cases:
       shopt -u -o posix
       for f in <(echo hi); do echo $f; done
 
+  - name: "Process substitution: builtins"
+    stdin: |
+      source <(echo VAR=100)
+      echo "var: ${VAR}"
+
   - name: "Process substitution: input redirection"
     stdin: |
       shopt -u -o posix


### PR DESCRIPTION
This fixes issues reported when doing something like `source <(some command)`.