### PR TITLE
chore: where possible replace `async-trait` with native async trait support in 1.75+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,6 @@ version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-recursion",
- "async-trait",
  "brush-parser",
  "cached",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "async-trait",
  "brush-parser",
  "cached",
  "cfg-if",

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [dependencies]
 async-recursion = "1.1.0"
-async-trait = "0.1.83"
 brush-parser = { version = "^0.2.8", path = "../brush-parser" }
 cached = "0.53.0"
 cfg-if = "1.0.0"

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 async-recursion = "1.1.0"
+async-trait = "0.1.83"
 brush-parser = { version = "^0.2.8", path = "../brush-parser" }
 cached = "0.53.0"
 cfg-if = "1.0.0"

--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use crate::{env, expansion, variables, Shell};
 use brush_parser::ast;
+use futures::future::{BoxFuture, FutureExt};
 
 /// Represents an error that occurs during evaluation of an arithmetic expression.
 #[derive(Debug, thiserror::Error)]
@@ -40,7 +41,7 @@ pub enum EvalError {
 }
 
 /// Trait implemented by arithmetic expressions that can be evaluated.
-#[async_trait::async_trait]
+
 pub trait ExpandAndEvaluate {
     /// Evaluate the given expression, returning the resulting numeric value.
     ///
@@ -51,7 +52,6 @@ pub trait ExpandAndEvaluate {
     async fn eval(&self, shell: &mut Shell, trace_if_needed: bool) -> Result<i64, EvalError>;
 }
 
-#[async_trait::async_trait]
 impl ExpandAndEvaluate for ast::UnexpandedArithmeticExpr {
     async fn eval(&self, shell: &mut Shell, trace_if_needed: bool) -> Result<i64, EvalError> {
         // Per documentation, first shell-expand it.
@@ -76,58 +76,60 @@ impl ExpandAndEvaluate for ast::UnexpandedArithmeticExpr {
 }
 
 /// Trait implemented by evaluatable arithmetic expressions.
-#[async_trait::async_trait]
+
 pub trait Evaluatable {
     /// Evaluate the given arithmetic expression, returning the resulting numeric value.
     ///
     /// # Arguments
     ///
     /// * `shell` - The shell to use for evaluation.
-    async fn eval(&self, shell: &mut Shell) -> Result<i64, EvalError>;
+    fn eval<'a>(&'a self, shell: &'a mut Shell) -> BoxFuture<'a, Result<i64, EvalError>>;
 }
 
-#[async_trait::async_trait]
 impl Evaluatable for ast::ArithmeticExpr {
-    async fn eval(&self, shell: &mut Shell) -> Result<i64, EvalError> {
-        let value = match self {
-            ast::ArithmeticExpr::Literal(l) => *l,
-            ast::ArithmeticExpr::Reference(lvalue) => deref_lvalue(shell, lvalue).await?,
-            ast::ArithmeticExpr::UnaryOp(op, operand) => {
-                apply_unary_op(shell, *op, operand).await?
-            }
-            ast::ArithmeticExpr::BinaryOp(op, left, right) => {
-                apply_binary_op(shell, *op, left, right).await?
-            }
-            ast::ArithmeticExpr::Conditional(condition, then_expr, else_expr) => {
-                let conditional_eval = condition.eval(shell).await?;
-
-                // Ensure we only evaluate the branch indicated by the condition.
-                if conditional_eval != 0 {
-                    then_expr.eval(shell).await?
-                } else {
-                    else_expr.eval(shell).await?
+    fn eval<'a>(&'a self, shell: &'a mut Shell) -> BoxFuture<'a, Result<i64, EvalError>> {
+        async move {
+            let value = match self {
+                ast::ArithmeticExpr::Literal(l) => *l,
+                ast::ArithmeticExpr::Reference(lvalue) => deref_lvalue(shell, lvalue).await?,
+                ast::ArithmeticExpr::UnaryOp(op, operand) => {
+                    apply_unary_op(shell, *op, operand).await?
                 }
-            }
-            ast::ArithmeticExpr::Assignment(lvalue, expr) => {
-                let expr_eval = expr.eval(shell).await?;
-                assign(shell, lvalue, expr_eval).await?
-            }
-            ast::ArithmeticExpr::UnaryAssignment(op, lvalue) => {
-                apply_unary_assignment_op(shell, lvalue, *op).await?
-            }
-            ast::ArithmeticExpr::BinaryAssignment(op, lvalue, operand) => {
-                let value = apply_binary_op(
-                    shell,
-                    *op,
-                    &ast::ArithmeticExpr::Reference(lvalue.clone()),
-                    operand,
-                )
-                .await?;
-                assign(shell, lvalue, value).await?
-            }
-        };
+                ast::ArithmeticExpr::BinaryOp(op, left, right) => {
+                    apply_binary_op(shell, *op, left, right).await?
+                }
+                ast::ArithmeticExpr::Conditional(condition, then_expr, else_expr) => {
+                    let conditional_eval = condition.eval(shell).await?;
 
-        Ok(value)
+                    // Ensure we only evaluate the branch indicated by the condition.
+                    if conditional_eval != 0 {
+                        then_expr.eval(shell).await?
+                    } else {
+                        else_expr.eval(shell).await?
+                    }
+                }
+                ast::ArithmeticExpr::Assignment(lvalue, expr) => {
+                    let expr_eval = expr.eval(shell).await?;
+                    assign(shell, lvalue, expr_eval).await?
+                }
+                ast::ArithmeticExpr::UnaryAssignment(op, lvalue) => {
+                    apply_unary_assignment_op(shell, lvalue, *op).await?
+                }
+                ast::ArithmeticExpr::BinaryAssignment(op, lvalue, operand) => {
+                    let value = apply_binary_op(
+                        shell,
+                        *op,
+                        &ast::ArithmeticExpr::Reference(lvalue.clone()),
+                        operand,
+                    )
+                    .await?;
+                    assign(shell, lvalue, value).await?
+                }
+            };
+
+            Ok(value)
+        }
+        .boxed()
     }
 }
 

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -208,6 +208,7 @@ pub trait Command: Parser {
     /// # Arguments
     ///
     /// * `context` - The context in which the command is being executed.
+    // NOTE: we use desugared async here because we need a Send marker
     fn execute(
         &self,
         context: commands::ExecutionContext<'_>,

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -170,7 +170,7 @@ pub type CommandExecuteFunc = fn(
 pub type CommandContentFunc = fn(&str, ContentType) -> Result<String, error::Error>;
 
 /// Trait implemented by built-in shell commands.
-#[async_trait::async_trait]
+
 pub trait Command: Parser {
     /// Instantiates the built-in command with the given arguments.
     ///
@@ -208,10 +208,10 @@ pub trait Command: Parser {
     /// # Arguments
     ///
     /// * `context` - The context in which the command is being executed.
-    async fn execute(
+    fn execute(
         &self,
         context: commands::ExecutionContext<'_>,
-    ) -> Result<ExitCode, error::Error>;
+    ) -> impl std::future::Future<Output = Result<ExitCode, error::Error>> + std::marker::Send;
 
     /// Returns the textual help content associated with the command.
     ///
@@ -236,7 +236,7 @@ pub trait Command: Parser {
 
 /// Trait implemented by built-in shell commands that take specially handled declarations
 /// as arguments.
-#[async_trait::async_trait]
+
 pub trait DeclarationCommand: Command {
     /// Stores the declarations within the command instance.
     ///

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -396,8 +396,7 @@ fn brush_help_styles() -> clap::builder::Styles {
 /// # Returns
 ///
 /// * a parsed struct T from [`clap::Parser::parse_from`]
-/// * the remain iterator `args` with `--` and the rest arguments if they present
-///   othervise None
+/// * the remain iterator `args` with `--` and the rest arguments if they present othervise None
 ///
 /// # Examples
 /// ```
@@ -421,8 +420,8 @@ where
     S: Into<std::ffi::OsString> + Clone + PartialEq<&'static str>,
 {
     let mut args = args.into_iter();
-    // the best way to save `--` is to get it out with a side effect while `clap` iterates over the args
-    // this way we can be 100% sure that we have '--' and the remaining args
+    // the best way to save `--` is to get it out with a side effect while `clap` iterates over the
+    // args this way we can be 100% sure that we have '--' and the remaining args
     // and we will iterate only once
     let mut hyphen = None;
     let args_before_hyphen = args.by_ref().take_while(|a| {
@@ -438,7 +437,8 @@ where
 }
 
 /// Similar to [`parse_known`] but with [`clap::Parser::try_parse_from`]
-/// This function is used to parse arguments in builtins such as [`crate::builtins::echo::EchoCommand`]
+/// This function is used to parse arguments in builtins such as
+/// [`crate::builtins::echo::EchoCommand`]
 pub fn try_parse_known<T: Parser>(
     args: impl IntoIterator<Item = String>,
 ) -> Result<(T, Option<impl Iterator<Item = String>>), clap::Error> {

--- a/brush-core/src/builtins/alias.rs
+++ b/brush-core/src/builtins/alias.rs
@@ -15,7 +15,7 @@ pub(crate) struct AliasCommand {
     aliases: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for AliasCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/alias.rs
+++ b/brush-core/src/builtins/alias.rs
@@ -15,7 +15,6 @@ pub(crate) struct AliasCommand {
     aliases: Vec<String>,
 }
 
-
 impl builtins::Command for AliasCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/bg.rs
+++ b/brush-core/src/builtins/bg.rs
@@ -10,7 +10,6 @@ pub(crate) struct BgCommand {
     job_specs: Vec<String>,
 }
 
-
 impl builtins::Command for BgCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/bg.rs
+++ b/brush-core/src/builtins/bg.rs
@@ -10,7 +10,7 @@ pub(crate) struct BgCommand {
     job_specs: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for BgCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/break_.rs
+++ b/brush-core/src/builtins/break_.rs
@@ -10,7 +10,6 @@ pub(crate) struct BreakCommand {
     which_loop: i8,
 }
 
-
 impl builtins::Command for BreakCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/break_.rs
+++ b/brush-core/src/builtins/break_.rs
@@ -10,7 +10,7 @@ pub(crate) struct BreakCommand {
     which_loop: i8,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for BreakCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/brushinfo.rs
+++ b/brush-core/src/builtins/brushinfo.rs
@@ -53,7 +53,6 @@ enum CompleteCommand {
     },
 }
 
-
 impl builtins::Command for BrushInfoCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/brushinfo.rs
+++ b/brush-core/src/builtins/brushinfo.rs
@@ -53,7 +53,7 @@ enum CompleteCommand {
     },
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for BrushInfoCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/builtin_.rs
+++ b/brush-core/src/builtins/builtin_.rs
@@ -14,7 +14,6 @@ pub(crate) struct BuiltinCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for BuiltinCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/builtin_.rs
+++ b/brush-core/src/builtins/builtin_.rs
@@ -14,7 +14,7 @@ pub(crate) struct BuiltinCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for BuiltinCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/cd.rs
+++ b/brush-core/src/builtins/cd.rs
@@ -28,7 +28,7 @@ pub(crate) struct CdCommand {
     target_dir: Option<PathBuf>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for CdCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/cd.rs
+++ b/brush-core/src/builtins/cd.rs
@@ -28,7 +28,6 @@ pub(crate) struct CdCommand {
     target_dir: Option<PathBuf>,
 }
 
-
 impl builtins::Command for CdCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/colon.rs
+++ b/brush-core/src/builtins/colon.rs
@@ -10,7 +10,6 @@ pub(crate) struct ColonCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for ColonCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/colon.rs
+++ b/brush-core/src/builtins/colon.rs
@@ -10,7 +10,7 @@ pub(crate) struct ColonCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ColonCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/command.rs
+++ b/brush-core/src/builtins/command.rs
@@ -26,7 +26,7 @@ pub(crate) struct CommandCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for CommandCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/command.rs
+++ b/brush-core/src/builtins/command.rs
@@ -26,7 +26,6 @@ pub(crate) struct CommandCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for CommandCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -210,7 +210,6 @@ pub(crate) struct CompleteCommand {
     names: Vec<String>,
 }
 
-
 impl builtins::Command for CompleteCommand {
     async fn execute(
         &self,
@@ -435,7 +434,6 @@ pub(crate) struct CompGenCommand {
     word: Option<String>,
 }
 
-
 impl builtins::Command for CompGenCommand {
     async fn execute(
         &self,
@@ -513,7 +511,6 @@ pub(crate) struct CompOptCommand {
     /// If specified, scopes updates to completions of the named commands.
     names: Vec<String>,
 }
-
 
 impl builtins::Command for CompOptCommand {
     async fn execute(

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -210,7 +210,7 @@ pub(crate) struct CompleteCommand {
     names: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for CompleteCommand {
     async fn execute(
         &self,
@@ -435,7 +435,7 @@ pub(crate) struct CompGenCommand {
     word: Option<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for CompGenCommand {
     async fn execute(
         &self,
@@ -514,7 +514,7 @@ pub(crate) struct CompOptCommand {
     names: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for CompOptCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/continue_.rs
+++ b/brush-core/src/builtins/continue_.rs
@@ -10,7 +10,7 @@ pub(crate) struct ContinueCommand {
     which_loop: i8,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ContinueCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/continue_.rs
+++ b/brush-core/src/builtins/continue_.rs
@@ -10,7 +10,6 @@ pub(crate) struct ContinueCommand {
     which_loop: i8,
 }
 
-
 impl builtins::Command for ContinueCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -110,7 +110,6 @@ impl builtins::DeclarationCommand for DeclareCommand {
 }
 
 #[allow(clippy::too_many_lines)]
-
 impl builtins::Command for DeclareCommand {
     fn takes_plus_options() -> bool {
         true

--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -110,7 +110,7 @@ impl builtins::DeclarationCommand for DeclareCommand {
 }
 
 #[allow(clippy::too_many_lines)]
-#[async_trait::async_trait]
+
 impl builtins::Command for DeclareCommand {
     fn takes_plus_options() -> bool {
         true

--- a/brush-core/src/builtins/dirs.rs
+++ b/brush-core/src/builtins/dirs.rs
@@ -25,7 +25,6 @@ pub(crate) struct DirsCommand {
     // TODO: implement +N and -N
 }
 
-
 impl builtins::Command for DirsCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/dirs.rs
+++ b/brush-core/src/builtins/dirs.rs
@@ -25,7 +25,7 @@ pub(crate) struct DirsCommand {
     // TODO: implement +N and -N
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for DirsCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/dot.rs
+++ b/brush-core/src/builtins/dot.rs
@@ -15,7 +15,7 @@ pub(crate) struct DotCommand {
     pub script_args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for DotCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/dot.rs
+++ b/brush-core/src/builtins/dot.rs
@@ -15,7 +15,6 @@ pub(crate) struct DotCommand {
     pub script_args: Vec<String>,
 }
 
-
 impl builtins::Command for DotCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/echo.rs
+++ b/brush-core/src/builtins/echo.rs
@@ -25,8 +25,8 @@ pub(crate) struct EchoCommand {
 }
 
 impl builtins::Command for EchoCommand {
-    /// Override the default [builtins::Command::new] function to handle clap's limitation related
-    /// to `--`. See [crate::builtins::parse_known] for more information
+    /// Override the default [`builtins::Command::new`] function to handle clap's limitation related
+    /// to `--`. See [`builtins::parse_known`] for more information
     /// TODO: we can safely remove this after the issue is resolved
     fn new<I>(args: I) -> Result<Self, clap::Error>
     where
@@ -74,6 +74,6 @@ impl builtins::Command for EchoCommand {
         write!(context.stdout(), "{s}")?;
         context.stdout().flush()?;
 
-        return Ok(builtins::ExitCode::Success);
+        Ok(builtins::ExitCode::Success)
     }
 }

--- a/brush-core/src/builtins/echo.rs
+++ b/brush-core/src/builtins/echo.rs
@@ -24,10 +24,9 @@ pub(crate) struct EchoCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for EchoCommand {
-    /// Override the default [builtins::Command::new] function to handle clap's limitation related to `--`.
-    /// See [crate::builtins::parse_known] for more information
+    /// Override the default [builtins::Command::new] function to handle clap's limitation related
+    /// to `--`. See [crate::builtins::parse_known] for more information
     /// TODO: we can safely remove this after the issue is resolved
     fn new<I>(args: I) -> Result<Self, clap::Error>
     where

--- a/brush-core/src/builtins/echo.rs
+++ b/brush-core/src/builtins/echo.rs
@@ -24,7 +24,7 @@ pub(crate) struct EchoCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for EchoCommand {
     /// Override the default [builtins::Command::new] function to handle clap's limitation related to `--`.
     /// See [crate::builtins::parse_known] for more information

--- a/brush-core/src/builtins/enable.rs
+++ b/brush-core/src/builtins/enable.rs
@@ -37,7 +37,7 @@ pub(crate) struct EnableCommand {
     names: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for EnableCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/enable.rs
+++ b/brush-core/src/builtins/enable.rs
@@ -37,7 +37,6 @@ pub(crate) struct EnableCommand {
     names: Vec<String>,
 }
 
-
 impl builtins::Command for EnableCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/eval.rs
+++ b/brush-core/src/builtins/eval.rs
@@ -9,7 +9,6 @@ pub(crate) struct EvalCommand {
     pub args: Vec<String>,
 }
 
-
 impl builtins::Command for EvalCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/eval.rs
+++ b/brush-core/src/builtins/eval.rs
@@ -9,7 +9,7 @@ pub(crate) struct EvalCommand {
     pub args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for EvalCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/exec.rs
+++ b/brush-core/src/builtins/exec.rs
@@ -23,7 +23,7 @@ pub(crate) struct ExecCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ExecCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/exec.rs
+++ b/brush-core/src/builtins/exec.rs
@@ -23,7 +23,6 @@ pub(crate) struct ExecCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for ExecCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/exit.rs
+++ b/brush-core/src/builtins/exit.rs
@@ -9,7 +9,7 @@ pub(crate) struct ExitCommand {
     code: Option<i32>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ExitCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/exit.rs
+++ b/brush-core/src/builtins/exit.rs
@@ -9,7 +9,6 @@ pub(crate) struct ExitCommand {
     code: Option<i32>,
 }
 
-
 impl builtins::Command for ExitCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/export.rs
+++ b/brush-core/src/builtins/export.rs
@@ -37,7 +37,7 @@ impl builtins::DeclarationCommand for ExportCommand {
     }
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ExportCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/export.rs
+++ b/brush-core/src/builtins/export.rs
@@ -37,7 +37,6 @@ impl builtins::DeclarationCommand for ExportCommand {
     }
 }
 
-
 impl builtins::Command for ExportCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/false_.rs
+++ b/brush-core/src/builtins/false_.rs
@@ -6,7 +6,6 @@ use crate::{builtins, commands};
 #[derive(Parser)]
 pub(crate) struct FalseCommand {}
 
-
 impl builtins::Command for FalseCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/false_.rs
+++ b/brush-core/src/builtins/false_.rs
@@ -6,7 +6,7 @@ use crate::{builtins, commands};
 #[derive(Parser)]
 pub(crate) struct FalseCommand {}
 
-#[async_trait::async_trait]
+
 impl builtins::Command for FalseCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/fg.rs
+++ b/brush-core/src/builtins/fg.rs
@@ -10,7 +10,7 @@ pub(crate) struct FgCommand {
     job_spec: Option<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for FgCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/fg.rs
+++ b/brush-core/src/builtins/fg.rs
@@ -10,7 +10,6 @@ pub(crate) struct FgCommand {
     job_spec: Option<String>,
 }
 
-
 impl builtins::Command for FgCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/getopts.rs
+++ b/brush-core/src/builtins/getopts.rs
@@ -18,7 +18,6 @@ pub(crate) struct GetOptsCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for GetOptsCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/getopts.rs
+++ b/brush-core/src/builtins/getopts.rs
@@ -18,7 +18,7 @@ pub(crate) struct GetOptsCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for GetOptsCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/help.rs
+++ b/brush-core/src/builtins/help.rs
@@ -22,7 +22,7 @@ pub(crate) struct HelpCommand {
     topic_patterns: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for HelpCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/help.rs
+++ b/brush-core/src/builtins/help.rs
@@ -22,7 +22,6 @@ pub(crate) struct HelpCommand {
     topic_patterns: Vec<String>,
 }
 
-
 impl builtins::Command for HelpCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/jobs.rs
+++ b/brush-core/src/builtins/jobs.rs
@@ -31,7 +31,7 @@ pub(crate) struct JobsCommand {
     job_specs: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for JobsCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/jobs.rs
+++ b/brush-core/src/builtins/jobs.rs
@@ -31,7 +31,6 @@ pub(crate) struct JobsCommand {
     job_specs: Vec<String>,
 }
 
-
 impl builtins::Command for JobsCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/kill.rs
+++ b/brush-core/src/builtins/kill.rs
@@ -25,7 +25,7 @@ pub(crate) struct KillCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for KillCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/kill.rs
+++ b/brush-core/src/builtins/kill.rs
@@ -16,7 +16,6 @@ pub(crate) struct KillCommand {
 
     //
     // TODO: implement -sigspec syntax
-    //
     /// List known signal names.
     #[arg(short = 'l', short_alias = 'L')]
     list_signals: bool,
@@ -24,7 +23,6 @@ pub(crate) struct KillCommand {
     // Interpretation of these depends on whether -l is present.
     args: Vec<String>,
 }
-
 
 impl builtins::Command for KillCommand {
     async fn execute(

--- a/brush-core/src/builtins/kill.rs
+++ b/brush-core/src/builtins/kill.rs
@@ -37,7 +37,7 @@ impl builtins::Command for KillCommand {
         }
 
         if self.list_signals {
-            return error::unimp("kill -l");
+            error::unimp("kill -l")
         } else {
             if self.args.len() != 1 {
                 writeln!(context.stderr(), "{}: invalid usage", context.command_name)?;

--- a/brush-core/src/builtins/let_.rs
+++ b/brush-core/src/builtins/let_.rs
@@ -11,7 +11,7 @@ pub(crate) struct LetCommand {
     exprs: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for LetCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/let_.rs
+++ b/brush-core/src/builtins/let_.rs
@@ -11,7 +11,6 @@ pub(crate) struct LetCommand {
     exprs: Vec<String>,
 }
 
-
 impl builtins::Command for LetCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/popd.rs
+++ b/brush-core/src/builtins/popd.rs
@@ -14,7 +14,7 @@ pub(crate) struct PopdCommand {
     //
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for PopdCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/popd.rs
+++ b/brush-core/src/builtins/popd.rs
@@ -11,9 +11,7 @@ pub(crate) struct PopdCommand {
     no_directory_change: bool,
     //
     // TODO: implement +N and -N
-    //
 }
-
 
 impl builtins::Command for PopdCommand {
     async fn execute(

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -16,7 +16,6 @@ pub(crate) struct PrintfCommand {
     format_and_args: Vec<String>,
 }
 
-
 impl builtins::Command for PrintfCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -30,7 +30,7 @@ impl builtins::Command for PrintfCommand {
             context.stdout().flush()?;
         }
 
-        return Ok(builtins::ExitCode::Success);
+        Ok(builtins::ExitCode::Success)
     }
 }
 

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -16,7 +16,7 @@ pub(crate) struct PrintfCommand {
     format_and_args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for PrintfCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/pushd.rs
+++ b/brush-core/src/builtins/pushd.rs
@@ -13,9 +13,7 @@ pub(crate) struct PushdCommand {
     dir: String,
     //
     // TODO: implement +N and -N
-    //
 }
-
 
 impl builtins::Command for PushdCommand {
     async fn execute(

--- a/brush-core/src/builtins/pushd.rs
+++ b/brush-core/src/builtins/pushd.rs
@@ -16,7 +16,7 @@ pub(crate) struct PushdCommand {
     //
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for PushdCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/pwd.rs
+++ b/brush-core/src/builtins/pwd.rs
@@ -14,7 +14,7 @@ pub(crate) struct PwdCommand {
     allow_symlinks: bool,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for PwdCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/pwd.rs
+++ b/brush-core/src/builtins/pwd.rs
@@ -14,7 +14,6 @@ pub(crate) struct PwdCommand {
     allow_symlinks: bool,
 }
 
-
 impl builtins::Command for PwdCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/read.rs
+++ b/brush-core/src/builtins/read.rs
@@ -59,7 +59,6 @@ pub(crate) struct ReadCommand {
     variable_names: Vec<String>,
 }
 
-
 impl builtins::Command for ReadCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/read.rs
+++ b/brush-core/src/builtins/read.rs
@@ -59,7 +59,7 @@ pub(crate) struct ReadCommand {
     variable_names: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ReadCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/return_.rs
+++ b/brush-core/src/builtins/return_.rs
@@ -9,7 +9,7 @@ pub(crate) struct ReturnCommand {
     code: Option<i32>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ReturnCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/return_.rs
+++ b/brush-core/src/builtins/return_.rs
@@ -9,7 +9,6 @@ pub(crate) struct ReturnCommand {
     code: Option<i32>,
 }
 
-
 impl builtins::Command for ReturnCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/set.rs
+++ b/brush-core/src/builtins/set.rs
@@ -130,7 +130,7 @@ pub(crate) struct SetCommand {
     positional_args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for SetCommand {
     fn takes_plus_options() -> bool {
         true

--- a/brush-core/src/builtins/set.rs
+++ b/brush-core/src/builtins/set.rs
@@ -130,7 +130,6 @@ pub(crate) struct SetCommand {
     positional_args: Vec<String>,
 }
 
-
 impl builtins::Command for SetCommand {
     fn takes_plus_options() -> bool {
         true

--- a/brush-core/src/builtins/shift.rs
+++ b/brush-core/src/builtins/shift.rs
@@ -9,7 +9,6 @@ pub(crate) struct ShiftCommand {
     n: Option<i32>,
 }
 
-
 impl builtins::Command for ShiftCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/shift.rs
+++ b/brush-core/src/builtins/shift.rs
@@ -9,7 +9,7 @@ pub(crate) struct ShiftCommand {
     n: Option<i32>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ShiftCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/shopt.rs
+++ b/brush-core/src/builtins/shopt.rs
@@ -31,7 +31,6 @@ pub(crate) struct ShoptCommand {
     options: Vec<String>,
 }
 
-
 impl builtins::Command for ShoptCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/shopt.rs
+++ b/brush-core/src/builtins/shopt.rs
@@ -31,7 +31,7 @@ pub(crate) struct ShoptCommand {
     options: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for ShoptCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/test.rs
+++ b/brush-core/src/builtins/test.rs
@@ -11,7 +11,7 @@ pub(crate) struct TestCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for TestCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/test.rs
+++ b/brush-core/src/builtins/test.rs
@@ -11,7 +11,6 @@ pub(crate) struct TestCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for TestCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/trap.rs
+++ b/brush-core/src/builtins/trap.rs
@@ -17,7 +17,7 @@ pub(crate) struct TrapCommand {
     args: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for TrapCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/trap.rs
+++ b/brush-core/src/builtins/trap.rs
@@ -17,7 +17,6 @@ pub(crate) struct TrapCommand {
     args: Vec<String>,
 }
 
-
 impl builtins::Command for TrapCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/true_.rs
+++ b/brush-core/src/builtins/true_.rs
@@ -6,7 +6,7 @@ use crate::{builtins, commands};
 #[derive(Parser)]
 pub(crate) struct TrueCommand {}
 
-#[async_trait::async_trait]
+
 impl builtins::Command for TrueCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/true_.rs
+++ b/brush-core/src/builtins/true_.rs
@@ -6,7 +6,6 @@ use crate::{builtins, commands};
 #[derive(Parser)]
 pub(crate) struct TrueCommand {}
 
-
 impl builtins::Command for TrueCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/type_.rs
+++ b/brush-core/src/builtins/type_.rs
@@ -44,7 +44,7 @@ enum ResolvedType {
     File(PathBuf),
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for TypeCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/type_.rs
+++ b/brush-core/src/builtins/type_.rs
@@ -44,7 +44,6 @@ enum ResolvedType {
     File(PathBuf),
 }
 
-
 impl builtins::Command for TypeCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/umask.rs
+++ b/brush-core/src/builtins/umask.rs
@@ -27,7 +27,7 @@ impl builtins::Command for UmaskCommand {
     ) -> Result<crate::builtins::ExitCode, crate::error::Error> {
         if let Some(mode) = &self.mode {
             if mode.starts_with(|c: char| c.is_digit(8)) {
-                let parsed = u32::from_str_radix(mode.as_str(), 8)?;
+                let parsed = nix::sys::stat::mode_t::from_str_radix(mode.as_str(), 8)?;
                 set_umask(parsed)?;
             } else {
                 return crate::error::unimp("umask setting mode from symbolic value");
@@ -63,17 +63,18 @@ cfg_if! {
             status.umask.ok_or_else(|| error::Error::InvalidUmask)
         }
     } else {
+        #[allow(clippy::unnecessary_wraps)]
         fn get_umask() -> Result<u32, error::Error> {
             let u = nix::sys::stat::umask(Mode::empty());
             nix::sys::stat::umask(u);
-            Ok(u.bits() as u32)
+            Ok(u32::from(u.bits()))
         }
     }
 }
 
-fn set_umask(value: u32) -> Result<(), error::Error> {
-    let mode =
-        nix::sys::stat::Mode::from_bits(value as _).ok_or_else(|| error::Error::InvalidUmask)?;
+fn set_umask(value: nix::sys::stat::mode_t) -> Result<(), error::Error> {
+    // value of mode_t can be platform dependent
+    let mode = nix::sys::stat::Mode::from_bits(value).ok_or_else(|| error::Error::InvalidUmask)?;
     nix::sys::stat::umask(mode);
     Ok(())
 }

--- a/brush-core/src/builtins/umask.rs
+++ b/brush-core/src/builtins/umask.rs
@@ -20,7 +20,6 @@ pub(crate) struct UmaskCommand {
     mode: Option<String>,
 }
 
-
 impl builtins::Command for UmaskCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/umask.rs
+++ b/brush-core/src/builtins/umask.rs
@@ -20,7 +20,7 @@ pub(crate) struct UmaskCommand {
     mode: Option<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for UmaskCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/unalias.rs
+++ b/brush-core/src/builtins/unalias.rs
@@ -14,7 +14,7 @@ pub(crate) struct UnaliasCommand {
     aliases: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for UnaliasCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/unalias.rs
+++ b/brush-core/src/builtins/unalias.rs
@@ -14,7 +14,6 @@ pub(crate) struct UnaliasCommand {
     aliases: Vec<String>,
 }
 
-
 impl builtins::Command for UnaliasCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/unimp.rs
+++ b/brush-core/src/builtins/unimp.rs
@@ -13,7 +13,6 @@ pub(crate) struct UnimplementedCommand {
     declarations: Vec<commands::CommandArg>,
 }
 
-
 impl builtins::Command for UnimplementedCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/unimp.rs
+++ b/brush-core/src/builtins/unimp.rs
@@ -13,7 +13,7 @@ pub(crate) struct UnimplementedCommand {
     declarations: Vec<commands::CommandArg>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for UnimplementedCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/unset.rs
+++ b/brush-core/src/builtins/unset.rs
@@ -34,7 +34,6 @@ impl UnsetNameInterpretation {
     }
 }
 
-
 impl builtins::Command for UnsetCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/unset.rs
+++ b/brush-core/src/builtins/unset.rs
@@ -34,7 +34,7 @@ impl UnsetNameInterpretation {
     }
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for UnsetCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/wait.rs
+++ b/brush-core/src/builtins/wait.rs
@@ -22,7 +22,7 @@ pub(crate) struct WaitCommand {
     job_specs: Vec<String>,
 }
 
-#[async_trait::async_trait]
+
 impl builtins::Command for WaitCommand {
     async fn execute(
         &self,

--- a/brush-core/src/builtins/wait.rs
+++ b/brush-core/src/builtins/wait.rs
@@ -22,7 +22,6 @@ pub(crate) struct WaitCommand {
     job_specs: Vec<String>,
 }
 
-
 impl builtins::Command for WaitCommand {
     async fn execute(
         &self,

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -190,4 +190,3 @@ pub enum Error {
 pub(crate) fn unimp<T>(msg: &'static str) -> Result<T, Error> {
     Err(Error::Unimplemented(msg))
 }
-

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -190,3 +190,4 @@ pub enum Error {
 pub(crate) fn unimp<T>(msg: &'static str) -> Result<T, Error> {
     Err(Error::Unimplemented(msg))
 }
+

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -1048,19 +1048,15 @@ async fn expand_assignment_value(
         ast::AssignmentValue::Array(arr) => {
             let mut expanded_values = vec![];
             for (key, value) in arr {
-                match key {
-                    Some(k) => {
-                        let expanded_key = expansion::basic_expand_word(shell, k).await?.into();
-                        let expanded_value =
-                            expansion::basic_expand_word(shell, value).await?.into();
-                        expanded_values.push((Some(expanded_key), expanded_value));
-                    }
-                    None => {
-                        let split_expanded_value =
-                            expansion::full_expand_and_split_word(shell, value).await?;
-                        for expanded_value in split_expanded_value {
-                            expanded_values.push((None, expanded_value.into()));
-                        }
+                if let Some(k) = key {
+                    let expanded_key = expansion::basic_expand_word(shell, k).await?.into();
+                    let expanded_value = expansion::basic_expand_word(shell, value).await?.into();
+                    expanded_values.push((Some(expanded_key), expanded_value));
+                } else {
+                    let split_expanded_value =
+                        expansion::full_expand_and_split_word(shell, value).await?;
+                    for expanded_value in split_expanded_value {
+                        expanded_values.push((None, expanded_value.into()));
                     }
                 }
             }

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -18,6 +18,7 @@ use crate::variables::{
     ArrayLiteral, ShellValue, ShellValueLiteral, ShellValueUnsetType, ShellVariable,
 };
 use crate::{error, expansion, extendedtests, jobs, openfiles, processes, sys, traps};
+use futures::future::{BoxFuture, FutureExt};
 
 /// Encapsulates the result of executing a command.
 #[derive(Debug, Default)]
@@ -126,16 +127,14 @@ pub enum ProcessGroupPolicy {
     SameProcessGroup,
 }
 
-#[async_trait::async_trait]
 pub trait Execute {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error>;
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>>;
 }
 
-#[async_trait::async_trait]
 trait ExecuteInPipeline {
     async fn execute_in_pipeline(
         &self,
@@ -143,68 +142,72 @@ trait ExecuteInPipeline {
     ) -> Result<CommandSpawnResult, error::Error>;
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::Program {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let mut result = ExecutionResult::success();
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let mut result = ExecutionResult::success();
 
-        for command in &self.complete_commands {
-            result = command.execute(shell, params).await?;
-            if result.exit_shell || result.return_from_function_or_script {
-                break;
+            for command in &self.complete_commands {
+                result = command.execute(shell, params).await?;
+                if result.exit_shell || result.return_from_function_or_script {
+                    break;
+                }
             }
-        }
 
-        shell.last_exit_status = result.exit_code;
-        Ok(result)
+            shell.last_exit_status = result.exit_code;
+            Ok(result)
+        }
+        .boxed()
     }
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::CompoundList {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let mut result = ExecutionResult::success();
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let mut result = ExecutionResult::success();
 
-        for ast::CompoundListItem(ao_list, sep) in &self.0 {
-            let run_async = matches!(sep, ast::SeparatorOperator::Async);
+            for ast::CompoundListItem(ao_list, sep) in &self.0 {
+                let run_async = matches!(sep, ast::SeparatorOperator::Async);
 
-            if run_async {
-                // TODO: Reenable launching in child process?
-                // let job = spawn_ao_list_in_child(ao_list, shell, params).await?;
+                if run_async {
+                    // TODO: Reenable launching in child process?
+                    // let job = spawn_ao_list_in_child(ao_list, shell, params).await?;
 
-                let job = spawn_ao_list_in_task(ao_list, shell, params);
-                let job_formatted = job.to_pid_style_string();
+                    let job = spawn_ao_list_in_task(ao_list, shell, params);
+                    let job_formatted = job.to_pid_style_string();
 
-                if shell.options.interactive {
-                    writeln!(shell.stderr(), "{job_formatted}")?;
+                    if shell.options.interactive {
+                        writeln!(shell.stderr(), "{job_formatted}")?;
+                    }
+
+                    result = ExecutionResult::success();
+                } else {
+                    result = ao_list.execute(shell, params).await?;
                 }
 
-                result = ExecutionResult::success();
-            } else {
-                result = ao_list.execute(shell, params).await?;
+                // Check for early return.
+                if result.return_from_function_or_script {
+                    break;
+                }
+
+                // TODO: Check for continue/break being in for/while/until loop.
+                if result.continue_loop.is_some() || result.break_loop.is_some() {
+                    break;
+                }
             }
 
-            // Check for early return.
-            if result.return_from_function_or_script {
-                break;
-            }
-
-            // TODO: Check for continue/break being in for/while/until loop.
-            if result.continue_loop.is_some() || result.break_loop.is_some() {
-                break;
-            }
+            shell.last_exit_status = result.exit_code;
+            Ok(result)
         }
-
-        shell.last_exit_status = result.exit_code;
-        Ok(result)
+        .boxed()
     }
 }
 
@@ -236,73 +239,77 @@ fn spawn_ao_list_in_task<'a>(
     job
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::AndOrList {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let mut result = self.first.execute(shell, params).await?;
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let mut result = self.first.execute(shell, params).await?;
 
-        for next_ao in &self.additional {
-            // Check for exit/return
-            if result.exit_shell || result.return_from_function_or_script {
-                break;
-            }
+            for next_ao in &self.additional {
+                // Check for exit/return
+                if result.exit_shell || result.return_from_function_or_script {
+                    break;
+                }
 
-            // Check for continue/break
-            // TODO: Validate that we're in a loop?
-            if result.continue_loop.is_some() || result.break_loop.is_some() {
-                break;
-            }
+                // Check for continue/break
+                // TODO: Validate that we're in a loop?
+                if result.continue_loop.is_some() || result.break_loop.is_some() {
+                    break;
+                }
 
-            let (is_and, pipeline) = match next_ao {
-                ast::AndOr::And(p) => (true, p),
-                ast::AndOr::Or(p) => (false, p),
-            };
+                let (is_and, pipeline) = match next_ao {
+                    ast::AndOr::And(p) => (true, p),
+                    ast::AndOr::Or(p) => (false, p),
+                };
 
-            // If we short-circuit, then we don't break out of the whole loop
-            // but we skip evaluating the current pipeline. We'll then continue
-            // on and possibly evaluate a subsequent one (depending on the
-            // operator before it).
-            if is_and {
-                if !result.is_success() {
+                // If we short-circuit, then we don't break out of the whole loop
+                // but we skip evaluating the current pipeline. We'll then continue
+                // on and possibly evaluate a subsequent one (depending on the
+                // operator before it).
+                if is_and {
+                    if !result.is_success() {
+                        continue;
+                    }
+                } else if result.is_success() {
                     continue;
                 }
-            } else if result.is_success() {
-                continue;
+
+                result = pipeline.execute(shell, params).await?;
             }
 
-            result = pipeline.execute(shell, params).await?;
+            Ok(result)
         }
-
-        Ok(result)
+        .boxed()
     }
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::Pipeline {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        // Spawn all the processes required for the pipeline, connecting outputs/inputs with pipes
-        // as needed.
-        let spawn_results = spawn_pipeline_processes(self, shell, params).await?;
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            // Spawn all the processes required for the pipeline, connecting outputs/inputs with
+            // pipes as needed.
+            let spawn_results = spawn_pipeline_processes(self, shell, params).await?;
 
-        // Wait for the processes.
-        let mut result = wait_for_pipeline_processes(self, spawn_results, shell).await?;
+            // Wait for the processes.
+            let mut result = wait_for_pipeline_processes(self, spawn_results, shell).await?;
 
-        // Invert the exit code if requested.
-        if self.bang {
-            result.exit_code = if result.exit_code == 0 { 1 } else { 0 };
+            // Invert the exit code if requested.
+            if self.bang {
+                result.exit_code = if result.exit_code == 0 { 1 } else { 0 };
+            }
+
+            shell.last_exit_status = result.exit_code;
+
+            Ok(result)
         }
-
-        shell.last_exit_status = result.exit_code;
-
-        Ok(result)
+        .boxed()
     }
 }
 
@@ -401,11 +408,10 @@ async fn wait_for_pipeline_processes(
     Ok(result)
 }
 
-#[async_trait::async_trait]
 impl ExecuteInPipeline for ast::Command {
     async fn execute_in_pipeline(
         &self,
-        pipeline_context: &mut PipelineExecutionContext,
+        pipeline_context: &mut PipelineExecutionContext<'_>,
     ) -> Result<CommandSpawnResult, error::Error> {
         if pipeline_context.shell.options.do_not_execute_commands {
             return Ok(CommandSpawnResult::ImmediateExit(0));
@@ -466,73 +472,217 @@ enum WhileOrUntil {
     Until,
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::CompoundCommand {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        match self {
-            ast::CompoundCommand::BraceGroup(ast::BraceGroupCommand(g)) => {
-                g.execute(shell, params).await
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            match self {
+                ast::CompoundCommand::BraceGroup(ast::BraceGroupCommand(g)) => {
+                    g.execute(shell, params).await
+                }
+                ast::CompoundCommand::Subshell(ast::SubshellCommand(s)) => {
+                    // Clone off a new subshell, and run the body of the subshell there.
+                    let mut subshell = shell.clone();
+                    s.execute(&mut subshell, params).await
+                }
+                ast::CompoundCommand::ForClause(f) => f.execute(shell, params).await,
+                ast::CompoundCommand::CaseClause(c) => c.execute(shell, params).await,
+                ast::CompoundCommand::IfClause(i) => i.execute(shell, params).await,
+                ast::CompoundCommand::WhileClause(w) => {
+                    (WhileOrUntil::While, w).execute(shell, params).await
+                }
+                ast::CompoundCommand::UntilClause(u) => {
+                    (WhileOrUntil::Until, u).execute(shell, params).await
+                }
+                ast::CompoundCommand::Arithmetic(a) => a.execute(shell, params).await,
+                ast::CompoundCommand::ArithmeticForClause(a) => a.execute(shell, params).await,
             }
-            ast::CompoundCommand::Subshell(ast::SubshellCommand(s)) => {
-                // Clone off a new subshell, and run the body of the subshell there.
-                let mut subshell = shell.clone();
-                s.execute(&mut subshell, params).await
-            }
-            ast::CompoundCommand::ForClause(f) => f.execute(shell, params).await,
-            ast::CompoundCommand::CaseClause(c) => c.execute(shell, params).await,
-            ast::CompoundCommand::IfClause(i) => i.execute(shell, params).await,
-            ast::CompoundCommand::WhileClause(w) => {
-                (WhileOrUntil::While, w).execute(shell, params).await
-            }
-            ast::CompoundCommand::UntilClause(u) => {
-                (WhileOrUntil::Until, u).execute(shell, params).await
-            }
-            ast::CompoundCommand::Arithmetic(a) => a.execute(shell, params).await,
-            ast::CompoundCommand::ArithmeticForClause(a) => a.execute(shell, params).await,
         }
+        .boxed()
     }
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::ForClauseCommand {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let mut result = ExecutionResult::success();
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let mut result = ExecutionResult::success();
 
-        if let Some(unexpanded_values) = &self.values {
-            // Expand all values, with splitting enabled.
-            let mut expanded_values = vec![];
-            for value in unexpanded_values {
-                let mut expanded = expansion::full_expand_and_split_word(shell, value).await?;
-                expanded_values.append(&mut expanded);
-            }
-
-            for value in expanded_values {
-                if shell.options.print_commands_and_arguments {
-                    shell.trace_command(std::format!(
-                        "for {} in {}",
-                        self.variable_name,
-                        unexpanded_values.iter().join(" ")
-                    ))?;
+            if let Some(unexpanded_values) = &self.values {
+                // Expand all values, with splitting enabled.
+                let mut expanded_values = vec![];
+                for value in unexpanded_values {
+                    let mut expanded = expansion::full_expand_and_split_word(shell, value).await?;
+                    expanded_values.append(&mut expanded);
                 }
 
-                // Update the variable.
-                shell.env.update_or_add(
-                    &self.variable_name,
-                    ShellValueLiteral::Scalar(value),
-                    |_| Ok(()),
-                    EnvironmentLookup::Anywhere,
-                    EnvironmentScope::Global,
-                )?;
+                for value in expanded_values {
+                    if shell.options.print_commands_and_arguments {
+                        shell.trace_command(std::format!(
+                            "for {} in {}",
+                            self.variable_name,
+                            unexpanded_values.iter().join(" ")
+                        ))?;
+                    }
 
-                result = self.body.0.execute(shell, params).await?;
+                    // Update the variable.
+                    shell.env.update_or_add(
+                        &self.variable_name,
+                        ShellValueLiteral::Scalar(value),
+                        |_| Ok(()),
+                        EnvironmentLookup::Anywhere,
+                        EnvironmentScope::Global,
+                    )?;
+
+                    result = self.body.0.execute(shell, params).await?;
+                    if result.return_from_function_or_script {
+                        break;
+                    }
+
+                    if let Some(continue_count) = &result.continue_loop {
+                        if *continue_count > 0 {
+                            return error::unimp("continue with count > 0");
+                        }
+
+                        result.continue_loop = None;
+                    }
+                    if let Some(break_count) = &result.break_loop {
+                        if *break_count == 0 {
+                            result.break_loop = None;
+                        } else {
+                            result.break_loop = Some(*break_count - 1);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            shell.last_exit_status = result.exit_code;
+            Ok(result)
+        }
+        .boxed()
+    }
+}
+
+impl Execute for ast::CaseClauseCommand {
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            // N.B. One would think it makes sense to trace the expanded value being switched
+            // on, but that's not it.
+            if shell.options.print_commands_and_arguments {
+                shell.trace_command(std::format!("case {} in", &self.value))?;
+            }
+
+            let expanded_value = expansion::basic_expand_word(shell, &self.value).await?;
+
+            for case in &self.cases {
+                let mut matches = false;
+
+                for pattern in &case.patterns {
+                    let expanded_pattern = expansion::basic_expand_pattern(shell, pattern).await?;
+                    if expanded_pattern
+                        .exactly_matches(expanded_value.as_str(), shell.options.extended_globbing)?
+                    {
+                        matches = true;
+                        break;
+                    }
+                }
+
+                if matches {
+                    if let Some(case_cmd) = &case.cmd {
+                        return case_cmd.execute(shell, params).await;
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            let result = ExecutionResult::success();
+            shell.last_exit_status = result.exit_code;
+
+            Ok(result)
+        }
+        .boxed()
+    }
+}
+
+impl Execute for ast::IfClauseCommand {
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let condition = self.condition.execute(shell, params).await?;
+
+            if condition.is_success() {
+                return self.then.execute(shell, params).await;
+            }
+
+            if let Some(elses) = &self.elses {
+                for else_clause in elses {
+                    match &else_clause.condition {
+                        Some(else_condition) => {
+                            let else_condition_result =
+                                else_condition.execute(shell, params).await?;
+                            if else_condition_result.is_success() {
+                                return else_clause.body.execute(shell, params).await;
+                            }
+                        }
+                        None => {
+                            return else_clause.body.execute(shell, params).await;
+                        }
+                    }
+                }
+            }
+
+            let result = ExecutionResult::success();
+            shell.last_exit_status = result.exit_code;
+
+            Ok(result)
+        }
+        .boxed()
+    }
+}
+
+impl Execute for (WhileOrUntil, &ast::WhileOrUntilClauseCommand) {
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let is_while = match self.0 {
+                WhileOrUntil::While => true,
+                WhileOrUntil::Until => false,
+            };
+            let test_condition = &self.1 .0;
+            let body = &self.1 .1;
+
+            let mut result = ExecutionResult::success();
+
+            loop {
+                let condition_result = test_condition.execute(shell, params).await?;
+
+                if condition_result.is_success() != is_while {
+                    break;
+                }
+
+                if condition_result.return_from_function_or_script {
+                    break;
+                }
+
+                result = body.0.execute(shell, params).await?;
                 if result.return_from_function_or_script {
                     break;
                 }
@@ -553,224 +703,96 @@ impl Execute for ast::ForClauseCommand {
                     break;
                 }
             }
-        }
 
-        shell.last_exit_status = result.exit_code;
-        Ok(result)
+            Ok(result)
+        }
+        .boxed()
     }
 }
 
-#[async_trait::async_trait]
-impl Execute for ast::CaseClauseCommand {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        // N.B. One would think it makes sense to trace the expanded value being switched
-        // on, but that's not it.
-        if shell.options.print_commands_and_arguments {
-            shell.trace_command(std::format!("case {} in", &self.value))?;
-        }
-
-        let expanded_value = expansion::basic_expand_word(shell, &self.value).await?;
-
-        for case in &self.cases {
-            let mut matches = false;
-
-            for pattern in &case.patterns {
-                let expanded_pattern = expansion::basic_expand_pattern(shell, pattern).await?;
-                if expanded_pattern
-                    .exactly_matches(expanded_value.as_str(), shell.options.extended_globbing)?
-                {
-                    matches = true;
-                    break;
-                }
-            }
-
-            if matches {
-                if let Some(case_cmd) = &case.cmd {
-                    return case_cmd.execute(shell, params).await;
-                } else {
-                    break;
-                }
-            }
-        }
-
-        let result = ExecutionResult::success();
-        shell.last_exit_status = result.exit_code;
-
-        Ok(result)
-    }
-}
-
-#[async_trait::async_trait]
-impl Execute for ast::IfClauseCommand {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let condition = self.condition.execute(shell, params).await?;
-
-        if condition.is_success() {
-            return self.then.execute(shell, params).await;
-        }
-
-        if let Some(elses) = &self.elses {
-            for else_clause in elses {
-                match &else_clause.condition {
-                    Some(else_condition) => {
-                        let else_condition_result = else_condition.execute(shell, params).await?;
-                        if else_condition_result.is_success() {
-                            return else_clause.body.execute(shell, params).await;
-                        }
-                    }
-                    None => {
-                        return else_clause.body.execute(shell, params).await;
-                    }
-                }
-            }
-        }
-
-        let result = ExecutionResult::success();
-        shell.last_exit_status = result.exit_code;
-
-        Ok(result)
-    }
-}
-
-#[async_trait::async_trait]
-impl Execute for (WhileOrUntil, &ast::WhileOrUntilClauseCommand) {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let is_while = match self.0 {
-            WhileOrUntil::While => true,
-            WhileOrUntil::Until => false,
-        };
-        let test_condition = &self.1 .0;
-        let body = &self.1 .1;
-
-        let mut result = ExecutionResult::success();
-
-        loop {
-            let condition_result = test_condition.execute(shell, params).await?;
-
-            if condition_result.is_success() != is_while {
-                break;
-            }
-
-            if condition_result.return_from_function_or_script {
-                break;
-            }
-
-            result = body.0.execute(shell, params).await?;
-            if result.return_from_function_or_script {
-                break;
-            }
-
-            if let Some(continue_count) = &result.continue_loop {
-                if *continue_count > 0 {
-                    return error::unimp("continue with count > 0");
-                }
-
-                result.continue_loop = None;
-            }
-            if let Some(break_count) = &result.break_loop {
-                if *break_count == 0 {
-                    result.break_loop = None;
-                } else {
-                    result.break_loop = Some(*break_count - 1);
-                }
-                break;
-            }
-        }
-
-        Ok(result)
-    }
-}
-
-#[async_trait::async_trait]
 impl Execute for ast::ArithmeticCommand {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        _params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let value = self.expr.eval(shell, true).await?;
-        let result = if value != 0 {
-            ExecutionResult::success()
-        } else {
-            ExecutionResult::new(1)
-        };
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        _params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let value = self.expr.eval(shell, true).await?;
+            let result = if value != 0 {
+                ExecutionResult::success()
+            } else {
+                ExecutionResult::new(1)
+            };
 
-        shell.last_exit_status = result.exit_code;
+            shell.last_exit_status = result.exit_code;
 
-        Ok(result)
+            Ok(result)
+        }
+        .boxed()
     }
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::ArithmeticForClauseCommand {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        let mut result = ExecutionResult::success();
-        if let Some(initializer) = &self.initializer {
-            initializer.eval(shell, true).await?;
-        }
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            let mut result = ExecutionResult::success();
+            if let Some(initializer) = &self.initializer {
+                initializer.eval(shell, true).await?;
+            }
 
-        loop {
-            if let Some(condition) = &self.condition {
-                if condition.eval(shell, true).await? == 0 {
+            loop {
+                if let Some(condition) = &self.condition {
+                    if condition.eval(shell, true).await? == 0 {
+                        break;
+                    }
+                }
+
+                result = self.body.0.execute(shell, params).await?;
+                if result.return_from_function_or_script {
                     break;
+                }
+
+                if let Some(updater) = &self.updater {
+                    updater.eval(shell, true).await?;
                 }
             }
 
-            result = self.body.0.execute(shell, params).await?;
-            if result.return_from_function_or_script {
-                break;
-            }
-
-            if let Some(updater) = &self.updater {
-                updater.eval(shell, true).await?;
-            }
+            shell.last_exit_status = result.exit_code;
+            Ok(result)
         }
-
-        shell.last_exit_status = result.exit_code;
-        Ok(result)
+        .boxed()
     }
 }
 
-#[async_trait::async_trait]
 impl Execute for ast::FunctionDefinition {
-    async fn execute(
-        &self,
-        shell: &mut Shell,
-        _params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        shell
-            .funcs
-            .update(self.fname.clone(), Arc::new(self.clone()));
+    fn execute<'a>(
+        &'a self,
+        shell: &'a mut Shell,
+        _params: &'a ExecutionParameters,
+    ) -> BoxFuture<'a, Result<ExecutionResult, error::Error>> {
+        async move {
+            shell
+                .funcs
+                .update(self.fname.clone(), Arc::new(self.clone()));
 
-        let result = ExecutionResult::success();
-        shell.last_exit_status = result.exit_code;
+            let result = ExecutionResult::success();
+            shell.last_exit_status = result.exit_code;
 
-        Ok(result)
+            Ok(result)
+        }
+        .boxed()
     }
 }
 
-#[async_trait::async_trait]
 impl ExecuteInPipeline for ast::SimpleCommand {
     #[allow(clippy::too_many_lines)] // TODO: refactor this function
     async fn execute_in_pipeline(
         &self,
-        context: &mut PipelineExecutionContext,
+        context: &mut PipelineExecutionContext<'_>,
     ) -> Result<CommandSpawnResult, error::Error> {
         let default_prefix = ast::CommandPrefix::default();
         let prefix_items = self.prefix.as_ref().unwrap_or(&default_prefix);

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -215,8 +215,8 @@ impl ShellVariable {
 
         if append {
             match (&self.value, &value) {
-                // If we're appending an array to a declared-but-unset variable (or appending anything to a declared-but-unset array),
-                // then fill it out first.
+                // If we're appending an array to a declared-but-unset variable (or appending
+                // anything to a declared-but-unset array), then fill it out first.
                 (ShellValue::Unset(_), ShellValueLiteral::Array(_))
                 | (
                     ShellValue::Unset(
@@ -226,8 +226,8 @@ impl ShellVariable {
                 ) => {
                     self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
                 }
-                // If we're trying to append an array to a string, we first promote the string to be an array
-                // with the string being present at index 0.
+                // If we're trying to append an array to a string, we first promote the string to be
+                // an array with the string being present at index 0.
                 (ShellValue::String(_), ShellValueLiteral::Array(_)) => {
                     self.convert_to_indexed_array()?;
                 }
@@ -289,9 +289,9 @@ impl ShellVariable {
                     ShellValueLiteral::Scalar(s),
                 ) => self.assign_at_index(String::from("0"), s, false),
 
-                // If we're updating an indexed array value with an array, then preserve the array type.
-                // We also default to using an indexed array if we are assigning an array to a previously
-                // string-holding variable.
+                // If we're updating an indexed array value with an array, then preserve the array
+                // type. We also default to using an indexed array if we are
+                // assigning an array to a previously string-holding variable.
                 (
                     ShellValue::IndexedArray(_)
                     | ShellValue::Unset(
@@ -305,7 +305,8 @@ impl ShellVariable {
                     Ok(())
                 }
 
-                // If we're updating an associative array value with an array, then preserve the array type.
+                // If we're updating an associative array value with an array, then preserve the
+                // array type.
                 (
                     ShellValue::AssociativeArray(_)
                     | ShellValue::Unset(ShellValueUnsetType::AssociativeArray),
@@ -334,7 +335,8 @@ impl ShellVariable {
     ///
     /// * `array_index` - The index at which to assign the value.
     /// * `value` - The value to assign to the variable at the given index.
-    /// * `append` - Whether or not to append the value to the preexisting value stored at the given index.
+    /// * `append` - Whether or not to append the value to the preexisting value stored at the given
+    ///   index.
     #[allow(clippy::needless_pass_by_value)]
     pub fn assign_at_index(
         &mut self,

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -53,6 +53,7 @@ pub trait InteractiveShell {
     /// Runs the interactive shell loop, reading commands from standard input and writing
     /// results to standard output and standard error. Continues until the shell
     /// normally exits or until a fatal error occurs.
+    // NOTE: we use desugared async here because [async_fn_in_trait] "warning: use of `async fn` in public traits is discouraged as auto trait bounds cannot be specified"
     fn run_interactively(&mut self) -> impl std::future::Future<Output = Result<(), ShellError>> {
         async {
             // TODO: Consider finding a better place for this.

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -32,7 +32,7 @@ pub struct InteractivePrompt {
 }
 
 /// Represents a shell capable of taking commands from standard input.
-#[async_trait::async_trait]
+
 pub trait InteractiveShell {
     /// Returns an immutable reference to the inner shell object.
     fn shell(&self) -> impl AsRef<brush_core::Shell> + Send;
@@ -53,94 +53,100 @@ pub trait InteractiveShell {
     /// Runs the interactive shell loop, reading commands from standard input and writing
     /// results to standard output and standard error. Continues until the shell
     /// normally exits or until a fatal error occurs.
-    async fn run_interactively(&mut self) -> Result<(), ShellError> {
-        // TODO: Consider finding a better place for this.
-        let _ = brush_core::TerminalControl::acquire()?;
+    fn run_interactively(&mut self) -> impl std::future::Future<Output = Result<(), ShellError>> {
+        async {
+            // TODO: Consider finding a better place for this.
+            let _ = brush_core::TerminalControl::acquire()?;
 
-        loop {
-            let result = self.run_interactively_once().await?;
-            match result {
-                InteractiveExecutionResult::Executed(brush_core::ExecutionResult {
-                    exit_shell,
-                    return_from_function_or_script,
-                    ..
-                }) => {
-                    if exit_shell {
+            loop {
+                let result = self.run_interactively_once().await?;
+                match result {
+                    InteractiveExecutionResult::Executed(brush_core::ExecutionResult {
+                        exit_shell,
+                        return_from_function_or_script,
+                        ..
+                    }) => {
+                        if exit_shell {
+                            break;
+                        }
+
+                        if return_from_function_or_script {
+                            tracing::error!("return from non-function/script");
+                        }
+                    }
+                    InteractiveExecutionResult::Failed(e) => {
+                        // Report the error, but continue to execute.
+                        tracing::error!("error: {:#}", e);
+                    }
+                    InteractiveExecutionResult::Eof => {
                         break;
                     }
-
-                    if return_from_function_or_script {
-                        tracing::error!("return from non-function/script");
-                    }
-                }
-                InteractiveExecutionResult::Failed(e) => {
-                    // Report the error, but continue to execute.
-                    tracing::error!("error: {:#}", e);
-                }
-                InteractiveExecutionResult::Eof => {
-                    break;
                 }
             }
-        }
 
-        if self.shell().as_ref().options.interactive {
-            writeln!(self.shell().as_ref().stderr(), "exit")?;
-        }
+            if self.shell().as_ref().options.interactive {
+                writeln!(self.shell().as_ref().stderr(), "exit")?;
+            }
 
-        if let Err(e) = self.update_history() {
-            // N.B. This seems like the sort of thing that's worth being noisy about,
-            // but bash doesn't do that -- and probably for a reason.
-            tracing::debug!("couldn't save history: {e}");
-        }
+            if let Err(e) = self.update_history() {
+                // N.B. This seems like the sort of thing that's worth being noisy about,
+                // but bash doesn't do that -- and probably for a reason.
+                tracing::debug!("couldn't save history: {e}");
+            }
 
-        Ok(())
+            Ok(())
+        }
     }
 
     /// Runs the interactive shell loop once, reading a single command from standard input.
-    async fn run_interactively_once(&mut self) -> Result<InteractiveExecutionResult, ShellError> {
-        let mut shell_mut = self.shell_mut();
+    fn run_interactively_once(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<InteractiveExecutionResult, ShellError>> {
+        async {
+            let mut shell_mut = self.shell_mut();
 
-        // Check for any completed jobs.
-        shell_mut.as_mut().check_for_completed_jobs()?;
+            // Check for any completed jobs.
+            shell_mut.as_mut().check_for_completed_jobs()?;
 
-        // If there's a variable called PROMPT_COMMAND, then run it first.
-        if let Some((_, prompt_cmd)) = shell_mut.as_mut().env.get("PROMPT_COMMAND") {
-            let prompt_cmd = prompt_cmd.value().to_cow_string().to_string();
+            // If there's a variable called PROMPT_COMMAND, then run it first.
+            if let Some((_, prompt_cmd)) = shell_mut.as_mut().env.get("PROMPT_COMMAND") {
+                let prompt_cmd = prompt_cmd.value().to_cow_string().to_string();
 
-            // Save (and later restore) the last exit status.
-            let prev_last_result = shell_mut.as_mut().last_exit_status;
+                // Save (and later restore) the last exit status.
+                let prev_last_result = shell_mut.as_mut().last_exit_status;
 
-            let params = shell_mut.as_mut().default_exec_params();
-
-            shell_mut.as_mut().run_string(prompt_cmd, &params).await?;
-            shell_mut.as_mut().last_exit_status = prev_last_result;
-        }
-
-        // Now that we've done that, compose the prompt.
-        let prompt = InteractivePrompt {
-            prompt: shell_mut.as_mut().compose_prompt().await?,
-            alt_side_prompt: shell_mut.as_mut().compose_alt_side_prompt().await?,
-            continuation_prompt: shell_mut.as_mut().continuation_prompt()?,
-        };
-
-        drop(shell_mut);
-
-        match self.read_line(prompt)? {
-            ReadResult::Input(read_result) => {
-                let mut shell_mut = self.shell_mut();
                 let params = shell_mut.as_mut().default_exec_params();
-                match shell_mut.as_mut().run_string(read_result, &params).await {
-                    Ok(result) => Ok(InteractiveExecutionResult::Executed(result)),
-                    Err(e) => Ok(InteractiveExecutionResult::Failed(e)),
-                }
+
+                shell_mut.as_mut().run_string(prompt_cmd, &params).await?;
+                shell_mut.as_mut().last_exit_status = prev_last_result;
             }
-            ReadResult::Eof => Ok(InteractiveExecutionResult::Eof),
-            ReadResult::Interrupted => {
-                let mut shell_mut = self.shell_mut();
-                shell_mut.as_mut().last_exit_status = 130;
-                Ok(InteractiveExecutionResult::Executed(
-                    brush_core::ExecutionResult::new(130),
-                ))
+
+            // Now that we've done that, compose the prompt.
+            let prompt = InteractivePrompt {
+                prompt: shell_mut.as_mut().compose_prompt().await?,
+                alt_side_prompt: shell_mut.as_mut().compose_alt_side_prompt().await?,
+                continuation_prompt: shell_mut.as_mut().continuation_prompt()?,
+            };
+
+            drop(shell_mut);
+
+            match self.read_line(prompt)? {
+                ReadResult::Input(read_result) => {
+                    let mut shell_mut = self.shell_mut();
+                    let params = shell_mut.as_mut().default_exec_params();
+                    match shell_mut.as_mut().run_string(read_result, &params).await {
+                        Ok(result) => Ok(InteractiveExecutionResult::Executed(result)),
+                        Err(e) => Ok(InteractiveExecutionResult::Failed(e)),
+                    }
+                }
+                ReadResult::Eof => Ok(InteractiveExecutionResult::Eof),
+                ReadResult::Interrupted => {
+                    let mut shell_mut = self.shell_mut();
+                    shell_mut.as_mut().last_exit_status = 130;
+                    Ok(InteractiveExecutionResult::Executed(
+                        brush_core::ExecutionResult::new(130),
+                    ))
+                }
             }
         }
     }

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -53,7 +53,8 @@ pub trait InteractiveShell {
     /// Runs the interactive shell loop, reading commands from standard input and writing
     /// results to standard output and standard error. Continues until the shell
     /// normally exits or until a fatal error occurs.
-    // NOTE: we use desugared async here because [async_fn_in_trait] "warning: use of `async fn` in public traits is discouraged as auto trait bounds cannot be specified"
+    // NOTE: we use desugared async here because [async_fn_in_trait] "warning: use of `async fn` in
+    // public traits is discouraged as auto trait bounds cannot be specified"
     fn run_interactively(&mut self) -> impl std::future::Future<Output = Result<(), ShellError>> {
         async {
             // TODO: Consider finding a better place for this.

--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -244,7 +244,8 @@ impl<'a> StyledInputLine<'a> {
     }
 
     fn skip_ahead(&mut self, dest: usize) {
-        // Append a no-op style to make sure we cover any trailing gaps in the input line not otherwise styled.
+        // Append a no-op style to make sure we cover any trailing gaps in the input line not
+        // otherwise styled.
         self.append_style(Style::new(), dest, dest);
     }
 

--- a/brush-shell/src/brushctl.rs
+++ b/brush-shell/src/brushctl.rs
@@ -42,7 +42,6 @@ enum EventsCommand {
     },
 }
 
-
 impl brush_core::builtins::Command for BrushCtlCommand {
     async fn execute(
         &self,
@@ -53,7 +52,6 @@ impl brush_core::builtins::Command for BrushCtlCommand {
         }
     }
 }
-
 
 impl EventsCommand {
     fn execute(

--- a/brush-shell/src/brushctl.rs
+++ b/brush-shell/src/brushctl.rs
@@ -42,7 +42,7 @@ enum EventsCommand {
     },
 }
 
-#[async_trait::async_trait]
+
 impl brush_core::builtins::Command for BrushCtlCommand {
     async fn execute(
         &self,
@@ -53,6 +53,7 @@ impl brush_core::builtins::Command for BrushCtlCommand {
         }
     }
 }
+
 
 impl EventsCommand {
     fn execute(

--- a/brush-shell/src/shell_factory.rs
+++ b/brush-shell/src/shell_factory.rs
@@ -1,4 +1,3 @@
-
 pub(crate) trait ShellFactory {
     type ShellType: brush_interactive::InteractiveShell + Send;
 
@@ -53,7 +52,6 @@ impl AsMut<brush_core::Shell> for StubShell {
 
 pub(crate) struct RustylineShellFactory;
 
-
 impl ShellFactory for RustylineShellFactory {
     #[cfg(all(feature = "rustyline", any(windows, unix)))]
     type ShellType = brush_interactive::RustylineShell;
@@ -78,7 +76,6 @@ impl ShellFactory for RustylineShellFactory {
 
 pub(crate) struct ReedlineShellFactory;
 
-
 impl ShellFactory for ReedlineShellFactory {
     #[cfg(all(feature = "reedline", any(windows, unix)))]
     type ShellType = brush_interactive::ReedlineShell;
@@ -102,7 +99,6 @@ impl ShellFactory for ReedlineShellFactory {
 }
 
 pub(crate) struct BasicShellFactory;
-
 
 impl ShellFactory for BasicShellFactory {
     #[cfg(feature = "basic")]

--- a/brush-shell/src/shell_factory.rs
+++ b/brush-shell/src/shell_factory.rs
@@ -1,4 +1,4 @@
-#[async_trait::async_trait]
+
 pub(crate) trait ShellFactory {
     type ShellType: brush_interactive::InteractiveShell + Send;
 
@@ -53,7 +53,7 @@ impl AsMut<brush_core::Shell> for StubShell {
 
 pub(crate) struct RustylineShellFactory;
 
-#[async_trait::async_trait]
+
 impl ShellFactory for RustylineShellFactory {
     #[cfg(all(feature = "rustyline", any(windows, unix)))]
     type ShellType = brush_interactive::RustylineShell;
@@ -78,7 +78,7 @@ impl ShellFactory for RustylineShellFactory {
 
 pub(crate) struct ReedlineShellFactory;
 
-#[async_trait::async_trait]
+
 impl ShellFactory for ReedlineShellFactory {
     #[cfg(all(feature = "reedline", any(windows, unix)))]
     type ShellType = brush_interactive::ReedlineShell;
@@ -103,7 +103,7 @@ impl ShellFactory for ReedlineShellFactory {
 
 pub(crate) struct BasicShellFactory;
 
-#[async_trait::async_trait]
+
 impl ShellFactory for BasicShellFactory {
     #[cfg(feature = "basic")]
     type ShellType = brush_interactive::BasicShell;


### PR DESCRIPTION
As of Rust 1.75, the `async_fn_in_trait` feature has been merged (see: https://github.com/rust-lang/rust/pull/115822), meaning the async-trait crate is now only required for dynamic dispatch (dyn Trait). Since brush doesn’t use `dyn Command`, I decided to try removing the dependency. ~~The modules `arithmetic.rs` and `interp.rs` are most affected, as they use async recursion, which requires futures to be boxed. I’ve wrapped all recursive functions in `async move { .. }.boxed()`.~~