### PR TITLE
fix: string replacement with slashes

### DIFF
--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -704,7 +704,7 @@ peg::parser! {
             s:$(arithmetic_word(<[':' | '}']>)) { ast::UnexpandedArithmeticExpr { value: s.to_owned() } }
 
         rule parameter_replacement_str() -> String =
-            "/" s:$(word(<['}' | '/']>)) { s.to_owned() }
+            "/" s:$(word(<['}']>)) { s.to_owned() }
 
         rule parameter_search_pattern() -> String =
             s:$(word(<['}' | '/']>)) { s.to_owned() }

--- a/brush-shell/tests/cases/arrays.yaml
+++ b/brush-shell/tests/cases/arrays.yaml
@@ -277,7 +277,6 @@ cases:
       echo ${x[${x[0]}]}
 
   - name: "Append array-resulting expansion to array"
-    skip: true # Need to asses on different bash versions
     stdin: |
       declare -a otherarray=("a" "b" "c")
       declare -a ourarray=()

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -595,6 +595,11 @@ cases:
       echo "\${arr[@]/world/WORLD}: ${arr[@]/world/WORLD}"
       echo "\${arr[*]/world/WORLD}: ${arr[*]/world/WORLD}"
 
+  - name: "Substring replacement with slashes"
+    stdin: |
+      var="Hello, world!"
+      echo "\${var/world//world}: ${var/world//world}"
+
   - name: "Prefix substring replacement"
     stdin: |
       var="Hello, world!"


### PR DESCRIPTION
Fixes the case where a string replacement contains `/` chars, e.g.:

```bash
${value/pattern/some/replacement}
```
