### PR TITLE
build: run cargo udeps in checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -277,6 +277,27 @@ jobs:
         if: matrix.rust-version == 'stable'
         run: cargo clippy --all-features --all-targets
 
+  # Check for unneeded dependencies.
+  check-deps:
+    name: "Check for unneeded dependencies"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up nightly rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Install cargo-udeps
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps
+
+      - name: Check for unused dependencies
+        run: cargo udeps --workspace --all-targets --all-features
+
   # Performance analysis of the code.
   benchmark:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Checks for unneeded dependencies in the project's crates.