### PR TITLE
feat: implement `kill -l`

### DIFF
--- a/brush-core/src/builtins/kill.rs
+++ b/brush-core/src/builtins/kill.rs
@@ -91,7 +91,7 @@ fn print_signals(
             let signal = s
                 .parse::<i32>()
                 .ok()
-                .map(|code| {
+                .and_then(|code| {
                     Signal::try_from(code)
                         .map(|s| {
                             // bash compatinility. `SIGHUP` -> `HUP`
@@ -99,7 +99,6 @@ fn print_signals(
                         })
                         .ok()
                 })
-                .flatten()
                 .or_else(|| {
                     // bash compatibility:
                     // support for names without `SIG`, for example `HUP` -> `SIGHUP`
@@ -117,10 +116,10 @@ fn print_signals(
             if let Some(signal) = signal {
                 match signal {
                     Sigspec::Signum(n) => {
-                        writeln!(context.stdout(), "{}", n)?;
+                        writeln!(context.stdout(), "{n}")?;
                     }
                     Sigspec::Sigspec(s) => {
-                        writeln!(context.stdout(), "{}", s)?;
+                        writeln!(context.stdout(), "{s}")?;
                     }
                 }
             } else {
@@ -135,7 +134,7 @@ fn print_signals(
         }
     } else {
         for i in Signal::iterator() {
-            writeln!(context.stdout(), "{}", i)?;
+            writeln!(context.stdout(), "{i}")?;
         }
     }
 

--- a/brush-core/src/builtins/kill.rs
+++ b/brush-core/src/builtins/kill.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
+use nix::sys::signal::Signal;
 use std::io::Write;
+use std::str::FromStr;
 
 use crate::{builtins, commands, error};
 
@@ -37,14 +39,12 @@ impl builtins::Command for KillCommand {
         }
 
         if self.list_signals {
-            error::unimp("kill -l")
+            return print_signals(&context, self.args.as_ref());
         } else {
             if self.args.len() != 1 {
                 writeln!(context.stderr(), "{}: invalid usage", context.command_name)?;
                 return Ok(builtins::ExitCode::InvalidUsage);
             }
-
-            let exit_code = builtins::ExitCode::Success;
 
             let pid_or_job_spec = &self.args[0];
             if pid_or_job_spec.starts_with('%') {
@@ -67,8 +67,77 @@ impl builtins::Command for KillCommand {
                 nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), nix::sys::signal::SIGKILL)
                     .map_err(|_errno| error::Error::FailedToSendSignal)?;
             }
+        }
+        Ok(builtins::ExitCode::Success)
+    }
+}
 
-            Ok(exit_code)
+fn print_signals(
+    context: &commands::ExecutionContext<'_>,
+    signals: &[String],
+) -> Result<builtins::ExitCode, error::Error> {
+    let mut exit_code = builtins::ExitCode::Success;
+    // TODO: `0 EXIT` signal is missing. It is not in the posix spec, but it exists in Bash
+    // https://man7.org/linux/man-pages/man7/signal.7.html
+    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html
+    if !signals.is_empty() {
+        for s in signals {
+            // If the user gives us a code, we print the name; if they give a name, we print its
+            // code.
+            enum Sigspec {
+                Sigspec(&'static str),
+                Signum(i32),
+            }
+            let signal = s
+                .parse::<i32>()
+                .ok()
+                .map(|code| {
+                    Signal::try_from(code)
+                        .map(|s| {
+                            // bash compatinility. `SIGHUP` -> `HUP`
+                            Sigspec::Sigspec(s.as_str().strip_prefix("SIG").unwrap_or(s.as_str()))
+                        })
+                        .ok()
+                })
+                .flatten()
+                .or_else(|| {
+                    // bash compatibility:
+                    // support for names without `SIG`, for example `HUP` -> `SIGHUP`
+                    let mut sig_str = String::with_capacity(3 + s.len());
+                    if s.len() >= 3 && s[..3] != *"SIG" {
+                        sig_str.push_str("SIG");
+                        sig_str.push_str(s.as_str());
+                    } else {
+                        sig_str.push_str(s.as_str());
+                    }
+                    Signal::from_str(sig_str.as_str())
+                        .ok()
+                        .map(|s| Sigspec::Signum(s as i32))
+                });
+            if let Some(signal) = signal {
+                match signal {
+                    Sigspec::Signum(n) => {
+                        writeln!(context.stdout(), "{}", n)?;
+                    }
+                    Sigspec::Sigspec(s) => {
+                        writeln!(context.stdout(), "{}", s)?;
+                    }
+                }
+            } else {
+                writeln!(
+                    context.stderr(),
+                    "{}: {}: invalid signal specification",
+                    context.command_name,
+                    s
+                )?;
+                exit_code = builtins::ExitCode::Custom(1);
+            }
+        }
+    } else {
+        for i in Signal::iterator() {
+            writeln!(context.stdout(), "{}", i)?;
         }
     }
+
+    Ok(exit_code)
 }

--- a/brush-core/src/builtins/kill.rs
+++ b/brush-core/src/builtins/kill.rs
@@ -110,8 +110,11 @@ fn print_signals(
             }
         }
     } else {
-        return crate::traps::format_signals(context.stdout(), TrapSignal::iterator())
-            .map(|()| builtins::ExitCode::Success);
+        return crate::traps::format_signals(
+            context.stdout(),
+            TrapSignal::iterator().filter(|s| !matches!(s, TrapSignal::Exit)),
+        )
+        .map(|()| builtins::ExitCode::Success);
     }
 
     Ok(exit_code)

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -487,10 +487,9 @@ impl Spec {
                     }
                 }
                 CompleteAction::Signal => {
-                    for signal in traps::TrapSignal::all_values() {
-                        let signal_str = signal.to_string();
-                        if signal_str.starts_with(token) {
-                            candidates.insert(signal_str);
+                    for signal in traps::TrapSignal::iterator() {
+                        if signal.as_str().starts_with(token) {
+                            candidates.insert(signal.as_str().to_string());
                         }
                     }
                 }

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -148,8 +148,8 @@ pub enum Error {
     ThreadingError(#[from] tokio::task::JoinError),
 
     /// An invalid signal was referenced.
-    #[error("invalid signal")]
-    InvalidSignal,
+    #[error("{0}: invalid signal specification")]
+    InvalidSignal(String),
 
     /// A system error occurred.
     #[cfg(unix)]

--- a/brush-core/src/sys/stubs/signal.rs
+++ b/brush-core/src/sys/stubs/signal.rs
@@ -1,13 +1,5 @@
 use crate::{error, sys, traps};
 
-pub(crate) fn parse_numeric_signal(_signal: i32) -> Result<traps::TrapSignal, error::Error> {
-    Err(error::Error::InvalidSignal)
-}
-
-pub(crate) fn parse_os_signal_name(_signal: &str) -> Result<traps::TrapSignal, error::Error> {
-    Err(error::Error::InvalidSignal)
-}
-
 pub(crate) fn continue_process(_pid: sys::process::ProcessId) -> Result<(), error::Error> {
     error::unimp("continue process")
 }

--- a/brush-core/src/sys/unix/signal.rs
+++ b/brush-core/src/sys/unix/signal.rs
@@ -1,18 +1,4 @@
-use std::str::FromStr;
-
-use crate::{error, sys, traps};
-
-pub(crate) fn parse_numeric_signal(signal: i32) -> Result<traps::TrapSignal, error::Error> {
-    Ok(traps::TrapSignal::Signal(
-        nix::sys::signal::Signal::try_from(signal).map_err(|_| error::Error::InvalidSignal)?,
-    ))
-}
-
-pub(crate) fn parse_os_signal_name(signal: &str) -> Result<traps::TrapSignal, error::Error> {
-    Ok(traps::TrapSignal::Signal(
-        nix::sys::signal::Signal::from_str(signal).map_err(|_| error::Error::InvalidSignal)?,
-    ))
-}
+use crate::{error, sys};
 
 pub(crate) fn continue_process(pid: sys::process::ProcessId) -> Result<(), error::Error> {
     #[allow(clippy::cast_possible_wrap)]

--- a/brush-core/src/traps.rs
+++ b/brush-core/src/traps.rs
@@ -1,4 +1,9 @@
+use std::str::FromStr;
 use std::{collections::HashMap, fmt::Display};
+
+use itertools::Itertools as _;
+
+use crate::error;
 
 /// Type of signal that can be trapped in the shell.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
@@ -16,28 +21,120 @@ pub enum TrapSignal {
 
 impl Display for TrapSignal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            #[cfg(unix)]
-            TrapSignal::Signal(s) => s.fmt(f),
-            TrapSignal::Debug => write!(f, "DEBUG"),
-            TrapSignal::Err => write!(f, "ERR"),
-            TrapSignal::Exit => write!(f, "EXIT"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
 impl TrapSignal {
-    /// Returns all possible values of `TrapSignal`.
-    #[allow(unused_mut)]
-    pub fn all_values() -> Vec<TrapSignal> {
-        let mut signals = vec![TrapSignal::Debug, TrapSignal::Err, TrapSignal::Exit];
+    /// Returns all possible values of [`TrapSignal`].
+    pub fn iterator() -> impl Iterator<Item = TrapSignal> {
+        const SIGNALS: &[TrapSignal] = &[TrapSignal::Debug, TrapSignal::Err, TrapSignal::Exit];
+        let iter = SIGNALS.iter().copied();
 
         #[cfg(unix)]
-        for signal in nix::sys::signal::Signal::iterator() {
-            signals.push(TrapSignal::Signal(signal));
+        let iter = itertools::chain!(
+            iter,
+            nix::sys::signal::Signal::iterator().map(TrapSignal::Signal)
+        );
+
+        iter
+    }
+
+    /// Converts [`TrapSignal`] into its corresponding signal name as a [`&'static str`](str)
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            #[cfg(unix)]
+            TrapSignal::Signal(s) => s.as_str(),
+            TrapSignal::Debug => "DEBUG",
+            TrapSignal::Err => "ERR",
+            TrapSignal::Exit => "EXIT",
+        }
+    }
+}
+
+/// Formats [`Iterator<Item = TrapSignal>`](TrapSignal)  to the provided writer.
+///
+/// # Arguments
+///
+/// * `f` - Any type that implements [`std::io::Write`].
+/// * `it` - An iterator over the signals that will be formatted into the `f`.
+pub fn format_signals(
+    mut f: impl std::io::Write,
+    it: impl Iterator<Item = TrapSignal>,
+) -> Result<(), error::Error> {
+    let it = it
+        .sorted_by(|a, b| Ord::cmp(&i32::from(*a), &i32::from(*b)))
+        .format_with("\n", |s, f| f(&format_args!("{}) {s}", i32::from(s))));
+    write!(f, "{it}")?;
+    Ok(())
+}
+
+// implement s.parse::<TrapSignal>()
+impl FromStr for TrapSignal {
+    type Err = error::Error;
+    fn from_str(s: &str) -> Result<Self, <TrapSignal as FromStr>::Err> {
+        if let Ok(n) = s.parse::<i32>() {
+            TrapSignal::try_from(n)
+        } else {
+            TrapSignal::try_from(s)
+        }
+    }
+}
+
+// from a signal number
+impl TryFrom<i32> for TrapSignal {
+    type Error = error::Error;
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            32 => TrapSignal::Debug,
+            33 => TrapSignal::Err,
+            0 => TrapSignal::Exit,
+            #[cfg(unix)]
+            value => TrapSignal::Signal(
+                nix::sys::signal::Signal::try_from(value)
+                    .map_err(|_| error::Error::InvalidSignal(value.to_string()))?,
+            ),
+            #[cfg(not(unix))]
+            _ => return Err(error::Error::InvalidSignal(value.to_string())),
+        })
+    }
+}
+
+// from a signal name
+impl TryFrom<&str> for TrapSignal {
+    type Error = error::Error;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let mut s = value.to_ascii_uppercase();
+        // Bash compatibility:
+        // support for signal names without the `SIG` prefix, for example `HUP` -> `SIGHUP`
+        if !s.starts_with("SIG") {
+            s.insert_str(0, "SIG");
         }
 
-        signals
+        Ok(match s.as_str() {
+            "SIGDEBUG" => TrapSignal::Debug,
+            "SIGERR" => TrapSignal::Err,
+            "SIGEXIT" => TrapSignal::Exit,
+
+            #[cfg(unix)]
+            _ => nix::sys::signal::Signal::from_str(s.as_str())
+                .map(TrapSignal::Signal)
+                .map_err(|_| error::Error::InvalidSignal(value.into()))?,
+            #[cfg(not(unix))]
+            _ => return Err(error::Error::InvalidSignal(value.into())),
+        })
+    }
+}
+
+impl From<TrapSignal> for i32 {
+    fn from(value: TrapSignal) -> Self {
+        match value {
+            #[cfg(unix)]
+            TrapSignal::Signal(s) => s as i32,
+            TrapSignal::Debug => 32,
+            TrapSignal::Err => 33,
+            TrapSignal::Exit => 0,
+        }
     }
 }
 

--- a/brush-shell/tests/cases/builtins/kill.yaml
+++ b/brush-shell/tests/cases/builtins/kill.yaml
@@ -4,7 +4,8 @@ cases:
     ignore_stderr: true
     stdin: |
       for i in $(seq 1 31); do kill -l $i; done
-      for i in $(kill -l | sed -e "s/[[:digit:]]*)//g"); do echo $i; done
+      # limit the number of signals to 32. Realtime signals are not implemented yet.
+      for i in $(kill -l | sed -e "s/[[:digit:]]*)//g"); do echo $i; done | head -32
       # invalid option
       kill -l 9999
       kill -l HUP

--- a/brush-shell/tests/cases/builtins/kill.yaml
+++ b/brush-shell/tests/cases/builtins/kill.yaml
@@ -6,7 +6,6 @@ cases:
     # 1) .. 2) .. 3)  .. etc. instead of just a simple list
     stdin: |
       # kill -l
-      # kill -l 0 # TODO: EXIT signal
       kill -l 1
       kill -l 2
       kill -l 3
@@ -36,8 +35,14 @@ cases:
       kill -l 28
       kill -l 29
       kill -l 30
+      kill -l 31
       # invalid option
       kill -l 9999
       kill -l HUP
+      kill -l iNt
+      kill -l int
       kill -l SIGHUP
+      kill -l EXIT
+      kill -l ERR
+      kill -l DEBUG
 

--- a/brush-shell/tests/cases/builtins/kill.yaml
+++ b/brush-shell/tests/cases/builtins/kill.yaml
@@ -2,40 +2,9 @@ name: "Builtins: kill"
 cases:
   - name: "kill -l"
     ignore_stderr: true
-    # note that we dont use 'kill -l' because of the shape of the bash list
-    # 1) .. 2) .. 3)  .. etc. instead of just a simple list
     stdin: |
-      # kill -l
-      kill -l 1
-      kill -l 2
-      kill -l 3
-      kill -l 4
-      kill -l 5
-      kill -l 6
-      kill -l 7
-      kill -l 9
-      kill -l 10
-      kill -l 11
-      kill -l 12
-      kill -l 13
-      kill -l 14
-      kill -l 15
-      kill -l 16
-      kill -l 17
-      kill -l 18
-      kill -l 19
-      kill -l 20
-      kill -l 21
-      kill -l 22
-      kill -l 23
-      kill -l 24
-      kill -l 25
-      kill -l 26
-      kill -l 27
-      kill -l 28
-      kill -l 29
-      kill -l 30
-      kill -l 31
+      for i in $(seq 1 31); do kill -l $i; done
+      for i in $(kill -l | sed -e "s/[[:digit:]]*)//g"); do echo $i; done
       # invalid option
       kill -l 9999
       kill -l HUP
@@ -43,4 +12,5 @@ cases:
       kill -l int
       kill -l SIGHUP
       kill -l EXIT
+
 

--- a/brush-shell/tests/cases/builtins/kill.yaml
+++ b/brush-shell/tests/cases/builtins/kill.yaml
@@ -43,6 +43,4 @@ cases:
       kill -l int
       kill -l SIGHUP
       kill -l EXIT
-      kill -l ERR
-      kill -l DEBUG
 

--- a/brush-shell/tests/cases/builtins/kill.yaml
+++ b/brush-shell/tests/cases/builtins/kill.yaml
@@ -4,8 +4,8 @@ cases:
     ignore_stderr: true
     stdin: |
       for i in $(seq 1 31); do kill -l $i; done
-      # limit the number of signals to 32. Realtime signals are not implemented yet.
-      for i in $(kill -l | sed -e "s/[[:digit:]]*)//g"); do echo $i; done | head -32
+      # limit the number of signals to 31. Realtime signals are not implemented yet.
+      for i in $(kill -l | sed -e "s/[[:digit:]]*)//g"); do echo $i; done | head -31
       # invalid option
       kill -l 9999
       kill -l HUP

--- a/brush-shell/tests/cases/builtins/kill.yaml
+++ b/brush-shell/tests/cases/builtins/kill.yaml
@@ -1,0 +1,43 @@
+name: "Builtins: kill"
+cases:
+  - name: "kill -l"
+    ignore_stderr: true
+    # note that we dont use 'kill -l' because of the shape of the bash list
+    # 1) .. 2) .. 3)  .. etc. instead of just a simple list
+    stdin: |
+      # kill -l
+      # kill -l 0 # TODO: EXIT signal
+      kill -l 1
+      kill -l 2
+      kill -l 3
+      kill -l 4
+      kill -l 5
+      kill -l 6
+      kill -l 7
+      kill -l 9
+      kill -l 10
+      kill -l 11
+      kill -l 12
+      kill -l 13
+      kill -l 14
+      kill -l 15
+      kill -l 16
+      kill -l 17
+      kill -l 18
+      kill -l 19
+      kill -l 20
+      kill -l 21
+      kill -l 22
+      kill -l 23
+      kill -l 24
+      kill -l 25
+      kill -l 26
+      kill -l 27
+      kill -l 28
+      kill -l 29
+      kill -l 30
+      # invalid option
+      kill -l 9999
+      kill -l HUP
+      kill -l SIGHUP
+


### PR DESCRIPTION
Utilize `nix::signal::Signal` to print the all signals.

Note that `0 - EXIT` is missing for now because it is not posix, and I didn't find any documentation for the `EXIT` signal, except for the `trap` builtin https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html

> If a sigspec is 0 or EXIT, arg is executed when the shell exits. 