### PR TITLE
fix: allow newlines in extended test exprs

### DIFF
--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -344,12 +344,12 @@ peg::parser! {
             }
 
         rule extended_test_command() -> ast::ExtendedTestExpr =
-            specific_word("[[") e:extended_test_expression() specific_word("]]") { e }
+            specific_word("[[") linebreak() e:extended_test_expression() linebreak() specific_word("]]") { e }
 
         rule extended_test_expression() -> ast::ExtendedTestExpr = precedence! {
-            left:(@) specific_operator("||") right:@ { ast::ExtendedTestExpr::Or(Box::from(left), Box::from(right)) }
+            left:(@) linebreak() specific_operator("||") linebreak() right:@ { ast::ExtendedTestExpr::Or(Box::from(left), Box::from(right)) }
             --
-            left:(@) specific_operator("&&") right:@ { ast::ExtendedTestExpr::And(Box::from(left), Box::from(right)) }
+            left:(@) linebreak() specific_operator("&&") linebreak() right:@ { ast::ExtendedTestExpr::And(Box::from(left), Box::from(right)) }
             --
             specific_word("!") e:@ { ast::ExtendedTestExpr::Not(Box::from(e)) }
             --

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -214,3 +214,11 @@ cases:
       check " "   && echo "2. Only space"
       check $'\t' && echo "3. Only space"
       check " a " && echo "4. Only space"
+
+  - name: "Newlines in test expression"
+    stdin: |
+      [[
+        "a" == "a"
+        &&
+        "b" == "b"
+      ]] && echo "Succeeded"


### PR DESCRIPTION
Newlines can appear right after the `[[` or right before the `]]`, as well as around `&&` and `||` operators.