### PR TITLE
fix(completion): fix -- handling in getopts

### DIFF
--- a/brush-core/src/builtins/getopts.rs
+++ b/brush-core/src/builtins/getopts.rs
@@ -21,6 +21,20 @@ pub(crate) struct GetOptsCommand {
 const VAR_GETOPTS_NEXT_CHAR_INDEX: &str = "__GETOPTS_NEXT_CHAR";
 
 impl builtins::Command for GetOptsCommand {
+    /// Override the default [`builtins::Command::new`] function to handle clap's limitation related
+    /// to `--`. See [`builtins::parse_known`] for more information
+    /// TODO: we can safely remove this after the issue is resolved
+    fn new<I>(args: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let (mut this, rest_args) = crate::builtins::try_parse_known::<GetOptsCommand>(args)?;
+        if let Some(args) = rest_args {
+            this.args.extend(args);
+        }
+        Ok(this)
+    }
+
     #[allow(clippy::too_many_lines)]
     async fn execute(
         &self,

--- a/brush-shell/tests/cases/builtins/getopts.yaml
+++ b/brush-shell/tests/cases/builtins/getopts.yaml
@@ -80,6 +80,22 @@ cases:
       echo "OPTIND: ${OPTIND}"
       echo "OPTERR: ${OPTERR}"
 
+  - name: "getopts: -- as first arg"
+    stdin: |
+      while getopts "ab:" myvar -- -a; do
+        echo "Result: $?"
+        echo "myvar: ${myvar}"
+        echo "OPTARG: ${OPTARG}"
+        echo "OPTIND: ${OPTIND}"
+        echo "OPTERR: ${OPTERR}"
+        echo "----------------"
+      done
+      echo "Done; result: $?"
+      echo "myvar: ${myvar}"
+      echo "OPTARG: ${OPTARG}"
+      echo "OPTIND: ${OPTIND}"
+      echo "OPTERR: ${OPTERR}"
+
   - name: "getopts: invalid option when optstr starts with colon"
     stdin: |
       getopts ":a:" myvar -b value


### PR DESCRIPTION
* Apply the same workaround to `getopts` that was added for `echo` in #147.
* Add a test case to cover `--` being passed as the first arg to `getopts` after the variable name.