### PR TITLE
build: run lychee to check intra-repo links in action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,28 @@
+name: "Docs"
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+  CLICOLOR_FORCE: 1
+
+jobs:
+  # Check links in docs
+  check-links:
+    name: "Check links"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Check repo-local links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: ". --offline --verbose --no-progress"
+          fail: true


### PR DESCRIPTION
We run in `--offline` mode to avoid network traffic originated by potentially untrusted content.