### PR TITLE
test: convert more test skips to known failures

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,7 @@
 [profile.default]
 retries = 3
 status-level = "slow"
+slow-timeout = { period = "5s", terminate-after = 3, grace-period = "2s" }
 
 [profile.default.junit]
 path = "test-results.xml"

--- a/brush-shell/tests/cases/builtins/shopt.yaml
+++ b/brush-shell/tests/cases/builtins/shopt.yaml
@@ -1,12 +1,13 @@
 name: "Builtins: shopt"
 cases:
   - name: "shopt defaults"
-    skip: true
+    known_failure: true # TODO: new options from newer version of bash?
     stdin: |
       shopt | sort | grep -v extglob
 
   - name: "shopt interactive defaults"
-    skip: true # TODO: Causes problems with cargo nextest
+    known_failure: true # TODO: new options from newer version of bash?
+    pty: true
     args: ["-i", "-c", "shopt | sort | grep -v extglob"]
 
   - name: "shopt -o defaults"
@@ -14,21 +15,21 @@ cases:
       shopt -o | sort
 
   - name: "shopt -o interactive defaults"
-    skip: true # TODO: Causes problems with cargo nextest
+    pty: true
     args: ["-i", "-c", "shopt -o | sort | grep -v monitor"]
 
   - name: "extglob defaults"
-    known_failure: true
+    known_failure: true # TODO: we force this setting on in our shell
     stdin: |
       shopt extglob
 
   - name: "extglob interactive defaults"
-    skip: true # TODO: Causes problems with cargo nextest
+    pty: true
     args: ["-i", "-c", "shopt extglob"]
     known_failure: true
 
   - name: "shopt -o interactive monitor default"
-    skip: true # TODO: Causes problems with cargo nextest
+    pty: true
     args: ["-i", "-c", "shopt -o monitor"]
 
   - name: "shopt toggle"

--- a/brush-shell/tests/cases/builtins/trap.yaml
+++ b/brush-shell/tests/cases/builtins/trap.yaml
@@ -13,7 +13,7 @@ cases:
       trap -p INT
 
   - name: "trap EXIT"
-    known_failure: true
+    known_failure: true # TODO: needs triage and debugging
     stdin: |
       trap "echo [exit]" EXIT
       trap -p EXIT

--- a/brush-shell/tests/cases/builtins/unset.yaml
+++ b/brush-shell/tests/cases/builtins/unset.yaml
@@ -48,7 +48,7 @@ cases:
       declare -p myarray
 
   - name: "Unset array element with interesting expression"
-    known_failure: true
+    known_failure: true # TODO: case needs implementing
     stdin: |
       declare -a myarray=(a b c d e)
 

--- a/brush-shell/tests/cases/here.yaml
+++ b/brush-shell/tests/cases/here.yaml
@@ -12,7 +12,7 @@ cases:
     args: ["./script.sh"]
 
   - name: "Here doc with expansions"
-    known_failure: true
+    known_failure: true # TODO: needs triage and debugging
     stdin: |
       cat <<END-MARKER
       Something here...
@@ -21,7 +21,7 @@ cases:
       END-MARKER
 
   - name: "Here doc with tab removal"
-    known_failure: true
+    known_failure: true # TODO: needs triage and debugging
     stdin: |
       cat <<-END-MARKER
       	Something here...

--- a/brush-shell/tests/cases/options.yaml
+++ b/brush-shell/tests/cases/options.yaml
@@ -5,7 +5,7 @@ cases:
       echo "Default options: $-"
 
   - name: "set -a"
-    known_failure: true
+    known_failure: true # TODO: set -a not implemented
     stdin: |
       unexported=original
       set -a

--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -53,7 +53,6 @@ cases:
       cat < <(echo hi)
 
   - name: "Process substitution: output redirection"
-    skip: true # Periodically fails, possibly due to output race condition.
     stdin: |
       shopt -u -o posix
       echo hi > >(wc -l)

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -338,7 +338,7 @@ cases:
       echo "  -> result: $?"
 
   - name: "Parameter expression: error on condition (non-interactive)"
-    known_failure: true
+    known_failure: true # TODO: needs triage and debugging
     ignore_stderr: true
     stdin: |
       echo "${non_existent_var?error message}"
@@ -393,7 +393,7 @@ cases:
       done
 
   - name: "Parameter expression: expanded array as default value"
-    known_failure: true
+    known_failure: true # TODO: needs triage and debugging
     stdin: |
       declare -a var=("abc" "def" "ghi" "")
 
@@ -694,7 +694,7 @@ cases:
       echo "\${arr2@Q}: ${arr2@Q}"
 
   - name: "Parameter quote transformations - K"
-    known_failure: true
+    known_failure: true # TODO: needs triage and debugging
     stdin: |
       var='""'
       echo "\${var@K}: ${var@K}"


### PR DESCRIPTION
Some of the tests previously being skipped could be run under `cargo nextest` in our compat test harness's "pty mode" instead. Some still fail, but at least they can be run and show up as known failures.