### PR TITLE
fix: omit dirs from executable searches

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -895,7 +895,7 @@ impl Shell {
     /// * `required_glob_pattern` - The glob pattern to match against.
     #[allow(clippy::manual_flatten)]
     pub fn find_executables_in_path(&self, required_glob_pattern: &str) -> Vec<PathBuf> {
-        let is_executable = |path: &Path| path.executable();
+        let is_executable = |path: &Path| path.is_file() && path.executable();
 
         let mut executables = vec![];
         for dir_str in self.env.get_str("PATH").unwrap_or_default().split(':') {


### PR DESCRIPTION
We were already filtering on executables, but forgot to filter on being a _file_. Among other things, this fixed an issue spotted in completion of help topics.