### PR TITLE
fix: slight compat improvements to set -x

### DIFF
--- a/brush-core/src/escape.rs
+++ b/brush-core/src/escape.rs
@@ -171,10 +171,10 @@ pub(crate) enum QuoteMode {
     Quote,
 }
 
-pub(crate) fn quote_if_needed(s: &str, mode: QuoteMode) -> String {
+pub(crate) fn quote_if_needed<S: AsRef<str>>(s: S, mode: QuoteMode) -> String {
     match mode {
-        QuoteMode::BackslashEscape => escape_with_backslash(s),
-        QuoteMode::Quote => escape_with_quoting(s),
+        QuoteMode::BackslashEscape => escape_with_backslash(s.as_ref()),
+        QuoteMode::Quote => escape_with_quoting(s.as_ref()),
     }
 }
 
@@ -197,7 +197,7 @@ fn escape_with_backslash(s: &str) -> String {
 
 fn escape_with_quoting(s: &str) -> String {
     // TODO: Handle single-quote!
-    if s.chars().any(needs_escaping) {
+    if s.is_empty() || s.chars().any(needs_escaping) {
         std::format!("'{s}'")
     } else {
         s.to_owned()
@@ -235,9 +235,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_escape() {
+    fn test_backslash_escape() {
         assert_eq!(quote_if_needed("a", QuoteMode::BackslashEscape), "a");
         assert_eq!(quote_if_needed("a b", QuoteMode::BackslashEscape), r"a\ b");
+        assert_eq!(quote_if_needed("", QuoteMode::BackslashEscape), "");
+    }
+
+    #[test]
+    fn test_quote_escape() {
+        assert_eq!(quote_if_needed("a", QuoteMode::Quote), "a");
+        assert_eq!(quote_if_needed("a b", QuoteMode::Quote), "'a b'");
+        assert_eq!(quote_if_needed("", QuoteMode::Quote), "''");
     }
 
     fn assert_echo_expands_to(unexpanded: &str, expected: &str) {

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -2,8 +2,11 @@ use brush_parser::ast;
 use std::path::Path;
 
 use crate::{
-    env, error, expansion, namedoptions, patterns,
-    sys::{fs::MetadataExt, fs::PathExt, users},
+    env, error, escape, expansion, namedoptions, patterns,
+    sys::{
+        fs::{MetadataExt, PathExt},
+        users,
+    },
     variables::{self, ArrayLiteral},
     Shell,
 };
@@ -47,7 +50,10 @@ async fn apply_unary_predicate(
     let expanded_operand = expansion::basic_expand_word(shell, operand).await?;
 
     if shell.options.print_commands_and_arguments {
-        shell.trace_command(std::format!("[[ {op} {expanded_operand} ]]"))?;
+        shell.trace_command(std::format!(
+            "[[ {op} {} ]]",
+            escape::quote_if_needed(&expanded_operand, escape::QuoteMode::Quote)
+        ))?;
     }
 
     apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell)

--- a/brush-shell/tests/cases/options.yaml
+++ b/brush-shell/tests/cases/options.yaml
@@ -39,9 +39,8 @@ cases:
         echo "Math checks"
       fi
 
-      # TODO: Re-enable these
-      # var=" "
-      # [[ ${var} && ! ${var//[[:space:]]/} ]]
+      var="x"
+      [[ ${var} && ${var//[[:space:]]/} ]]
 
       for ((i = 0; i < 3; i++)); do
         echo $i


### PR DESCRIPTION
Does a better job of single-quoting words that need it in simple commands (and some cases of extended test expressions.