### PR TITLE
fix: leave trailing whitespace out of reedline completion suggestions

### DIFF
--- a/brush-interactive/src/reedline/completer.rs
+++ b/brush-interactive/src/reedline/completer.rs
@@ -62,6 +62,12 @@ impl ReedlineCompleter {
             }
         }
 
+        // See if there's whitespace at the end.
+        let append_whitespace = candidate.ends_with(' ');
+        if append_whitespace {
+            candidate.pop();
+        }
+
         reedline::Suggestion {
             value: candidate,
             description: None,
@@ -71,7 +77,7 @@ impl ReedlineCompleter {
                 start: insertion_index,
                 end: insertion_index + delete_count,
             },
-            append_whitespace: false, // TODO: compute this
+            append_whitespace,
         }
     }
 }


### PR DESCRIPTION
In the future we can simplify this (rather than having to postprocess the candidates), but this is a more targeted fix that works for now without a bit of refactoring.