### PR TITLE
fix: correct pattern removal expansions on arrays

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -777,59 +777,48 @@ impl<'a> WordExpander<'a> {
                 indirect,
                 pattern,
             } => {
-                let expanded_parameter: String =
-                    self.expand_parameter(&parameter, indirect).await?.into();
+                let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
                 let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
-                let result = patterns::remove_smallest_matching_suffix(
-                    expanded_parameter.as_str(),
-                    &expanded_pattern,
-                )?;
-                Ok(Expansion::from(result.to_owned()))
+                transform_expansion(expanded_parameter, |s| {
+                    patterns::remove_smallest_matching_suffix(s.as_str(), &expanded_pattern)
+                        .map(|s| s.to_owned())
+                })
             }
             brush_parser::word::ParameterExpr::RemoveLargestSuffixPattern {
                 parameter,
                 indirect,
                 pattern,
             } => {
-                let expanded_parameter: String =
-                    self.expand_parameter(&parameter, indirect).await?.into();
+                let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
                 let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
-                let result = patterns::remove_largest_matching_suffix(
-                    expanded_parameter.as_str(),
-                    &expanded_pattern,
-                )?;
-
-                Ok(Expansion::from(result.to_owned()))
+                transform_expansion(expanded_parameter, |s| {
+                    patterns::remove_largest_matching_suffix(s.as_str(), &expanded_pattern)
+                        .map(|s| s.to_owned())
+                })
             }
             brush_parser::word::ParameterExpr::RemoveSmallestPrefixPattern {
                 parameter,
                 indirect,
                 pattern,
             } => {
-                let expanded_parameter: String =
-                    self.expand_parameter(&parameter, indirect).await?.into();
+                let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
                 let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
-                let result = patterns::remove_smallest_matching_prefix(
-                    expanded_parameter.as_str(),
-                    &expanded_pattern,
-                )?;
-
-                Ok(Expansion::from(result.to_owned()))
+                transform_expansion(expanded_parameter, |s| {
+                    patterns::remove_smallest_matching_prefix(s.as_str(), &expanded_pattern)
+                        .map(|s| s.to_owned())
+                })
             }
             brush_parser::word::ParameterExpr::RemoveLargestPrefixPattern {
                 parameter,
                 indirect,
                 pattern,
             } => {
-                let expanded_parameter: String =
-                    self.expand_parameter(&parameter, indirect).await?.into();
+                let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
                 let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
-                let result = patterns::remove_largest_matching_prefix(
-                    expanded_parameter.as_str(),
-                    &expanded_pattern,
-                )?;
-
-                Ok(Expansion::from(result.to_owned()))
+                transform_expansion(expanded_parameter, |s| {
+                    patterns::remove_largest_matching_prefix(s.as_str(), &expanded_pattern)
+                        .map(|s| s.to_owned())
+                })
             }
             brush_parser::word::ParameterExpr::Substring {
                 parameter,

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -813,3 +813,17 @@ cases:
 
       echo "{2..9..2}"
       echo {2..9..2}
+
+  - name: "Iterate through modified array"
+    stdin: |
+      array=("aa" "ba" "ca")
+
+      echo "With quotes:"
+      for i in "${array[@]%a}"; do
+          echo "Element: '$i'"
+      done
+
+      echo "Without quotes:"
+      for i in ${array[@]%a}; do
+          echo "Element: '$i'"
+      done


### PR DESCRIPTION
This was missed when the other expansions were retrofitted to support arrays; uses existing `transform_expansion` helper to simplify the work of iteratively transforming all elements of the array.