### PR TITLE
test: enable setting min oracle version on tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "version-compare",
 ]
 
 [[package]]
@@ -2364,6 +2365,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -69,3 +69,4 @@ regex = "1.11.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_yaml = "0.9.34"
 strip-ansi-escapes = "0.2.0"
+version-compare = "0.2.0"

--- a/brush-shell/tests/cases/builtins/shopt.yaml
+++ b/brush-shell/tests/cases/builtins/shopt.yaml
@@ -1,11 +1,13 @@
 name: "Builtins: shopt"
 cases:
   - name: "shopt defaults"
+    min_oracle_version: 5.2
     known_failure: true # TODO: new options from newer version of bash?
     stdin: |
       shopt | sort | grep -v extglob
 
   - name: "shopt interactive defaults"
+    min_oracle_version: 5.2
     known_failure: true # TODO: new options from newer version of bash?
     pty: true
     args: ["-i", "-c", "shopt | sort | grep -v extglob"]

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -721,6 +721,7 @@ cases:
       echo "\${arr2[*]@K}: ${arr2[*]@K}"
 
   - name: "Parameter quote transformations - k"
+    min_oracle_version: 5.2
     stdin: |
       var='""'
       echo "\${var@k}: ${var@k}"


### PR DESCRIPTION
This enables us to tag certain tests as only being applicable when a given minimum version of the oracle (i.e., `bash`) is installed on the test system. This is practically useful since we now have a few tests that pass when comparing `brush` to `bash` only when `bash` is `>= 5.2`.