### PR TITLE
feat: implement support for ;;& and ;& in case items

### DIFF
--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -171,7 +171,6 @@ pub type CommandExecuteFunc = fn(
 pub type CommandContentFunc = fn(&str, ContentType) -> Result<String, error::Error>;
 
 /// Trait implemented by built-in shell commands.
-
 pub trait Command: Parser {
     /// Instantiates the built-in command with the given arguments.
     ///
@@ -238,7 +237,6 @@ pub trait Command: Parser {
 
 /// Trait implemented by built-in shell commands that take specially handled declarations
 /// as arguments.
-
 pub trait DeclarationCommand: Command {
     /// Stores the declarations within the command instance.
     ///

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -285,7 +285,8 @@ impl Pattern {
         }
 
         if self.multiline {
-            // Set option for multiline matching + set option for allowing '.' pattern to match newline.
+            // Set option for multiline matching + set option for allowing '.' pattern to match
+            // newline.
             regex_str.push_str("(?ms)");
         }
 
@@ -522,11 +523,11 @@ mod tests {
     #[test]
     fn test_pattern_word_translation() -> Result<()> {
         assert_eq!(
-            pattern_to_exact_regex_str(&vec![PatternPiece::Pattern("a*".to_owned())])?.as_str(),
+            pattern_to_exact_regex_str(vec![PatternPiece::Pattern("a*".to_owned())])?.as_str(),
             "^a.*$"
         );
         assert_eq!(
-            pattern_to_exact_regex_str(&vec![
+            pattern_to_exact_regex_str(vec![
                 PatternPiece::Pattern("a*".to_owned()),
                 PatternPiece::Literal("b".to_owned()),
             ])?
@@ -534,7 +535,7 @@ mod tests {
             "^a.*b$"
         );
         assert_eq!(
-            pattern_to_exact_regex_str(&vec![
+            pattern_to_exact_regex_str(vec![
                 PatternPiece::Literal("a*".to_owned()),
                 PatternPiece::Pattern("b".to_owned()),
             ])?

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -32,7 +32,6 @@ pub struct InteractivePrompt {
 }
 
 /// Represents a shell capable of taking commands from standard input.
-
 pub trait InteractiveShell {
     /// Returns an immutable reference to the inner shell object.
     fn shell(&self) -> impl AsRef<brush_core::Shell> + Send;

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -936,7 +936,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
 
     fn is_operator(&self, s: &str) -> bool {
         // Handle non-POSIX operators.
-        if !self.options.posix_mode && matches!(s, "<<<" | "&>" | "&>>") {
+        if !self.options.posix_mode && matches!(s, "<<<" | "&>" | "&>>" | ";;&" | ";&") {
             return true;
         }
 

--- a/brush-shell/tests/cases/compound_cmds/case.yaml
+++ b/brush-shell/tests/cases/compound_cmds/case.yaml
@@ -61,3 +61,55 @@ cases:
       a) echo "a";;
       b) echo "b"
       esac
+
+  - name: "Case with fall-through"
+    stdin: |
+      case "b" in
+      a) echo "a";;
+      b) echo "b";&
+      c) echo "c";;
+      d) echo "d";;
+      esac
+
+  - name: "Case with resuming switch"
+    stdin: |
+      case "b" in
+      a) echo "a";;
+      b) echo "b";;&
+      c) echo "c";;
+      *) echo "*";;
+      d) echo "d";;
+      esac
+
+  - name: "Case status values"
+    stdin: |
+      function yield() {
+        return $1
+      }
+
+      case "a" in
+      x) yield 10;;
+      a) yield 11;;
+      b) yield 12;;
+      esac
+      echo "1: $?"
+
+      case "a" in
+      b) yield 10;;
+      c) yield 11;;
+      esac
+      echo "2: $?"
+
+      case "a" in
+      a) yield 10;&
+      b) yield 11;;
+      c) yield 12;;
+      esac
+      echo "3: $?"
+
+      case "a" in
+      a) yield 10;;&
+      *) yield 11;;
+      x) yield 12;;
+      esac
+      echo "4: $?"


### PR DESCRIPTION
Implements support for bash extensions to case item terminators: `;;&` and `;&`.

Fixes one of the issues tracked by #222.