### PR TITLE
fix(completion): correct behavior of slice past end of array

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -853,9 +853,7 @@ impl<'a> WordExpander<'a> {
                 let expanded_offset = usize::try_from(expanded_offset)?;
 
                 let expanded_parameter_len = expanded_parameter.polymorphic_len();
-                if expanded_offset >= expanded_parameter_len {
-                    return Ok(Expansion::from(String::new()));
-                }
+                let expanded_offset = min(expanded_offset, expanded_parameter_len);
 
                 let end_offset = if let Some(length) = length {
                     let mut expanded_length = length.eval(self.shell, false).await?;

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -668,6 +668,16 @@ cases:
       echo "\${myarray[@]:2:2}: ${myarray[@]:2:2}"
       echo "\${myarray[@]:2}: ${myarray[@]:2}"
 
+  - name: "Substring operator past end of array"
+    stdin: |
+      set a b c
+      declare -a result1=("${@:3}")
+      declare -p result1
+
+      myarray=(a b c)
+      declare -a result2=("${myarray[@]:3}")
+      declare -p result2
+
   - name: "Substring with length (with nested expressions)"
     stdin: |
       var="Hello, world!"


### PR DESCRIPTION
When using the substring/slice operator past the end of an array, make sure not to yield an empty string.