### PR TITLE
fix: allow usually-operator chars in regex parens

### DIFF
--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -420,7 +420,11 @@ peg::parser! {
         rule regex_word_piece() =
             word() {} /
             specific_operator("|") {} /
-            specific_operator("(") inner:regex_word() specific_operator(")") {}
+            specific_operator("(") parenthesized_regex_word()* specific_operator(")") {}
+
+        rule parenthesized_regex_word() =
+            regex_word_piece() /
+            !specific_operator(")") !specific_operator("]]") [_]
 
         rule name() -> &'input str =
             w:[Token::Word(_, _)] { w.to_str() }

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -215,6 +215,11 @@ cases:
         echo "Matches"
       fi
 
+  - name: "Regex with special chars in parens"
+    stdin: |
+      [[ "<" =~ (<) ]] && echo "1. Matched"
+      [[ ">" =~ (<) ]] && echo "2. Matched"
+
   - name: "Empty and space checks"
     stdin: |
       check() {


### PR DESCRIPTION
In an extended test command, the following example regex is not allowed:

```
[[ str =~ < ]]
```

But if it's placed in parentheses, it *is* allowed:

```
[[ str =~ (<) ]]
```

These changes relax our parser's restrictions on which tokens typically parsed as operators may be allowed in that context. We add a compat test case to confirm.