### PR TITLE
feat: several fixes for bash-completion + tests

### DIFF
--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -19,28 +19,28 @@ pub(crate) struct CommonCompleteCommandArgs {
     actions: Vec<CompleteAction>,
 
     /// File glob pattern to be expanded to generate completions.
-    #[arg(short = 'G')]
+    #[arg(short = 'G', allow_hyphen_values = true)]
     glob_pattern: Option<String>,
 
     /// List of words that will be considered as completions.
-    #[arg(short = 'W')]
+    #[arg(short = 'W', allow_hyphen_values = true)]
     word_list: Option<String>,
 
     /// Name of a shell function to invoke to generate completions.
-    #[arg(short = 'F')]
+    #[arg(short = 'F', allow_hyphen_values = true)]
     function_name: Option<String>,
 
     /// Command to execute to generate completions.
-    #[arg(short = 'C')]
+    #[arg(short = 'C', allow_hyphen_values = true)]
     command: Option<String>,
 
-    #[arg(short = 'X')]
+    #[arg(short = 'X', allow_hyphen_values = true)]
     filter_pattern: Option<String>,
 
-    #[arg(short = 'P')]
+    #[arg(short = 'P', allow_hyphen_values = true)]
     prefix: Option<String>,
 
-    #[arg(short = 'S')]
+    #[arg(short = 'S', allow_hyphen_values = true)]
     suffix: Option<String>,
 
     /// Complete with valid aliases.
@@ -431,6 +431,7 @@ pub(crate) struct CompGenCommand {
     #[clap(flatten)]
     common_args: CommonCompleteCommandArgs,
 
+    #[clap(allow_hyphen_values = true)]
     word: Option<String>,
 }
 

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -103,9 +103,13 @@ pub enum Error {
     #[error("invalid pattern: '{0}'")]
     InvalidPattern(String),
 
-    /// An invalid regular expression was provided.
-    #[error("invalid regex: {0}")]
+    /// A regular expression error occurred
+    #[error("regex error: {0}")]
     RegexError(#[from] fancy_regex::Error),
+
+    /// An invalid regular expression was provided.
+    #[error("invalid regex: {0}; expression: '{1}'")]
+    InvalidRegexError(fancy_regex::Error, String),
 
     /// An I/O error occurred.
     #[error("i/o error: {0}")]

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -37,3 +37,4 @@ pub use error::Error;
 pub use interp::{ExecutionParameters, ExecutionResult};
 pub use shell::{CreateOptions, Shell};
 pub use terminal::TerminalControl;
+pub use variables::{ShellValue, ShellVariable};

--- a/brush-core/src/regex.rs
+++ b/brush-core/src/regex.rs
@@ -48,7 +48,7 @@ impl Regex {
             .collect();
 
         // TODO: Evaluate how compatible the `fancy_regex` crate is with POSIX EREs.
-        let re = fancy_regex::Regex::new(regex_pattern.as_str())?;
+        let re = compile_regex(regex_pattern)?;
 
         Ok(re.captures(value)?.map(|captures| {
             captures
@@ -56,6 +56,15 @@ impl Regex {
                 .map(|c| c.map(|m| m.as_str().to_owned()))
                 .collect()
         }))
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[cached::proc_macro::cached(size = 64, result = true)]
+pub(crate) fn compile_regex(regex_str: String) -> Result<fancy_regex::Regex, error::Error> {
+    match fancy_regex::Regex::new(regex_str.as_str()) {
+        Ok(re) => Ok(re),
+        Err(e) => Err(error::Error::InvalidRegexError(e, regex_str)),
     }
 }
 

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -409,7 +409,7 @@ impl Shell {
     /// * `source_info` - Information about the source of the script.
     /// * `args` - The arguments to pass to the script as positional parameters.
     /// * `params` - Execution parameters.
-    pub async fn source_file<F: Read, S: AsRef<str>>(
+    async fn source_file<F: Read, S: AsRef<str>>(
         &mut self,
         file: F,
         source_info: &brush_parser::SourceInfo,
@@ -950,7 +950,7 @@ impl Shell {
     /// # Arguments
     ///
     /// * `target_dir` - The path to set as the working directory.
-    pub(crate) fn set_working_dir(&mut self, target_dir: &Path) -> Result<(), error::Error> {
+    pub fn set_working_dir(&mut self, target_dir: &Path) -> Result<(), error::Error> {
         let abs_path = self.get_absolute_path(target_dir);
 
         match std::fs::metadata(&abs_path) {

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -1137,6 +1137,12 @@ impl From<&tokenizer::Token> for Word {
     }
 }
 
+impl From<String> for Word {
+    fn from(s: String) -> Word {
+        Word { value: s }
+    }
+}
+
 impl Word {
     /// Constructs a new `Word` from a given string.
     pub fn new(s: &str) -> Self {

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -15,4 +15,4 @@ mod tokenizer;
 
 pub use error::{ParseError, TestCommandParseError, WordParseError};
 pub use parser::{parse_tokens, Parser, ParserOptions, SourceInfo};
-pub use tokenizer::{tokenize_str, Token, TokenLocation};
+pub use tokenizer::{tokenize_str, SourcePosition, Token, TokenLocation};

--- a/brush-parser/src/pattern.rs
+++ b/brush-parser/src/pattern.rs
@@ -79,7 +79,7 @@ peg::parser! {
             range:$([_] "-" [_]) { range.to_owned() }
 
         rule char_list() -> String =
-            chars:$([c if c != ']']+) { chars.to_owned() }
+            chars:$([c if c != ']']+) { escape_char_class_char_list(chars) }
 
         rule wildcard() -> String =
             "?" { String::from(".") } /
@@ -144,6 +144,10 @@ pub fn regex_char_needs_escaping(c: char) -> bool {
         c,
         '[' | ']' | '(' | ')' | '{' | '}' | '*' | '?' | '.' | '+' | '^' | '$' | '|' | '\\'
     )
+}
+
+fn escape_char_class_char_list(s: &str) -> String {
+    s.replace('[', r"\[")
 }
 
 #[cfg(test)]

--- a/brush-shell/tests/cases/arrays.yaml
+++ b/brush-shell/tests/cases/arrays.yaml
@@ -27,6 +27,16 @@ cases:
       echo "var[*]: ${var[*]}"
       declare -p var
 
+  - name: "Define array with expansion"
+    stdin: |
+      body='a b'
+
+      var=($body)
+      declare -p var
+
+      declare -a var2=($body)
+      declare -p var2
+
   - name: "Arrays with empty values"
     stdin: |
       var1=(a "" c)

--- a/brush-shell/tests/cases/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/builtins/compgen.yaml
@@ -56,3 +56,7 @@ cases:
       compgen -W "one two three" -- t | sort
       echo "2. compgen -W with expansion"
       myvar=value compgen -W '${myvar}'
+
+  - name: "compgen -W with options"
+    stdin: |
+      compgen -W '--abc --def' -- '--ab'

--- a/brush-shell/tests/cases/builtins/printf.yaml
+++ b/brush-shell/tests/cases/builtins/printf.yaml
@@ -18,3 +18,7 @@ cases:
       declare -a myarray=()
       printf -v 'myarray[5]' "%s, %s" "Hello" "world"
       declare | grep myarray
+
+  - name: "printf with -v as a format arg"
+    stdin: |
+      printf "%s\n" "-v"

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -1,0 +1,143 @@
+// For now, only compile this for Linux.
+#![cfg(target_os = "linux")]
+#![allow(clippy::panic_in_result_fn)]
+
+use anyhow::Result;
+use assert_fs::prelude::*;
+use std::path::Path;
+
+struct TestShellWithBashCompletion {
+    shell: brush_core::Shell,
+    temp_dir: assert_fs::TempDir,
+}
+
+const BASH_COMPLETION_SCRIPT: &str = "/usr/share/bash-completion/bash_completion";
+
+impl TestShellWithBashCompletion {
+    async fn new() -> Result<Self> {
+        let temp_dir = assert_fs::TempDir::new()?;
+
+        let create_options = brush_core::CreateOptions {
+            no_profile: true,
+            no_rc: true,
+            ..Default::default()
+        };
+
+        let mut shell = brush_core::Shell::new(&create_options).await?;
+
+        let exec_params = shell.default_exec_params();
+        let source_result = shell
+            .source::<String>(Path::new(BASH_COMPLETION_SCRIPT), &[], &exec_params)
+            .await?;
+
+        if source_result.exit_code != 0 {
+            return Err(anyhow::anyhow!("failed to source bash completion script"));
+        }
+
+        shell.set_working_dir(temp_dir.path())?;
+
+        Ok(Self { shell, temp_dir })
+    }
+
+    pub async fn complete(&mut self, line: &str, pos: usize) -> Result<Vec<String>> {
+        let completions = self.shell.get_completions(line, pos).await?;
+        Ok(completions.candidates.into_iter().collect())
+    }
+
+    pub fn set_var(&mut self, name: &str, value: &str) -> Result<()> {
+        self.shell
+            .env
+            .set_global(name, brush_core::ShellVariable::new(value.into()))?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn complete_relative_file_path() -> Result<()> {
+    let mut test_shell = TestShellWithBashCompletion::new().await?;
+
+    // Create file and dir.
+    test_shell.temp_dir.child("item1").touch()?;
+    test_shell.temp_dir.child("item2").create_dir_all()?;
+
+    // Complete; expect to see the two files.
+    let input = "ls item";
+    let results = test_shell.complete(input, input.len()).await?;
+
+    assert_eq!(results, ["item1", "item2"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn complete_relative_dir_path() -> Result<()> {
+    let mut test_shell = TestShellWithBashCompletion::new().await?;
+
+    // Create file and dir.
+    test_shell.temp_dir.child("item1").touch()?;
+    test_shell.temp_dir.child("item2").create_dir_all()?;
+
+    // Complete; expect to see just the dir.
+    let input = "cd item";
+    let results = test_shell.complete(input, input.len()).await?;
+
+    assert_eq!(results, ["item2"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn complete_variable_names() -> Result<()> {
+    let mut test_shell = TestShellWithBashCompletion::new().await?;
+
+    // Set a few vars.
+    test_shell.set_var("TESTVAR1", "")?;
+    test_shell.set_var("TESTVAR2", "")?;
+
+    // Complete.
+    let input = "echo $TESTVAR";
+    let results = test_shell.complete(input, input.len()).await?;
+    assert_eq!(results, ["$TESTVAR1", "$TESTVAR2"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn complete_variable_names_with_braces() -> Result<()> {
+    let mut test_shell = TestShellWithBashCompletion::new().await?;
+
+    // Set a few vars.
+    test_shell.set_var("TESTVAR1", "")?;
+    test_shell.set_var("TESTVAR2", "")?;
+
+    // Complete.
+    let input = "echo ${TESTVAR";
+    let results = test_shell.complete(input, input.len()).await?;
+    assert_eq!(results, ["${TESTVAR1}", "${TESTVAR2}"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn complete_help_topic() -> Result<()> {
+    let mut test_shell = TestShellWithBashCompletion::new().await?;
+
+    // Complete.
+    let input = "help expor";
+    let results = test_shell.complete(input, input.len()).await?;
+    assert_eq!(results, ["export"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn complete_command_option() -> Result<()> {
+    let mut test_shell = TestShellWithBashCompletion::new().await?;
+
+    // Complete.
+    let input = "ls --hel";
+    let results = test_shell.complete(input, input.len()).await?;
+    assert_eq!(results, ["--help"]);
+
+    Ok(())
+}


### PR DESCRIPTION
* Correct `compgen` handling of positional args that start with a hyphen
* Correct `printf` handling of `-v` in a format argument.
* Fix bug with stale `REPLY` value in `read` of an empty line
* Correct handling of Ctrl+D in `read`
* Fix missing terminal setting restoration on Ctrl+C in `read`
* Support completing a line that fails tokenization
* Fix use of `declare` to assign an array from the split expansion of a variable
* Fix escaping of `[` char in a character class in a pattern
* Clean up skipping logic in compat tests harness
* Add some basic tests for completion via `brushinfo complete`