### PR TITLE
fix: assorted completion issues with ~ and vars

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,6 +2,7 @@
 retries = 3
 status-level = "slow"
 slow-timeout = { period = "5s", terminate-after = 3, grace-period = "2s" }
+fail-fast = false
 
 [profile.default.junit]
 path = "test-results.xml"

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -442,7 +442,6 @@ impl builtins::Command for CompGenCommand {
         context: commands::ExecutionContext<'_>,
     ) -> Result<crate::builtins::ExitCode, crate::error::Error> {
         let spec = self.common_args.create_spec();
-
         let token_to_complete = self.word.as_deref().unwrap_or_default();
 
         // N.B. We basic-expand the token-to-be-completed first.
@@ -471,6 +470,12 @@ impl builtins::Command for CompGenCommand {
 
         match result {
             completion::Answer::Candidates(candidates, _options) => {
+                // We are expected to return 1 if there are no candidates, even if no errors
+                // occurred along the way.
+                if candidates.is_empty() {
+                    return Ok(builtins::ExitCode::Custom(1));
+                }
+
                 for candidate in candidates {
                     writeln!(context.stdout(), "{candidate}")?;
                 }

--- a/brush-core/src/builtins/echo.rs
+++ b/brush-core/src/builtins/echo.rs
@@ -55,7 +55,7 @@ impl builtins::Command for EchoCommand {
 
                 let (expanded_arg, keep_going) = escape::expand_backslash_escapes(
                     arg.as_str(),
-                    escape::EscapeMode::EchoBuiltin,
+                    escape::EscapeExpansionMode::EchoBuiltin,
                 )?;
                 s.push_str(&String::from_utf8_lossy(expanded_arg.as_slice()));
 

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -1,4 +1,4 @@
-use crate::{error, regex};
+use crate::{error, regex, trace_categories};
 use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
@@ -110,7 +110,7 @@ impl Pattern {
             return Ok(vec![concatenated]);
         }
 
-        tracing::debug!("expanding pattern: {self:?}");
+        tracing::debug!(target: trace_categories::PATTERN, "expanding pattern: {self:?}");
 
         let mut components: Vec<PatternWord> = vec![];
         for piece in &self.pieces {
@@ -221,7 +221,7 @@ impl Pattern {
             })
             .collect();
 
-        tracing::debug!("  => results: {results:?}");
+        tracing::debug!(target: trace_categories::PATTERN, "  => results: {results:?}");
 
         Ok(results)
     }
@@ -308,7 +308,7 @@ impl Pattern {
             enable_extended_globbing,
         )?;
 
-        tracing::debug!("pattern: '{self:?}' => regex: '{regex_str}'");
+        tracing::debug!(target: trace_categories::PATTERN, "pattern: '{self:?}' => regex: '{regex_str}'");
 
         let re = regex::compile_regex(regex_str)?;
         Ok(re)

--- a/brush-core/src/trace_categories.rs
+++ b/brush-core/src/trace_categories.rs
@@ -1,4 +1,6 @@
 pub(crate) const COMMANDS: &str = "commands";
 pub(crate) const COMPLETION: &str = "completion";
+pub(crate) const EXPANSION: &str = "expansion";
 pub(crate) const JOBS: &str = "jobs";
 pub(crate) const PARSE: &str = "parse";
+pub(crate) const PATTERN: &str = "pattern";

--- a/brush-parser/src/arithmetic.rs
+++ b/brush-parser/src/arithmetic.rs
@@ -9,7 +9,7 @@ use crate::error;
 ///
 /// * `input` - The arithmetic expression to parse, in string form.
 pub fn parse(input: &str) -> Result<ast::ArithmeticExpr, crate::error::WordParseError> {
-    tracing::debug!("parsing arithmetic expression: '{input}'");
+    tracing::debug!(target: "arithmetic", "parsing arithmetic expression: '{input}'");
 
     // Special-case the empty string.
 

--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -132,7 +132,7 @@ pub fn parse_tokens(
             Ok(program)
         }
         Err(parse_error) => {
-            tracing::debug!("Parse error: {:?}", parse_error);
+            tracing::debug!(target: "parse", "Parse error: {:?}", parse_error);
             Err(error::convert_peg_parse_error(
                 parse_error,
                 tokens.as_slice(),

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -381,12 +381,12 @@ fn cacheable_parse(
     word: String,
     options: ParserOptions,
 ) -> Result<Vec<WordPieceWithSource>, error::WordParseError> {
-    tracing::debug!("Parsing word '{}'", word);
+    tracing::debug!(target: "expansion", "Parsing word '{}'", word);
 
     let pieces = expansion_parser::unexpanded_word(word.as_str(), &options)
         .map_err(|err| error::WordParseError::Word(word.to_owned(), err))?;
 
-    tracing::debug!(target: "parse", "Parsed word '{}' => {{{:?}}}", word, pieces);
+    tracing::debug!(target: "expansion", "Parsed word '{}' => {{{:?}}}", word, pieces);
 
     Ok(pieces)
 }

--- a/brush-shell/src/events.rs
+++ b/brush-shell/src/events.rs
@@ -96,17 +96,13 @@ impl TraceEventConfig {
 
         for event in &self.enabled_trace_events {
             let targets = match event {
-                TraceEvent::Arithmetic => vec!["parser::arithmetic"],
+                TraceEvent::Arithmetic => vec!["arithmetic"],
                 TraceEvent::Commands => vec!["commands"],
-                TraceEvent::Complete => vec![
-                    "completion",
-                    "shell::completion",
-                    "shell::builtins::complete",
-                ],
-                TraceEvent::Expand => vec!["parser::word", "shell::expansion"],
+                TraceEvent::Complete => vec!["completion"],
+                TraceEvent::Expand => vec!["expansion"],
                 TraceEvent::Jobs => vec!["jobs"],
                 TraceEvent::Parse => vec!["parse"],
-                TraceEvent::Pattern => vec!["shell::pattern"],
+                TraceEvent::Pattern => vec!["pattern"],
                 TraceEvent::Tokenize => vec!["tokenize"],
             };
 

--- a/brush-shell/tests/cases/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/builtins/compgen.yaml
@@ -60,3 +60,44 @@ cases:
   - name: "compgen -W with options"
     stdin: |
       compgen -W '--abc --def' -- '--ab'
+
+  - name: "compgen with no matches"
+    stdin: |
+      compgen -W yes no && echo "1. Result"
+
+  - name: "compgen -f with tilde"
+    stdin: |
+      touch item1
+      HOME=$(pwd)
+
+      echo "[0]"
+      for p in $(compgen -f ~); do
+        echo ${p//$HOME/HOME}
+      done
+
+      echo "[1]"
+      for p in $(compgen -f ~/); do
+        echo ${p//$HOME/HOME}
+      done
+
+  - name: "compgen -f with quoted tilde"
+    known_failure: true
+    stdin: |
+      touch item1
+      HOME=$(pwd)
+
+      echo "[0]"
+      for p in $(compgen -f '~/'); do
+        echo ${p//$HOME/HOME}
+      done
+
+  - name: "compgen -f with quoted var"
+    known_failure: true
+    stdin: |
+      touch item1
+      HOME=$(pwd)
+
+      echo "[0]"
+      for p in $(compgen -f '$HOME/'); do
+        echo ${p//$HOME/HOME}
+      done

--- a/brush-shell/tests/cases/builtins/printf.yaml
+++ b/brush-shell/tests/cases/builtins/printf.yaml
@@ -22,3 +22,14 @@ cases:
   - name: "printf with -v as a format arg"
     stdin: |
       printf "%s\n" "-v"
+
+  - name: "printf %q"
+    stdin: |
+      echo "[1]"
+      printf "%q" 'TEXT'; echo
+
+      echo "[2]"
+      printf "%q" '$VAR'; echo
+
+      echo "[3]"
+      printf "%q" '"'; echo

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -135,6 +135,12 @@ cases:
       [[ "abc" == "a*" ]] && echo "1. Matches"
       [[ "abc" != "a*" ]] && echo "2. Matches"
 
+  - name: "Tilde binary string matching"
+    known_failure: true
+    stdin: |
+      x='~/'
+      [[ $x == ~* ]] && echo "1. Matches"
+
   - name: "Arithmetic extended tests"
     stdin: |
       [[ 0 -eq 0 ]] && echo "1. Pass"

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -61,6 +61,11 @@ cases:
       x=$(echo foo | (wc -l; echo hi))
       echo "\$x: $x"
 
+  - name: "Command substitution exit code"
+    stdin: |
+      x=$(false) && echo "1. Made it past false"
+      y=$(true) && echo "2. Made it past true"
+
   - name: "Backtick command substitution"
     stdin: |
       echo `echo hi`


### PR DESCRIPTION
Adds 5 new automated test cases for completion + gets them (mostly) passing:
* Completion under an empty dir
* Completion of a non-existent relative path
* Complete absolute file paths
* Complete file path containing variable (e.g., `$HOME`)
* Complete file path containing `~`

_(Note that we needed to leave 2 tests temporarily disabled as they pass only on certain versions of `bash-completion`. Rather than further complicate the PR; we will address them separately.)_

This entailed:
* Propagating exit results from failed command substitution through to assignments that depend on it.
* Targeted compatibility fix for limited set of `printf %q` cases
* Return 1 from `compgen` when no completions were generated
* Only filtering completions based on the token-being-completed for action-generated completions, not for those coming from an invoked function
* Stop unconditionally expanding token-being-completed in non-`compgen` scenarios