### PR TITLE
test: run completion tests using bash-completion 2.14.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,6 +164,17 @@ jobs:
           ${BASH_PATH} --version
           echo "BASH_PATH=${BASH_PATH}">>$GITHUB_ENV
 
+      - name: "Download recent bash-completion sources for tests"
+        uses: actions/checkout@v4
+        with:
+          repository: "scop/bash-completion"
+          ref: "2.14.0"
+          path: "bash-completion"
+
+      - name: "Setup bash-completion"
+        run: |
+          echo "BASH_COMPLETION_PATH=${GITHUB_WORKSPACE}/bash-completion/bash_completion">>$GITHUB_ENV
+
       - name: Test
         run: |
           set -euxo pipefail

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -25,6 +25,10 @@ harness = false
 name = "brush-interactive-tests"
 path = "tests/interactive_tests.rs"
 
+[[test]]
+name = "brush-completion-tests"
+path = "tests/completion_tests.rs"
+
 [features]
 default = ["basic", "reedline"]
 basic = []


### PR DESCRIPTION
* Enable running completion tests using an alternate installation of `bash-completion` (via `BASH_COMPLETION_PATH` variable)
* Add another relatively simple completion test
* Update CI workflow to download `bash-completion` v2.14.0 and run `brush-completion-tests` with it