### PR TITLE
fix: support here documents in command substitutions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "indenter",
  "peg",
  "pprof",
+ "pretty_assertions",
  "thiserror",
  "tracing",
  "utf8-chars",
@@ -1741,6 +1742,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2973,12 @@ dependencies = [
  "clap-markdown",
  "clap_mangen",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -439,7 +439,7 @@ impl Shell {
             brush_parser::Parser::new(&mut reader, &self.parser_options(), source_info);
 
         tracing::debug!(target: trace_categories::PARSE, "Parsing sourced file: {}", source_info.source);
-        let parse_result = parser.parse(false);
+        let parse_result = parser.parse();
 
         let mut other_positional_parameters = args.iter().map(|s| s.as_ref().to_owned()).collect();
         let mut other_shell_name = Some(source_info.source.clone());
@@ -1180,5 +1180,5 @@ fn parse_string_impl(
         brush_parser::Parser::new(&mut reader, &parser_options, &source_info);
 
     tracing::debug!(target: trace_categories::PARSE, "Parsing string as program...");
-    parser.parse(true)
+    parser.parse()
 }

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -30,6 +30,7 @@ utf8-chars = "3.0.5"
 anyhow = "1.0.91"
 assert_matches = "1.5.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.13.0", features = ["criterion", "flamegraph"] }

--- a/brush-shell/tests/cases/here.yaml
+++ b/brush-shell/tests/cases/here.yaml
@@ -1,6 +1,14 @@
 name: "Here docs/strings"
 cases:
   - name: "Basic here doc"
+    stdin: |
+      cat <<END-MARKER
+      Something here...
+      ...and here.
+      END-MARKER
+      echo "This is after"
+
+  - name: "Basic here doc in a script"
     test_files:
       - path: "script.sh"
         contents: |
@@ -39,3 +47,56 @@ cases:
       shopt -ou posix
       cat <<<"Something here."
       wc -l <<<"Something"
+
+  - name: "Empty here doc"
+    stdin: |
+      wc -l <<EOF
+      EOF
+
+  - name: "Here doc with other tokens after tag"
+    stdin: |
+      wc -l <<EOF | wc -l
+      A B C
+      1 2 3
+      EOF
+
+  - name: "Multiple here docs"
+    stdin: |
+      cat <<EOF1 <<EOF2
+      A B C
+      EOF1
+      1 2 3
+      EOF2
+
+  - name: "Here doc in a command substitution"
+    stdin: |
+      test1=$(cat <<EOF
+      1
+      2 3
+      4 5 6
+      EOF
+      )
+
+      echo "${test1}"
+
+  - name: "Multiple here docs in a command substitution"
+    stdin: |
+      test1=$(cat <<EOF1 <<EOF2
+      A B C
+      EOF1
+      D E F
+      EOF2
+      )
+
+      echo "${test1}"
+
+  - name: "Complex here docs in a command substitution"
+    stdin: |
+      test1=$(cat <<EOF1 <<EOF2 | wc -l
+      A B C
+      EOF1
+      D E F
+      EOF2
+      )
+
+      echo "${test1}"


### PR DESCRIPTION
The main challenge that we've encountered here is that tokenization of a here-document in `brush` has previously not included *all* pieces of the original input; notably it omitted yielding the matching closing tag, since it was not strictly needed by the parser. While testing these changes, we found deeper challenges with empty here-documents and multiple here-documents (potentially mixed with non-redirection tokens on the initial command line).

While there is opportunity to improve this in the future, the main design we're going with:

* Tokenizer reorders tokens so that the redirection operation, start here tag, here document body, and end here tag are consecutive. This simplifies life for the parser so it doesn't need to maintain a FIFO-based here tag state, which would be tricky to do in our current PEG-based parser.
* For command substitutions and subshells, the tokenizer needs to *re-reorder* those tokens to reproduce the original textual order.
* Tokenizer yields sufficiently rich token delimit reasons so that the caller can re-insert newlines in the right places if needed.

Additionally:

* Adds tests to cover more interesting here-document scenarios, including when embedded in command substitutions.
* Adds more possible branches to the `TokenEndReason` type to yield richer contextual information to the tokenizer caller.
* Switches parser tests over to using `pretty_assertions` for easier to read error output.

Resolves #234.

