### PR TITLE
fix: multiple issues blocking docker cmd completion

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -543,6 +543,7 @@ impl<'a> WordExpander<'a> {
                 let mut fields: Vec<WordField> = vec![];
 
                 let pieces_is_empty = pieces.is_empty();
+                let concatenation_joiner = self.shell.get_ifs_first_char();
 
                 for piece in pieces {
                     let Expansion {
@@ -561,7 +562,9 @@ impl<'a> WordExpander<'a> {
                                     .map(|piece| piece.make_unsplittable())
                                     .collect()
                             })
-                            .intersperse(vec![ExpansionPiece::Unsplittable(String::from(" "))])
+                            .intersperse(vec![ExpansionPiece::Unsplittable(
+                                concatenation_joiner.to_string(),
+                            )])
                             .flatten()
                             .collect();
 

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -883,6 +883,11 @@ impl Shell {
         )
     }
 
+    /// Returns the first character of the IFS variable, or a space if it is not set.
+    pub(crate) fn get_ifs_first_char(&self) -> char {
+        self.get_ifs().chars().next().unwrap_or(' ')
+    }
+
     /// Generates command completions for the shell.
     ///
     /// # Arguments

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -226,6 +226,12 @@ impl ShellVariable {
                 ) => {
                     self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
                 }
+                // If we're appending a scalar to a declared-but-unset variable, then
+                // start with the empty string. This will result in the right thing happening,
+                // even in treat-as-integer cases.
+                (ShellValue::Unset(_), ShellValueLiteral::Scalar(_)) => {
+                    self.assign(ShellValueLiteral::Scalar(String::new()), false)?;
+                }
                 // If we're trying to append an array to a string, we first promote the string to be
                 // an array with the string being present at index 0.
                 (ShellValue::String(_), ShellValueLiteral::Array(_)) => {
@@ -273,7 +279,7 @@ impl ShellVariable {
                         )
                     }
                 },
-                ShellValue::Unset(_) => error::unimp("appending to unset variable"),
+                ShellValue::Unset(_) => unreachable!("covered in conversion above"),
                 ShellValue::Random => Ok(()),
             }
         } else {
@@ -826,6 +832,12 @@ impl From<&str> for ShellValue {
 impl From<&String> for ShellValue {
     fn from(value: &String) -> Self {
         ShellValue::String(value.clone())
+    }
+}
+
+impl From<String> for ShellValue {
+    fn from(value: String) -> Self {
+        ShellValue::String(value)
     }
 }
 

--- a/brush-shell/tests/cases/arrays.yaml
+++ b/brush-shell/tests/cases/arrays.yaml
@@ -297,3 +297,13 @@ cases:
       }
 
       outer
+
+  - name: "Array element expansion with non-standard IFS"
+    stdin: |
+      IFS='|'
+
+      declare -a myarray=(abc 1 f)
+      echo "\"\${myarray[@]}\": ${myarray[@]}"
+      echo "\"\${myarray[*]}\": ${myarray[*]}"
+      echo "\${myarray[@]}:" ${myarray[@]}
+      echo "\${myarray[*]}:" ${myarray[*]}

--- a/brush-shell/tests/cases/variables.yaml
+++ b/brush-shell/tests/cases/variables.yaml
@@ -5,3 +5,13 @@ cases:
       x=something
       x+=here
       echo "x: ${x}"
+
+  - name: "Append to an unset variable"
+    stdin: |
+      declare -a myvar
+      myvar+=abc
+      echo "myvar: ${myvar}"
+
+      declare -i myint
+      myint+=abc
+      echo "myint: ${myint}"


### PR DESCRIPTION
Enables appending scalar values to declared but uninitialized variables. 

Fixes concatenation of array values with non-default IFS values. 