### PR TITLE
fix: the heredoc inside a substitution

### DIFF
--- a/brush-shell/tests/cases/here.yaml
+++ b/brush-shell/tests/cases/here.yaml
@@ -39,3 +39,14 @@ cases:
       shopt -ou posix
       cat <<<"Something here."
       wc -l <<<"Something"
+
+  - name: "Here doc in a command substitution"
+    stdin: |
+      test1=$(cat <<EOF
+      1
+      2 3
+      4 5 6
+      EOF
+      )
+
+      echo "${test1}"


### PR DESCRIPTION
Addressed: #234 

I've got your branch and added a test to replicate the issue. `parser::tests::parse_subshell_with_heredoc`. When the subshell is invoked, the ending here tag is alredy stripped.

1. after the initial tokenezing, the word is `$(cat <<EOF 1\n\n)`
2. running the expansion
3. the word becomes `s = "cat <<EOF 1\n\n"`
4. starting a subshell: `let result = subshell.run_string(s, &params).await?;` in `expansion.rs`at the  L530.
5. getting an error:
```
Err( Tokenizing { inner: UnterminatedHereDocuments( "EOF1", "line 1 col 11", ), position: Some( SourcePosition { index: 22, line: 5, column: 1, }, ), },)
```
6. subshell returns exit_code 2

I don't know how to fix this issue yet though