### PR TITLE
fix: honor IFS in read builtin

### DIFF
--- a/brush-core/src/builtins/read.rs
+++ b/brush-core/src/builtins/read.rs
@@ -91,10 +91,7 @@ impl builtins::Command for ReadCommand {
         let input_line = self.read_line(input_stream, context.stdout())?;
 
         if let Some(input_line) = input_line {
-            let mut fields: VecDeque<_> = input_line
-                .split_ascii_whitespace()
-                .map(|field| field.to_owned())
-                .collect();
+            let mut fields: VecDeque<_> = split_line_by_ifs(&context, input_line.as_str());
 
             // If -a was specified, then place the fields as elements into the array.
             if let Some(array_variable) = &self.array_variable {
@@ -273,4 +270,14 @@ impl ReadCommand {
         }
         Ok(orig_term_attr)
     }
+}
+
+fn split_line_by_ifs(context: &commands::ExecutionContext<'_>, line: &str) -> VecDeque<String> {
+    // Retrieve effective value of IFS for splitting.
+    let ifs = context.shell.get_ifs();
+    let split_chars: Vec<char> = ifs.chars().collect();
+
+    line.split(split_chars.as_slice())
+        .map(|field| field.to_owned())
+        .collect()
 }

--- a/brush-shell/tests/cases/builtins/read.yaml
+++ b/brush-shell/tests/cases/builtins/read.yaml
@@ -29,3 +29,10 @@ cases:
     stdin: |
       read myvar < <(echo hello)
       echo "myvar: ${myvar}"
+
+  - name: "read with custom IFS"
+    stdin: |
+      content="    a    b    c "
+      while IFS= read line; do
+          echo "LINE: '$line'"
+      done <<<"${content}"


### PR DESCRIPTION
Ensure that splitting happening in `read` honors the current effective value of `IFS` in the current environment.

Among other things, this fixes completion for arguments to `tar`. (The custom completion routines for `tar` in `bash-completion` do custom parsing of the `--help` output of `tar`; that parsing required `read`ing in that output and using complex regexes to match against it.)