### PR TITLE
fix: fixes for short-circuit precedence + parameter expr replacement

### DIFF
--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -176,6 +176,10 @@ pub enum Error {
     /// Printf failure
     #[error("printf failure: {0}")]
     PrintfFailure(i32),
+
+    /// Interrupted
+    #[error("interrupted")]
+    Interrupted,
 }
 
 /// Convenience function for returning an error for unimplemented functionality.

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1005,6 +1005,9 @@ impl<'a> WordExpander<'a> {
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
                 let expanded_pattern = self.basic_expand_to_str(&pattern).await?;
+
+                // If no replacement was provided, then we replace with an empty string.
+                let replacement = replacement.unwrap_or(String::new());
                 let expanded_replacement = self.basic_expand_to_str(&replacement).await?;
 
                 let regex = patterns::pattern_to_regex(

--- a/brush-interactive/src/completion.rs
+++ b/brush-interactive/src/completion.rs
@@ -16,14 +16,13 @@ pub(crate) async fn complete_async(
     tokio::pin!(completion_future);
 
     // Wait for the completions to come back or interruption, whichever happens first.
-    let result = loop {
-        tokio::select! {
-            result = &mut completion_future => {
-                break result;
-            }
-            _ = tokio::signal::ctrl_c() => {
-            },
+    let result = tokio::select! {
+        result = &mut completion_future => {
+            result
         }
+        _ = tokio::signal::ctrl_c() => {
+            Err(brush_core::Error::Interrupted)
+        },
     };
 
     let mut completions = result.unwrap_or_else(|_| brush_core::completion::Completions {

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -304,7 +304,7 @@ pub enum ParameterExpr {
         /// Pattern to match.
         pattern: String,
         /// Replacement string.
-        replacement: String,
+        replacement: Option<String>,
         /// Kind of match to perform.
         match_kind: SubstringMatchKind,
     },
@@ -593,16 +593,16 @@ peg::parser! {
             indirect:parameter_indirection() parameter:parameter() "@" op:non_posix_parameter_transformation_op() {
                 ParameterExpr::Transform { parameter, indirect, op }
             } /
-            indirect:parameter_indirection() parameter:parameter() "/#" pattern:parameter_search_pattern() "/" replacement:parameter_replacement_str() {
+            indirect:parameter_indirection() parameter:parameter() "/#" pattern:parameter_search_pattern() replacement:parameter_replacement_str()? {
                 ParameterExpr::ReplaceSubstring { parameter, indirect, pattern, replacement, match_kind: SubstringMatchKind::Prefix }
             } /
-            indirect:parameter_indirection() parameter:parameter() "/%" pattern:parameter_search_pattern() "/" replacement:parameter_replacement_str() {
+            indirect:parameter_indirection() parameter:parameter() "/%" pattern:parameter_search_pattern() replacement:parameter_replacement_str()? {
                 ParameterExpr::ReplaceSubstring { parameter, indirect, pattern, replacement, match_kind: SubstringMatchKind::Suffix }
             } /
-            indirect:parameter_indirection() parameter:parameter() "//" pattern:parameter_search_pattern() "/" replacement:parameter_replacement_str() {
+            indirect:parameter_indirection() parameter:parameter() "//" pattern:parameter_search_pattern() replacement:parameter_replacement_str()? {
                 ParameterExpr::ReplaceSubstring { parameter, indirect, pattern, replacement, match_kind: SubstringMatchKind::Anywhere }
             } /
-            indirect:parameter_indirection() parameter:parameter() "/" pattern:parameter_search_pattern() "/" replacement:parameter_replacement_str() {
+            indirect:parameter_indirection() parameter:parameter() "/" pattern:parameter_search_pattern() replacement:parameter_replacement_str()? {
                 ParameterExpr::ReplaceSubstring { parameter, indirect, pattern, replacement, match_kind: SubstringMatchKind::FirstOccurrence }
             } /
             indirect:parameter_indirection() parameter:parameter() "^^" pattern:parameter_expression_word()? {
@@ -697,7 +697,7 @@ peg::parser! {
             s:$(arithmetic_word(<[':' | '}']>)) { ast::UnexpandedArithmeticExpr { value: s.to_owned() } }
 
         rule parameter_replacement_str() -> String =
-            s:$(word(<['}' | '/']>)) { s.to_owned() }
+            "/" s:$(word(<['}' | '/']>)) { s.to_owned() }
 
         rule parameter_search_pattern() -> String =
             s:$(word(<['}' | '/']>)) { s.to_owned() }

--- a/brush-shell/tests/cases/and_or.yaml
+++ b/brush-shell/tests/cases/and_or.yaml
@@ -14,3 +14,9 @@ cases:
     stdin: |
       false || false || false || echo "Got to the end"
       echo "1" && echo "2" && echo "3" && echo "4"
+
+  - name: "Mixed chains"
+    stdin: |
+      false && true  || echo "1. Got to the end"
+      false && false || echo "2. Got to the end"
+      true  && false || echo "3. Got to the end"

--- a/brush-shell/tests/cases/compound_cmds/for.yaml
+++ b/brush-shell/tests/cases/compound_cmds/for.yaml
@@ -15,6 +15,33 @@ cases:
         break
       done
 
+  - name: "Break 1 in nested for loops"
+    stdin: |
+      for f in 1 2 3; do
+        for g in a b c; do
+          echo "f=$f g=$g"
+          break 1
+        done
+      done
+
+  - name: "Break 2 in nested for loops"
+    stdin: |
+      for f in 1 2 3; do
+        for g in a b c; do
+          echo "f=$f g=$g"
+          break 2
+        done
+      done
+
+  - name: "Break out of nested for/while loops"
+    stdin: |
+      for f in 1 2 3; do
+        while true; do
+          echo "f=$f"
+          break 2
+        done
+      done
+
   - name: "Continue in for loop"
     stdin: |
       for f in 1 2 3; do

--- a/brush-shell/tests/cases/compound_cmds/while.yaml
+++ b/brush-shell/tests/cases/compound_cmds/while.yaml
@@ -11,6 +11,17 @@ cases:
         break
       done
 
+  - name: "break 2 in nested loops"
+    stdin: |
+      while false; do
+        echo 'Starting inner loop'
+        while true; do
+          echo 'In loop'
+          break 2
+        done
+        echo 'Finished inner loop'
+      done
+
   - name: "Arithmetic in while loop"
     stdin: |
       i=5

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -124,6 +124,13 @@ cases:
       [[ "abc" != a* ]] && echo "2. Fail"
       [[ a* != "abc" ]] && echo "3. Pass"
 
+  - name: "Binary string matching with expansion"
+    known_failure: true
+    stdin: |
+      exclude="0123456789"
+      [[ "clue" == +([$exclude]) ]] && echo "1. Fail"
+      [[ "8675309" == +([$exclude]) ]] && echo "2. Pass"
+
   - name: "Quoted pattern binary string matching"
     stdin: |
       [[ "abc" == "a*" ]] && echo "1. Matches"

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -617,6 +617,11 @@ cases:
       echo "\${arr[@]//world/WORLD}: ${arr[@]//world/WORLD}"
       echo "\${arr[*]//world/WORLD}: ${arr[*]//world/WORLD}"
 
+  - name: "Global substring removal"
+    stdin: |
+      var="That is not all"
+      echo "\${var//not }: ${var//not}"
+
   - name: "Substring from offset"
     stdin: |
       var="Hello, world!"


### PR DESCRIPTION
* Correct short-circuiting of `&&` / `||` in mixed chains
* Enable `${var//pattern}` without a specified replacement
* Enable `break` to be used in an and-or list
* Add tests for corrected functionality