### PR TITLE
feat: implement  `$SHLVL` and `$BASH_SUBSHELL`

### DIFF
--- a/brush-shell/tests/cases/compound_cmds/subshell.yaml
+++ b/brush-shell/tests/cases/compound_cmds/subshell.yaml
@@ -23,3 +23,37 @@ cases:
   - name: "Piped subshell usage"
     stdin: |
       (echo hi) | wc -l
+
+  - name: "SHLVL subshell"
+    stdin: |
+      initial="$SHLVL"
+      function rec_subshell {
+          if [ "$1" -ge "$2" ]; then
+              exit
+          else
+              (
+                  test $initial -eq $SHLVL; echo $?
+                  rec_subshell $(($1 + 1)) $2
+              )
+          fi
+      }
+      rec_subshell 1 10
+
+
+  - name: "BASH_SUBSHELL"
+    stdin: |
+      initial="$BASH_SUBSHELL"
+
+      function rec_subshell {
+          if [ "$1" -ge "$2" ]; then
+              exit
+          else
+              (
+                  test $initial -ne $BASH_SUBSHELL; echo $?
+                  echo $BASH_SUBSHELL
+                  initial=$BASH_SUBSHELL
+                  rec_subshell $(($1 + 1)) $2
+              )
+          fi
+      }
+      rec_subshell 1 10


### PR DESCRIPTION
Implementation of `$SHLVL` and `$BASH_SUBSHELL` variables. https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html.

### SHLVL
> Incremented by one each time a new instance of Bash is started. This is intended to be a count of how deeply your Bash shells are nested. 

### BASH_SUBSHELL

> Incremented by one within each subshell or subshell environment when the shell begins executing in that environment. The initial value is 0. If BASH_SUBSHELL is unset, it loses its special properties, even if it is subsequently reset. 

Im not sure how to test `SHLVL`, because it requires starting a new shell inside the test.