### PR TITLE
fix: workarounds for edge word parsing cases

### DIFF
--- a/brush-interactive/src/reedline/completer.rs
+++ b/brush-interactive/src/reedline/completer.rs
@@ -37,7 +37,7 @@ impl ReedlineCompleter {
         insertion_index: usize,
         delete_count: usize,
     ) -> reedline::Suggestion {
-        let mut style = nu_ansi_term::Style::new().dimmed();
+        let mut style = nu_ansi_term::Style::new();
         if candidate.ends_with(std::path::MAIN_SEPARATOR) {
             style = style.fg(nu_ansi_term::Color::Green);
         }

--- a/brush-interactive/src/reedline/reedline_shell.rs
+++ b/brush-interactive/src/reedline/reedline_shell.rs
@@ -1,3 +1,4 @@
+use nu_ansi_term::Color;
 use reedline::MenuBuilder;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -45,7 +46,9 @@ impl ReedlineShell {
         let completion_menu = Box::new(
             reedline::ColumnarMenu::default()
                 .with_name(COMPLETION_MENU_NAME)
-                .with_marker(""),
+                .with_marker("")
+                .with_selected_text_style(Color::Blue.bold().reverse())
+                .with_selected_match_text_style(Color::Blue.bold().reverse()),
         );
 
         // Set up key bindings.
@@ -54,11 +57,7 @@ impl ReedlineShell {
         // Set up default history-based hinter.
         let mut hinter = reedline::DefaultHinter::default();
         if !options.disable_color {
-            hinter = hinter.with_style(
-                nu_ansi_term::Style::new()
-                    .italic()
-                    .fg(nu_ansi_term::Color::DarkGray),
-            );
+            hinter = hinter.with_style(nu_ansi_term::Style::new().italic().fg(Color::DarkGray));
         }
 
         // Instantiate reedline with some defaults and hand it ownership of

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -125,7 +125,6 @@ cases:
       [[ a* != "abc" ]] && echo "3. Pass"
 
   - name: "Binary string matching with expansion"
-    known_failure: true
     stdin: |
       exclude="0123456789"
       [[ "clue" == +([$exclude]) ]] && echo "1. Fail"

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -56,6 +56,11 @@ cases:
       echo "$(var="updated"; echo ${var})"
       echo "var=${var}"
 
+  - name: "Command substitution with embedded parens"
+    stdin: |
+      x=$(echo foo | (wc -l; echo hi))
+      echo "\$x: $x"
+
   - name: "Backtick command substitution"
     stdin: |
       echo `echo hi`


### PR DESCRIPTION
* Fixes 'Binary string matching with expansion' test case
* Adds + fixes 'Command substitution with embedded parens' test case