### PR TITLE
chore: adopt #[expect()] wherever possible

### DIFF
--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -153,7 +153,6 @@ async fn deref_lvalue(shell: &mut Shell, lvalue: &ast::ArithmeticTarget) -> Resu
     Ok(value)
 }
 
-#[allow(clippy::unnecessary_wraps)]
 async fn apply_unary_op(
     shell: &mut Shell,
     op: ast::UnaryOperator,
@@ -205,8 +204,8 @@ async fn apply_binary_op(
     let left = left.eval(shell).await?;
     let right = right.eval(shell).await?;
 
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::cast_sign_loss)]
+    #[expect(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_sign_loss)]
     match op {
         ast::BinaryOperator::Power => {
             if right >= 0 {
@@ -280,7 +279,6 @@ async fn apply_unary_assignment_op(
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
 async fn assign(
     shell: &mut Shell,
     lvalue: &ast::ArithmeticTarget,

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -105,7 +105,6 @@ macro_rules! minus_or_plus_flag_arg {
 pub(crate) use minus_or_plus_flag_arg;
 
 /// Result of executing a built-in command.
-#[allow(clippy::module_name_repetitions)]
 pub struct BuiltinResult {
     /// The exit code from the command.
     pub exit_code: ExitCode,
@@ -395,8 +394,7 @@ fn brush_help_styles() -> clap::builder::Styles {
 /// # Returns
 ///
 /// * a parsed struct T from [`clap::Parser::parse_from`]
-/// * the remain iterator `args` with `--` and the rest arguments if they present
-///   othervise None
+/// * the remain iterator `args` with `--` and the rest arguments if they present othervise None
 ///
 /// # Examples
 /// ```
@@ -420,8 +418,8 @@ where
     S: Into<std::ffi::OsString> + Clone + PartialEq<&'static str>,
 {
     let mut args = args.into_iter();
-    // the best way to save `--` is to get it out with a side effect while `clap` iterates over the args
-    // this way we can be 100% sure that we have '--' and the remaining args
+    // the best way to save `--` is to get it out with a side effect while `clap` iterates over the
+    // args this way we can be 100% sure that we have '--' and the remaining args
     // and we will iterate only once
     let mut hyphen = None;
     let args_before_hyphen = args.by_ref().take_while(|a| {
@@ -437,7 +435,8 @@ where
 }
 
 /// Similar to [`parse_known`] but with [`clap::Parser::try_parse_from`]
-/// This function is used to parse arguments in builtins such as [`crate::builtins::echo::EchoCommand`]
+/// This function is used to parse arguments in builtins such as
+/// [`crate::builtins::echo::EchoCommand`]
 pub fn try_parse_known<T: Parser>(
     args: impl IntoIterator<Item = String>,
 ) -> Result<(T, Option<impl Iterator<Item = String>>), clap::Error> {

--- a/brush-core/src/builtins/break_.rs
+++ b/brush-core/src/builtins/break_.rs
@@ -21,7 +21,7 @@ impl builtins::Command for BreakCommand {
             return Ok(builtins::ExitCode::InvalidUsage);
         }
 
-        #[allow(clippy::cast_sign_loss)]
+        #[expect(clippy::cast_sign_loss)]
         Ok(builtins::ExitCode::BreakLoop((self.which_loop - 1) as u8))
     }
 }

--- a/brush-core/src/builtins/brushinfo.rs
+++ b/brush-core/src/builtins/brushinfo.rs
@@ -18,7 +18,7 @@ enum CommandGroup {
 }
 
 /// Commands for configuring tracing events.
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 #[derive(Subcommand)]
 enum ProcessCommand {
     /// Display process ID.

--- a/brush-core/src/builtins/command.rs
+++ b/brush-core/src/builtins/command.rs
@@ -82,7 +82,7 @@ impl Display for FoundCommand {
 }
 
 impl CommandCommand {
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     fn try_find_command(&self, shell: &shell::Shell) -> Option<FoundCommand> {
         // Look in path.
         if self.command_name.contains(std::path::MAIN_SEPARATOR) {
@@ -127,8 +127,6 @@ impl CommandCommand {
         // We do not have an existing process group to place this into.
         let mut pgid = None;
 
-        #[allow(clippy::cast_possible_truncation)]
-        #[allow(clippy::cast_sign_loss)]
         match commands::execute(context, &mut pgid, args, false /* use functions? */).await? {
             commands::CommandSpawnResult::SpawnedProcess(mut child) => {
                 // TODO: jobs: review this logic

--- a/brush-core/src/builtins/continue_.rs
+++ b/brush-core/src/builtins/continue_.rs
@@ -21,7 +21,7 @@ impl builtins::Command for ContinueCommand {
             return Ok(builtins::ExitCode::InvalidUsage);
         }
 
-        #[allow(clippy::cast_sign_loss)]
+        #[expect(clippy::cast_sign_loss)]
         Ok(builtins::ExitCode::ContinueLoop(
             (self.which_loop - 1) as u8,
         ))

--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -109,7 +109,6 @@ impl builtins::DeclarationCommand for DeclareCommand {
     }
 }
 
-#[allow(clippy::too_many_lines)]
 #[async_trait::async_trait]
 impl builtins::Command for DeclareCommand {
     fn takes_plus_options() -> bool {
@@ -308,7 +307,7 @@ impl DeclareCommand {
         Ok(true)
     }
 
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     fn declaration_to_name_and_value(
         declaration: &commands::CommandArg,
     ) -> Result<(String, Option<String>, Option<ShellValueLiteral>, bool), error::Error> {
@@ -396,7 +395,7 @@ impl DeclareCommand {
         //
 
         // We start by excluding all variables that are not enumerable.
-        #[allow(clippy::type_complexity)]
+        #[expect(clippy::type_complexity)]
         let mut filters: Vec<Box<dyn Fn((&String, &ShellVariable)) -> bool>> =
             vec![Box::new(|(_, v)| v.is_enumerable())];
 
@@ -509,7 +508,7 @@ impl DeclareCommand {
         Ok(())
     }
 
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     fn apply_attributes_before_update(&self, var: &mut ShellVariable) -> Result<(), error::Error> {
         if let Some(value) = self.make_integer.to_bool() {
             if value {
@@ -563,7 +562,6 @@ impl DeclareCommand {
         Ok(())
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     fn apply_attributes_after_update(
         &self,
         var: &mut ShellVariable,

--- a/brush-core/src/builtins/exit.rs
+++ b/brush-core/src/builtins/exit.rs
@@ -17,7 +17,7 @@ impl builtins::Command for ExitCommand {
     ) -> Result<crate::builtins::ExitCode, crate::error::Error> {
         let code_8bit: u8;
 
-        #[allow(clippy::cast_sign_loss)]
+        #[expect(clippy::cast_sign_loss)]
         if let Some(code_32bit) = &self.code {
             code_8bit = (code_32bit & 0xFF) as u8;
         } else {

--- a/brush-core/src/builtins/factory.rs
+++ b/brush-core/src/builtins/factory.rs
@@ -90,7 +90,7 @@ fn exec_simple_builtin<T: SimpleCommand + Send + Sync>(
     Box::pin(async move { exec_simple_builtin_impl::<T>(context, args).await })
 }
 
-#[allow(clippy::unused_async)]
+#[expect(clippy::unused_async)]
 async fn exec_simple_builtin_impl<T: SimpleCommand + Send + Sync>(
     context: commands::ExecutionContext<'_>,
     args: Vec<CommandArg>,
@@ -181,7 +181,6 @@ async fn exec_declaration_builtin_impl<T: builtins::DeclarationCommand + Send + 
     })
 }
 
-#[allow(clippy::too_many_lines)]
 pub(crate) fn get_default_builtins(
     options: &crate::CreateOptions,
 ) -> HashMap<String, builtins::Registration> {

--- a/brush-core/src/builtins/help.rs
+++ b/brush-core/src/builtins/help.rs
@@ -56,7 +56,7 @@ impl HelpCommand {
         )?;
 
         let builtins = get_builtins_sorted_by_name(context);
-        let items_per_column = (builtins.len() + COLUMN_COUNT - 1) / COLUMN_COUNT;
+        let items_per_column = builtins.len().div_ceil(COLUMN_COUNT);
 
         for i in 0..items_per_column {
             for j in 0..COLUMN_COUNT {

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -51,7 +51,7 @@ impl PrintfCommand {
         self.evaluate_via_external_command(context)
     }
 
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     fn evaluate_via_external_command(
         &self,
         context: &commands::ExecutionContext<'_>,

--- a/brush-core/src/builtins/read.rs
+++ b/brush-core/src/builtins/read.rs
@@ -79,7 +79,7 @@ impl builtins::Command for ReadCommand {
         }
 
         // Find the input stream to use.
-        #[allow(clippy::cast_lossless)]
+        #[expect(clippy::cast_lossless)]
         let input_stream = if let Some(fd_num) = self.fd_num_to_read {
             let fd_num = fd_num as u32;
             context

--- a/brush-core/src/builtins/return_.rs
+++ b/brush-core/src/builtins/return_.rs
@@ -16,7 +16,7 @@ impl builtins::Command for ReturnCommand {
         context: commands::ExecutionContext<'_>,
     ) -> Result<crate::builtins::ExitCode, crate::error::Error> {
         let code_8bit: u8;
-        #[allow(clippy::cast_sign_loss)]
+        #[expect(clippy::cast_sign_loss)]
         if let Some(code_32bit) = &self.code {
             code_8bit = (code_32bit & 0xFF) as u8;
         } else {

--- a/brush-core/src/builtins/set.rs
+++ b/brush-core/src/builtins/set.rs
@@ -136,7 +136,7 @@ impl builtins::Command for SetCommand {
         true
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     async fn execute(
         &self,
         context: commands::ExecutionContext<'_>,

--- a/brush-core/src/builtins/shift.rs
+++ b/brush-core/src/builtins/shift.rs
@@ -21,7 +21,7 @@ impl builtins::Command for ShiftCommand {
             return Ok(builtins::ExitCode::InvalidUsage);
         }
 
-        #[allow(clippy::cast_sign_loss)]
+        #[expect(clippy::cast_sign_loss)]
         let n = n as usize;
 
         if n > context.shell.positional_parameters.len() {

--- a/brush-core/src/builtins/trap.rs
+++ b/brush-core/src/builtins/trap.rs
@@ -55,9 +55,7 @@ impl builtins::Command for TrapCommand {
     }
 }
 
-#[allow(unused_variables)]
 impl TrapCommand {
-    #[allow(clippy::unnecessary_wraps)]
     fn display_signals(context: &commands::ExecutionContext<'_>) -> Result<(), error::Error> {
         #[cfg(unix)]
         for signal in nix::sys::signal::Signal::iterator() {

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -33,9 +33,7 @@ pub(crate) enum CommandSpawnResult {
 
 impl CommandSpawnResult {
     // TODO: jobs: remove `no_wait`; it doesn't make any sense
-    #[allow(clippy::too_many_lines)]
     pub async fn wait(self, no_wait: bool) -> Result<CommandWaitResult, error::Error> {
-        #[allow(clippy::ignored_unit_patterns)]
         match self {
             CommandSpawnResult::SpawnedProcess(mut child) => {
                 let process_wait_result = if !no_wait {
@@ -128,7 +126,7 @@ impl ExecutionContext<'_> {
     }
 
     /// Returns the file descriptor with the given number.
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     pub fn fd(&self, fd: u32) -> Option<openfiles::OpenFile> {
         self.params
             .open_files
@@ -177,7 +175,6 @@ impl From<&String> for CommandArg {
     }
 }
 
-#[allow(unused_variables)]
 pub(crate) fn compose_std_command<S: AsRef<OsStr>>(
     shell: &mut Shell,
     command_name: &str,
@@ -308,7 +305,6 @@ pub(crate) async fn execute(
     execute_external_command(cmd_context, process_group_id, &args[1..])
 }
 
-#[allow(clippy::too_many_lines)]
 pub(crate) fn execute_external_command(
     context: ExecutionContext<'_>,
     process_group_id: &mut Option<i32>,
@@ -323,7 +319,6 @@ pub(crate) fn execute_external_command(
     }
 
     // Before we lose ownership of the open files, figure out if stdin will be a terminal.
-    #[allow(unused_variables)]
     let child_stdin_is_terminal = context
         .params
         .open_files
@@ -334,7 +329,6 @@ pub(crate) fn execute_external_command(
     let new_pg = context.should_cmd_lead_own_process_group();
 
     // Compose the std::process::Command that encapsulates what we want to launch.
-    #[allow(unused_mut)]
     let mut cmd = compose_std_command(
         context.shell,
         context.command_name.as_str(),
@@ -377,7 +371,7 @@ pub(crate) fn execute_external_command(
     match sys::process::spawn(cmd) {
         Ok(child) => {
             // Retrieve the pid.
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             let pid = child.id().map(|id| id as i32);
             if let Some(pid) = &pid {
                 if new_pg {

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -228,7 +228,7 @@ impl Spec {
     ///
     /// * `shell` - The shell instance to use for completion generation.
     /// * `context` - The context in which completion is being generated.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub async fn get_completions(
         &self,
         shell: &mut Shell,
@@ -686,7 +686,7 @@ impl Config {
     /// * `shell` - The shell instance to use for completion generation.
     /// * `input` - The input line for which completions are being generated.
     /// * `position` - The 0-based index of the cursor in the input line.
-    #[allow(clippy::cast_sign_loss)]
+    #[expect(clippy::cast_sign_loss)]
     pub async fn get_completions(
         &self,
         shell: &mut Shell,

--- a/brush-core/src/escape.rs
+++ b/brush-core/src/escape.rs
@@ -8,7 +8,7 @@ pub(crate) enum EscapeMode {
     AnsiCQuotes,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(crate) fn expand_backslash_escapes(
     s: &str,
     mode: EscapeMode,

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -360,7 +360,7 @@ impl<'a> WordExpander<'a> {
         let expansion = self.basic_expand(word).await?;
 
         // TODO: Use IFS instead for separator?
-        #[allow(unstable_name_collisions)]
+        #[expect(unstable_name_collisions)]
         let pattern_pieces: Vec<_> = expansion
             .fields
             .into_iter()
@@ -385,7 +385,7 @@ impl<'a> WordExpander<'a> {
         let expansion = self.basic_expand(word).await?;
 
         // TODO: Use IFS instead for separator?
-        #[allow(unstable_name_collisions)]
+        #[expect(unstable_name_collisions)]
         let regex_pieces: Vec<_> = expansion
             .fields
             .into_iter()
@@ -543,7 +543,7 @@ impl<'a> WordExpander<'a> {
                     } = self.expand_word_piece(piece).await?;
 
                     let fields_to_append = if concatenate {
-                        #[allow(unstable_name_collisions)]
+                        #[expect(unstable_name_collisions)]
                         let mut concatenated: Vec<ExpansionPiece> = this_fields
                             .into_iter()
                             .map(|WordField(pieces)| {
@@ -659,12 +659,11 @@ impl<'a> WordExpander<'a> {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     async fn expand_parameter_expr(
         &mut self,
         expr: brush_parser::word::ParameterExpr,
     ) -> Result<Expansion, error::Error> {
-        #[allow(clippy::cast_possible_truncation)]
         match expr {
             brush_parser::word::ParameterExpr::Parameter {
                 parameter,
@@ -1283,7 +1282,7 @@ impl<'a> WordExpander<'a> {
         Ok(index_to_use)
     }
 
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     fn expand_special_parameter(
         &mut self,
         parameter: &brush_parser::word::SpecialParameter,
@@ -1338,7 +1337,7 @@ impl<'a> WordExpander<'a> {
         Ok(value.to_string())
     }
 
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     fn uppercase_first_char(
         &mut self,
         s: String,
@@ -1368,7 +1367,7 @@ impl<'a> WordExpander<'a> {
         }
     }
 
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     fn lowercase_first_char(
         &mut self,
         s: String,
@@ -1440,7 +1439,7 @@ impl<'a> WordExpander<'a> {
         }
     }
 
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     fn replace_substring(
         s: &str,
         regex: &fancy_regex::Regex,
@@ -1562,7 +1561,7 @@ fn transform_expansion(
     })
 }
 
-#[allow(clippy::panic_in_result_fn)]
+#[expect(clippy::panic_in_result_fn)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -13,7 +13,6 @@ pub(crate) async fn eval_extended_test_expr(
     expr: &ast::ExtendedTestExpr,
     shell: &mut Shell,
 ) -> Result<bool, error::Error> {
-    #[allow(clippy::single_match_else)]
     match expr {
         ast::ExtendedTestExpr::UnaryTest(op, operand) => {
             apply_unary_predicate(op, operand, shell).await
@@ -53,13 +52,12 @@ async fn apply_unary_predicate(
     apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell)
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(crate) fn apply_unary_predicate_to_str(
     op: &ast::UnaryPredicate,
     operand: &str,
     shell: &mut Shell,
 ) -> Result<bool, error::Error> {
-    #[allow(clippy::match_single_binding)]
     match op {
         ast::UnaryPredicate::StringHasNonZeroLength => Ok(!operand.is_empty()),
         ast::UnaryPredicate::StringHasZeroLength => Ok(operand.is_empty()),
@@ -174,14 +172,13 @@ pub(crate) fn apply_unary_predicate_to_str(
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 async fn apply_binary_predicate(
     op: &ast::BinaryPredicate,
     left: &ast::Word,
     right: &ast::Word,
     shell: &mut Shell,
 ) -> Result<bool, error::Error> {
-    #[allow(clippy::single_match_else)]
     match op {
         ast::BinaryPredicate::StringMatchesRegex => {
             if shell.options.print_commands_and_arguments {

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -46,13 +46,13 @@ impl From<processes::ProcessWaitResult> for ExecutionResult {
 impl From<std::process::Output> for ExecutionResult {
     fn from(output: std::process::Output) -> ExecutionResult {
         if let Some(code) = output.status.code() {
-            #[allow(clippy::cast_sign_loss)]
+            #[expect(clippy::cast_sign_loss)]
             return Self::new((code & 0xFF) as u8);
         }
 
         #[cfg(unix)]
         if let Some(signal) = output.status.signal() {
-            #[allow(clippy::cast_sign_loss)]
+            #[expect(clippy::cast_sign_loss)]
             return Self::new((signal & 0xFF) as u8 + 128);
         }
 
@@ -88,7 +88,7 @@ impl ExecutionResult {
         // TODO: Decide how to sort this out in a platform-independent way.
         const SIGTSTP: std::os::raw::c_int = 20;
 
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         Self::new(128 + SIGTSTP as u8)
     }
 }
@@ -761,7 +761,7 @@ impl Execute for ast::FunctionDefinition {
 
 #[async_trait::async_trait]
 impl ExecuteInPipeline for ast::SimpleCommand {
-    #[allow(clippy::too_many_lines)] // TODO: refactor this function
+    #[expect(clippy::too_many_lines)] // TODO: refactor this function
     async fn execute_in_pipeline(
         &self,
         context: &mut PipelineExecutionContext,
@@ -1059,7 +1059,7 @@ async fn basic_expand_assignment_value(
     Ok(expanded)
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 async fn apply_assignment(
     assignment: &ast::Assignment,
     shell: &mut Shell,
@@ -1221,7 +1221,7 @@ fn setup_pipeline_redirection(
     Ok(())
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(crate) async fn setup_redirect<'a>(
     open_files: &'a mut OpenFiles,
     shell: &mut Shell,
@@ -1461,7 +1461,6 @@ fn setup_process_substitution(
     Ok((candidate_fd_num, target_file))
 }
 
-#[allow(unused_variables)]
 fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Error> {
     let (reader, mut writer) = sys::pipes::pipe()?;
 

--- a/brush-core/src/jobs.rs
+++ b/brush-core/src/jobs.rs
@@ -51,7 +51,7 @@ impl JobTask {
         }
     }
 
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::unwrap_in_result)]
     fn poll(&mut self) -> Option<Result<ExecutionResult, error::Error>> {
         match self {
             JobTask::External(process) => {
@@ -324,7 +324,7 @@ impl Job {
     }
 
     /// Polls whether the job has completed.
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     pub fn poll_done(
         &mut self,
     ) -> Result<Option<Result<ExecutionResult, error::Error>>, error::Error> {
@@ -374,7 +374,6 @@ impl Job {
     }
 
     /// Moves the job to execute in the background.
-    #[allow(clippy::unused_self)]
     pub fn move_to_background(&mut self) -> Result<(), error::Error> {
         if matches!(self.state, JobState::Stopped) {
             if let Some(pgid) = self.get_process_group_id() {

--- a/brush-core/src/openfiles.rs
+++ b/brush-core/src/openfiles.rs
@@ -61,7 +61,7 @@ impl OpenFile {
 
     /// Retrieves the raw file descriptor for the open file.
     #[cfg(unix)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn as_raw_fd(&self) -> Result<i32, error::Error> {
         match self {
             OpenFile::Stdin => Ok(std::io::stdin().as_raw_fd()),

--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -2,7 +2,7 @@ use crate::CreateOptions;
 
 /// Runtime changeable options for a shell instance.
 #[derive(Clone, Default)]
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 pub struct RuntimeOptions {
     //
     // Single-character options.

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -78,8 +78,8 @@ impl Pattern {
     /// * `working_dir` - The current working directory, used for relative paths.
     /// * `enable_extended_globbing` - Whether or not to enable extended globbing (extglob).
     /// * `path_filter` - Optionally provides a function that filters paths after expansion.
-    #[allow(clippy::too_many_lines)]
-    #[allow(clippy::unwrap_in_result)]
+    #[expect(clippy::too_many_lines)]
+    #[expect(clippy::unwrap_in_result)]
     pub(crate) fn expand<PF>(
         &self,
         working_dir: &Path,
@@ -474,7 +474,7 @@ fn compile_regex(regex_str: String) -> fancy_regex::Result<fancy_regex::Regex> {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic_in_result_fn)]
+#[expect(clippy::panic_in_result_fn)]
 mod tests {
     use super::*;
     use anyhow::Result;

--- a/brush-core/src/processes.rs
+++ b/brush-core/src/processes.rs
@@ -29,9 +29,7 @@ impl ChildProcess {
     }
 
     pub async fn wait(&mut self) -> Result<ProcessWaitResult, error::Error> {
-        #[allow(unused_mut)]
         let mut sigtstp = sys::signal::tstp_signal_listener()?;
-        #[allow(unused_mut)]
         let mut sigchld = sys::signal::chld_signal_listener()?;
 
         loop {

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -867,7 +867,6 @@ impl Shell {
     /// # Arguments
     ///
     /// * `required_glob_pattern` - The glob pattern to match against.
-    #[allow(clippy::manual_flatten)]
     pub(crate) fn find_executables_in_path(&self, required_glob_pattern: &str) -> Vec<PathBuf> {
         let is_executable = |path: &Path| path.executable();
 

--- a/brush-core/src/sys/fs.rs
+++ b/brush-core/src/sys/fs.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub(crate) use super::platform::fs::*;
 
 #[cfg(unix)]

--- a/brush-core/src/sys/unix/signal.rs
+++ b/brush-core/src/sys/unix/signal.rs
@@ -15,7 +15,6 @@ pub(crate) fn parse_os_signal_name(signal: &str) -> Result<traps::TrapSignal, er
 }
 
 pub(crate) fn continue_process(pid: sys::process::ProcessId) -> Result<(), error::Error> {
-    #[allow(clippy::cast_possible_wrap)]
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), nix::sys::signal::SIGCONT)
         .map_err(|_errno| error::Error::FailedToSendSignal)?;
     Ok(())
@@ -45,7 +44,6 @@ pub(crate) fn chld_signal_listener() -> Result<tokio::signal::unix::Signal, erro
     Ok(signal)
 }
 
-#[allow(unused)]
 pub(crate) use tokio::signal::ctrl_c as await_ctrl_c;
 
 pub(crate) fn mask_sigttou() -> Result<(), error::Error> {

--- a/brush-core/src/sys/unix/terminal.rs
+++ b/brush-core/src/sys/unix/terminal.rs
@@ -47,12 +47,12 @@ pub(crate) fn is_stdin_a_terminal() -> Result<bool, error::Error> {
     Ok(result)
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_parent_process_id() -> Option<sys::process::ProcessId> {
     Some(nix::unistd::getppid().as_raw())
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_process_group_id() -> Option<sys::process::ProcessId> {
     Some(nix::unistd::getpgrp().as_raw())
 }

--- a/brush-core/src/sys/unix/users.rs
+++ b/brush-core/src/sys/unix/users.rs
@@ -25,12 +25,12 @@ pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
     None
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_effective_uid() -> Result<u32, error::Error> {
     Ok(uzers::get_effective_uid())
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_effective_gid() -> Result<u32, error::Error> {
     Ok(uzers::get_effective_gid())
 }
@@ -40,14 +40,14 @@ pub(crate) fn get_current_username() -> Result<String, error::Error> {
     Ok(username.to_string_lossy().to_string())
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
     // TODO: implement this
     tracing::debug!("UNIMPLEMENTED: get_all_users");
     Ok(vec![])
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_groups() -> Result<Vec<String>, error::Error> {
     // TODO: implement this
     tracing::debug!("UNIMPLEMENTED: get_all_groups");

--- a/brush-core/src/sys/windows/users.rs
+++ b/brush-core/src/sys/windows/users.rs
@@ -31,13 +31,13 @@ pub(crate) fn get_current_username() -> Result<String, error::Error> {
     Ok(username)
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
     // TODO: implement some version of this for Windows
     Ok(vec![])
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_groups() -> Result<Vec<String>, error::Error> {
     // TODO: implement some version of this for Windows
     Ok(vec![])

--- a/brush-core/src/terminal.rs
+++ b/brush-core/src/terminal.rs
@@ -1,7 +1,7 @@
 use crate::{error, sys};
 
 /// Encapsulates the state of a controlled terminal.
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 pub struct TerminalControl {
     prev_fg_pid: Option<sys::process::ProcessId>,
 }

--- a/brush-core/src/traps.rs
+++ b/brush-core/src/traps.rs
@@ -28,7 +28,6 @@ impl Display for TrapSignal {
 
 impl TrapSignal {
     /// Returns all possible values of `TrapSignal`.
-    #[allow(unused_mut)]
     pub fn all_values() -> Vec<TrapSignal> {
         let mut signals = vec![TrapSignal::Debug, TrapSignal::Err, TrapSignal::Exit];
 

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -215,8 +215,8 @@ impl ShellVariable {
 
         if append {
             match (&self.value, &value) {
-                // If we're appending an array to a declared-but-unset variable (or appending anything to a declared-but-unset array),
-                // then fill it out first.
+                // If we're appending an array to a declared-but-unset variable (or appending
+                // anything to a declared-but-unset array), then fill it out first.
                 (ShellValue::Unset(_), ShellValueLiteral::Array(_))
                 | (
                     ShellValue::Unset(
@@ -226,8 +226,8 @@ impl ShellVariable {
                 ) => {
                     self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
                 }
-                // If we're trying to append an array to a string, we first promote the string to be an array
-                // with the string being present at index 0.
+                // If we're trying to append an array to a string, we first promote the string to be
+                // an array with the string being present at index 0.
                 (ShellValue::String(_), ShellValueLiteral::Array(_)) => {
                     self.convert_to_indexed_array()?;
                 }
@@ -289,9 +289,9 @@ impl ShellVariable {
                     ShellValueLiteral::Scalar(s),
                 ) => self.assign_at_index(String::from("0"), s, false),
 
-                // If we're updating an indexed array value with an array, then preserve the array type.
-                // We also default to using an indexed array if we are assigning an array to a previously
-                // string-holding variable.
+                // If we're updating an indexed array value with an array, then preserve the array
+                // type. We also default to using an indexed array if we are
+                // assigning an array to a previously string-holding variable.
                 (
                     ShellValue::IndexedArray(_)
                     | ShellValue::Unset(
@@ -305,7 +305,8 @@ impl ShellVariable {
                     Ok(())
                 }
 
-                // If we're updating an associative array value with an array, then preserve the array type.
+                // If we're updating an associative array value with an array, then preserve the
+                // array type.
                 (
                     ShellValue::AssociativeArray(_)
                     | ShellValue::Unset(ShellValueUnsetType::AssociativeArray),
@@ -334,8 +335,8 @@ impl ShellVariable {
     ///
     /// * `array_index` - The index at which to assign the value.
     /// * `value` - The value to assign to the variable at the given index.
-    /// * `append` - Whether or not to append the value to the preexisting value stored at the given index.
-    #[allow(clippy::needless_pass_by_value)]
+    /// * `append` - Whether or not to append the value to the preexisting value stored at the given
+    ///   index.
     pub fn assign_at_index(
         &mut self,
         array_index: String,
@@ -602,7 +603,7 @@ impl ShellValue {
         Ok(ShellValue::IndexedArray(values))
     }
 
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     fn update_indexed_array_from_literals(
         existing_values: &mut BTreeMap<u64, String>,
         literal_values: ArrayLiteral,
@@ -720,7 +721,7 @@ impl ShellValue {
     /// # Arguments
     ///
     /// * `index` - The index at which to retrieve the value.
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     pub fn get_at(&self, index: &str) -> Result<Option<Cow<'_, str>>, error::Error> {
         match self {
             ShellValue::Unset(_) => Ok(None),

--- a/brush-interactive/src/error.rs
+++ b/brush-interactive/src/error.rs
@@ -1,6 +1,5 @@
 /// Represents an error encountered while running or otherwise managing an interactive shell.
-#[allow(clippy::module_name_repetitions)]
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::module_name_repetitions)]
 #[derive(thiserror::Error, Debug)]
 pub enum ShellError {
     /// An error occurred with the embedded shell.

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use utf8_chars::BufReadCharsExt;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) enum TokenEndReason {
     /// End of input was reached.
@@ -475,7 +475,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
         self.next_token_until(None)
     }
 
-    #[allow(clippy::if_same_then_else)]
+    #[expect(clippy::if_same_then_else)]
     fn next_token_until(
         &mut self,
         terminating_char: Option<char>,
@@ -962,7 +962,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Iterator for Tokenizer<'a, R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.next_token() {
-            #[allow(clippy::manual_map)]
+            #[expect(clippy::manual_map)]
             Ok(result) => match result.token {
                 Some(_) => Some(Ok(result)),
                 None => None,

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -34,7 +34,7 @@ pub enum InputBackend {
        disable_help_flag = true,
        disable_version_flag = true,
        styles = brush_help_styles())]
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 pub struct CommandLineArgs {
     /// Display usage information.
     #[clap(long = "help", action = clap::ArgAction::HelpLong)]

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
         }
     };
 
-    #[allow(clippy::cast_lossless)]
+    #[expect(clippy::cast_lossless)]
     std::process::exit(exit_code as i32);
 }
 

--- a/brush-shell/src/productinfo.rs
+++ b/brush-shell/src/productinfo.rs
@@ -7,7 +7,7 @@ const PRODUCT_HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
 const PRODUCT_REPO: &str = env!("CARGO_PKG_REPOSITORY");
 
 /// The URI to display as the product's homepage.
-#[allow(clippy::const_is_empty)]
+#[expect(clippy::const_is_empty)]
 pub const PRODUCT_DISPLAY_URI: &str = if !PRODUCT_HOMEPAGE.is_empty() {
     PRODUCT_HOMEPAGE
 } else {

--- a/brush-shell/src/shell_factory.rs
+++ b/brush-shell/src/shell_factory.rs
@@ -10,15 +10,15 @@ pub(crate) trait ShellFactory {
 
 pub(crate) struct StubShell;
 
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 impl brush_interactive::InteractiveShell for StubShell {
-    #[allow(unreachable_code)]
+    #[expect(unreachable_code)]
     fn shell(&self) -> impl AsRef<brush_core::Shell> + Send {
         panic!("No interactive shell implementation available");
         self
     }
 
-    #[allow(unreachable_code)]
+    #[expect(unreachable_code)]
     fn shell_mut(&mut self) -> impl AsMut<brush_core::Shell> + Send {
         panic!("No interactive shell implementation available");
         self
@@ -36,14 +36,14 @@ impl brush_interactive::InteractiveShell for StubShell {
     }
 }
 
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 impl AsRef<brush_core::Shell> for StubShell {
     fn as_ref(&self) -> &brush_core::Shell {
         panic!("No interactive shell implementation available")
     }
 }
 
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 impl AsMut<brush_core::Shell> for StubShell {
     fn as_mut(&mut self) -> &mut brush_core::Shell {
         panic!("No interactive shell implementation available")
@@ -59,7 +59,6 @@ impl ShellFactory for RustylineShellFactory {
     #[cfg(not(any(windows, unix)))]
     type ShellType = StubShell;
 
-    #[allow(unused)]
     async fn create(
         &self,
         options: &brush_interactive::Options,
@@ -84,7 +83,7 @@ impl ShellFactory for BasicShellFactory {
     #[cfg(any(windows, unix))]
     type ShellType = StubShell;
 
-    #[allow(unused)]
+    #[expect(unused)]
     async fn create(
         &self,
         options: &brush_interactive::Options,

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -57,7 +57,7 @@ impl TestConfig {
         })
     }
 
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     pub fn for_sh_testing(options: &TestOptions) -> Result<Self> {
         // Skip rc file and profile for deterministic behavior across systems/distros.
         Ok(Self {
@@ -82,7 +82,7 @@ impl TestConfig {
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 async fn cli_integration_tests(options: TestOptions) -> Result<()> {
     let dir = env!("CARGO_MANIFEST_DIR");
 
@@ -350,7 +350,6 @@ struct TestCaseSet {
     pub source_dir: PathBuf,
 }
 
-#[allow(clippy::struct_field_names)]
 struct TestCaseSetResults {
     pub name: Option<String>,
     pub config_name: String,
@@ -504,7 +503,7 @@ impl TestCaseResult {
         self.write_details(std::io::stderr(), options)
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub fn write_details<W: std::io::Write>(
         &self,
         mut writer: W,
@@ -943,7 +942,7 @@ impl TestCase {
         test_cmd
     }
 
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     #[cfg(unix)]
     async fn run_command_with_pty(&self, cmd: std::process::Command) -> Result<RunResult> {
         use expectrl::Expect;
@@ -1026,7 +1025,7 @@ impl TestCase {
         }
     }
 
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     async fn run_command_with_stdin(&self, cmd: std::process::Command) -> Result<RunResult> {
         const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
 
@@ -1136,7 +1135,7 @@ impl ExitStatusComparison {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum StringComparison {
     Ignored {
         test_string: String,


### PR DESCRIPTION
`#[expect]` will complain if the indicated warning doesn't apply. This allows us to quickly notice as soon as an allowed warning no longer needs to be allowed.