### PR TITLE
feat(prompts): enable PS0, custom right-side prompts, more

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -940,10 +940,7 @@ impl<'a> WordExpander<'a> {
                 op,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-
-                transform_expansion(expanded_parameter, |s| {
-                    self.apply_transform_to(&op, s.as_str())
-                })
+                transform_expansion(expanded_parameter, |s| self.apply_transform_to(&op, s))
             }
             brush_parser::word::ParameterExpr::UppercaseFirstChar {
                 parameter,
@@ -1455,18 +1452,20 @@ impl<'a> WordExpander<'a> {
     fn apply_transform_to(
         &self,
         op: &ParameterTransformOp,
-        s: &str,
+        s: String,
     ) -> Result<String, error::Error> {
         match op {
             brush_parser::word::ParameterTransformOp::PromptExpand => {
                 prompt::expand_prompt(self.shell, s)
             }
             brush_parser::word::ParameterTransformOp::CapitalizeInitial => {
-                Ok(to_initial_capitals(s))
+                Ok(to_initial_capitals(s.as_str()))
             }
             brush_parser::word::ParameterTransformOp::ExpandEscapeSequences => {
-                let (result, _) =
-                    escape::expand_backslash_escapes(s, escape::EscapeExpansionMode::AnsiCQuotes)?;
+                let (result, _) = escape::expand_backslash_escapes(
+                    s.as_str(),
+                    escape::EscapeExpansionMode::AnsiCQuotes,
+                )?;
                 Ok(String::from_utf8_lossy(result.as_slice()).into_owned())
             }
             brush_parser::word::ParameterTransformOp::PossiblyQuoteWithArraysExpanded {
@@ -1474,10 +1473,10 @@ impl<'a> WordExpander<'a> {
             } => {
                 // TODO: This isn't right for arrays.
                 // TODO: This doesn't honor 'separate_words'
-                Ok(variables::quote_str_for_assignment(s))
+                Ok(variables::quote_str_for_assignment(s.as_str()))
             }
             brush_parser::word::ParameterTransformOp::Quoted => {
-                Ok(variables::quote_str_for_assignment(s))
+                Ok(variables::quote_str_for_assignment(s.as_str()))
             }
             brush_parser::word::ParameterTransformOp::ToLowerCase => Ok(s.to_lowercase()),
             brush_parser::word::ParameterTransformOp::ToUpperCase => Ok(s.to_uppercase()),

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -134,6 +134,12 @@ pub trait InteractiveShell {
             match self.read_line(prompt)? {
                 ReadResult::Input(read_result) => {
                     let mut shell_mut = self.shell_mut();
+
+                    let precmd_prompt = shell_mut.as_mut().compose_precmd_prompt().await?;
+                    if !precmd_prompt.is_empty() {
+                        print!("{precmd_prompt}");
+                    }
+
                     let params = shell_mut.as_mut().default_exec_params();
                     match shell_mut.as_mut().run_string(read_result, &params).await {
                         Ok(result) => Ok(InteractiveExecutionResult::Executed(result)),

--- a/brush-interactive/src/reedline/prompt.rs
+++ b/brush-interactive/src/reedline/prompt.rs
@@ -2,7 +2,15 @@ use crate::interactive_shell::InteractivePrompt;
 
 impl reedline::Prompt for InteractivePrompt {
     fn render_prompt_left(&self) -> std::borrow::Cow<str> {
-        self.prompt.as_str().into()
+        // [Workaround: see https://github.com/nushell/reedline/issues/707]
+        // If the prompt starts with a newline character, then there's a chance
+        // that it won't be rendered correctly. For this specific case, insert
+        // an extra space character before the newline.
+        if self.prompt.starts_with('\n') {
+            std::format!(" {}", self.prompt).into()
+        } else {
+            self.prompt.as_str().into()
+        }
     }
 
     fn render_prompt_right(&self) -> std::borrow::Cow<str> {


### PR DESCRIPTION
Details:

* Add new `brush`-specific variable (`BRUSH_PS_ALT`) for right-side prompts, supported by the `reedline` backend.
* Implement support for `PS0`
* Start advertising `BASH_VERSION`
* Add workaround for `reedline` issues with prompts that start with a leading newline character

With these changes, `starship` no longer needs to install a debug trap handler and can perform slightly better. Newlines in prompts seem to render more correctly thanks to the workaround mentioned too.