### PR TITLE
fix: assorted completion-related issues

### DIFF
--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -442,15 +442,11 @@ impl builtins::Command for CompGenCommand {
         let spec = self.common_args.create_spec();
         let token_to_complete = self.word.as_deref().unwrap_or_default();
 
-        // N.B. We basic-expand the token-to-be-completed first.
-        let mut throwaway_shell = context.shell.clone();
-        let expanded_token_to_complete = throwaway_shell
-            .basic_expand_string(token_to_complete)
-            .await
-            .unwrap_or_else(|_| token_to_complete.to_owned());
+        // We unquote the token-to-be-completed before passing it to the completion system.
+        let unquoted_token = brush_parser::unquote_str(token_to_complete);
 
         let completion_context = completion::Context {
-            token_to_complete: expanded_token_to_complete.as_str(),
+            token_to_complete: unquoted_token.as_str(),
             preceding_token: None,
             command_name: None,
             token_index: 0,

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -44,9 +44,7 @@ impl PrintfCommand {
             [fmt, arg] if fmt == "%s" => Ok(arg.clone()),
             // Special-case invocation of printf with %q-based format string from bash-completion.
             // It has hard-coded expectation of backslash-style escaping instead of quoting.
-            [fmt, arg] if fmt == "%q" || fmt == "~%q" => {
-                Ok(Self::evaluate_format_with_percent_q(None, arg))
-            }
+            [fmt, arg] if fmt == "%q" => Ok(Self::evaluate_format_with_percent_q(None, arg)),
             [fmt, arg] if fmt == "~%q" => Ok(Self::evaluate_format_with_percent_q(Some("~"), arg)),
             // Fallback to external command.
             _ => self.evaluate_via_external_command(context),

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -233,12 +233,20 @@ impl Shell {
         random_var.treat_as_integer();
         env.set_global("RANDOM", random_var)?;
 
+        // Parsing and completion vars
         env.set_global("IFS", ShellVariable::new(" \t\n".into()))?;
         env.set_global(
             "COMP_WORDBREAKS",
             ShellVariable::new(" \t\n\"\'><=;|&(:".into()),
         )?;
 
+        // getopts vars
+        env.set_global("OPTERR", ShellVariable::new("1".into()))?;
+        let mut optind_var = ShellVariable::new("1".into());
+        optind_var.treat_as_integer();
+        env.set_global("OPTIND", optind_var)?;
+
+        // OS info vars
         let os_type = match std::env::consts::OS {
             "linux" => "linux-gnu",
             "windows" => "windows",
@@ -256,6 +264,7 @@ impl Shell {
                 )?;
             }
         }
+
         #[cfg(unix)]
         if !env.is_set("PATH") {
             env.set_global(
@@ -273,7 +282,7 @@ impl Shell {
             env.set_global(
                 "BASH_VERSINFO",
                 ShellVariable::new(ShellValue::indexed_array_from_slice(
-                    ["5", "1", "1", "1", "release", "unknown"].as_slice(),
+                    ["5", "2", "15", "1", "release", "unknown"].as_slice(),
                 )),
             )?;
         }

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -15,4 +15,4 @@ mod tokenizer;
 
 pub use error::{ParseError, TestCommandParseError, WordParseError};
 pub use parser::{parse_tokens, Parser, ParserOptions, SourceInfo};
-pub use tokenizer::{tokenize_str, SourcePosition, Token, TokenLocation};
+pub use tokenizer::{tokenize_str, unquote_str, SourcePosition, Token, TokenLocation};

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -553,7 +553,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
 
                     let next_here_tag = &self.cross_state.current_here_tags[0];
                     let tag_str: Cow<'_, str> = if next_here_tag.tag_was_escaped_or_quoted {
-                        remove_quotes_from(next_here_tag.tag.as_str()).into()
+                        unquote_str(next_here_tag.tag.as_str()).into()
                     } else {
                         next_here_tag.tag.as_str().into()
                     };
@@ -1010,7 +1010,12 @@ fn is_quoting_char(c: char) -> bool {
     matches!(c, '\\' | '\'' | '\"')
 }
 
-fn remove_quotes_from(s: &str) -> String {
+/// Return a string with all the quoting removed.
+///
+/// # Arguments
+///
+/// * `s` - The string to unquote.
+pub fn unquote_str(s: &str) -> String {
     let mut result = String::new();
 
     let mut in_escape = false;
@@ -1392,9 +1397,9 @@ SOMETHING
 
     #[test]
     fn test_quote_removal() {
-        assert_eq!(remove_quotes_from(r#""hello""#), "hello");
-        assert_eq!(remove_quotes_from(r#"'hello'"#), "hello");
-        assert_eq!(remove_quotes_from(r#""hel\"lo""#), r#"hel"lo"#);
-        assert_eq!(remove_quotes_from(r#"'hel\'lo'"#), r#"hel'lo"#);
+        assert_eq!(unquote_str(r#""hello""#), "hello");
+        assert_eq!(unquote_str(r#"'hello'"#), "hello");
+        assert_eq!(unquote_str(r#""hel\"lo""#), r#"hel"lo"#);
+        assert_eq!(unquote_str(r#"'hel\'lo'"#), r#"hel'lo"#);
     }
 }

--- a/brush-shell/tests/cases/arrays.yaml
+++ b/brush-shell/tests/cases/arrays.yaml
@@ -275,3 +275,13 @@ cases:
     stdin: |
       x=(2 3 4)
       echo ${x[${x[0]}]}
+
+  - name: "Append array-resulting expansion to array"
+    skip: true # Need to asses on different bash versions
+    stdin: |
+      declare -a otherarray=("a" "b" "c")
+      declare -a ourarray=()
+
+      ourarray+=("${otherarray[@]/a/x}")
+      declare -p otherarray
+      declare -p ourarray

--- a/brush-shell/tests/cases/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/builtins/compgen.yaml
@@ -101,3 +101,14 @@ cases:
       for p in $(compgen -f '$HOME/'); do
         echo ${p//$HOME/HOME}
       done
+
+  - name: "compgen -f with quoted + escaped var"
+    known_failure: true
+    stdin: |
+      touch item1
+      HOME=$(pwd)
+
+      echo "[0]"
+      for p in $(compgen -f '\$HOME/'); do
+        echo ${p//$HOME/HOME}
+      done

--- a/brush-shell/tests/cases/builtins/getopts.yaml
+++ b/brush-shell/tests/cases/builtins/getopts.yaml
@@ -12,6 +12,7 @@ cases:
           esac
           echo "OPTIND is now ${OPTIND}"
           echo "OPTERR is now ${OPTERR}"
+        echo "----------------"
         done
         echo "Result: $?"
         echo "option: ${option}"
@@ -39,6 +40,7 @@ cases:
         echo "OPTARG: ${OPTARG}"
         echo "OPTIND: ${OPTIND}"
         echo "OPTERR: ${OPTERR}"
+        echo "----------------"
       done
       echo "Done; result: $?"
       echo "myvar: ${myvar}"
@@ -54,6 +56,7 @@ cases:
         echo "OPTARG: ${OPTARG}"
         echo "OPTIND: ${OPTIND}"
         echo "OPTERR: ${OPTERR}"
+        echo "----------------"
       done
       echo "Done; result: $?"
       echo "myvar: ${myvar}"
@@ -69,6 +72,7 @@ cases:
         echo "OPTARG: ${OPTARG}"
         echo "OPTIND: ${OPTIND}"
         echo "OPTERR: ${OPTERR}"
+        echo "----------------"
       done
       echo "Done; result: $?"
       echo "myvar: ${myvar}"
@@ -90,6 +94,22 @@ cases:
     stdin: |
       getopts "a:" myvar -b value
       echo "Result: $?"
+      echo "myvar: ${myvar}"
+      echo "OPTARG: ${OPTARG}"
+      echo "OPTIND: ${OPTIND}"
+      echo "OPTERR: ${OPTERR}"
+
+  - name: "getopts: multiple options in one token"
+    stdin: |
+      while getopts "a:bcdefg" myvar -fedcba something -g; do
+        echo "Result: $?"
+        echo "myvar: ${myvar}"
+        echo "OPTARG: ${OPTARG}"
+        echo "OPTIND: ${OPTIND}"
+        echo "OPTERR: ${OPTERR}"
+        echo "----------------"
+      done
+      echo "Done; result: $?"
       echo "myvar: ${myvar}"
       echo "OPTARG: ${OPTARG}"
       echo "OPTIND: ${OPTIND}"

--- a/brush-shell/tests/cases/builtins/printf.yaml
+++ b/brush-shell/tests/cases/builtins/printf.yaml
@@ -33,3 +33,14 @@ cases:
 
       echo "[3]"
       printf "%q" '"'; echo
+
+  - name: "printf ~%q"
+    stdin: |
+      echo "[1]"
+      printf "~%q" 'TEXT'; echo
+
+      echo "[2]"
+      printf "~%q" '$VAR'; echo
+
+      echo "[3]"
+      printf "~%q" '"'; echo

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -148,7 +148,6 @@ async fn complete_absolute_paths() -> Result<()> {
     Ok(())
 }
 
-#[ignore] // TODO: Fix this for newer versions of bash-completion
 #[tokio::test]
 async fn complete_path_with_var() -> Result<()> {
     let mut test_shell = TestShellWithBashCompletion::new().await?;
@@ -182,7 +181,6 @@ async fn complete_path_with_var() -> Result<()> {
     Ok(())
 }
 
-#[ignore] // TODO: Fix this for newer versions of bash-completion
 #[tokio::test]
 async fn complete_path_with_tilde() -> Result<()> {
     let mut test_shell = TestShellWithBashCompletion::new().await?;


### PR DESCRIPTION
* Unquote the token-to-be-completed passed into `compgen`
* Support multiple-options-in-one-token in `getopts` (e.g., `-abc` as shorthand for `-a` `-b` `-c`)
* Initialize `OPTIND`, `OPTERR` in each newly constructed shell.
* Fix bug in `printf` hack for `%q` and `~%q`.
* Don't filter out file/dir completions whose prefixes don't match the token-being-completed (e.g., for `~` et al.).
* For file/dir completions, basic-expand the token-to-be-completed (we formerly did this higher up the stack).
* Express compatibility with a slightly newer version of `bash` (5.2.x).
* Re-enable some previously disabled tests.