### PR TITLE
feat(set): implement nullglob option

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -510,7 +510,7 @@ impl<'a> WordExpander<'a> {
             )
             .unwrap_or_default();
 
-        if expansions.is_empty() {
+        if expansions.is_empty() && !self.shell.options.expand_non_matching_patterns_to_null {
             vec![String::from(field)]
         } else {
             expansions

--- a/brush-shell/tests/cases/patterns.yaml
+++ b/brush-shell/tests/cases/patterns.yaml
@@ -3,6 +3,14 @@ cases:
   - name: "Single file expansion"
     stdin: "echo file1.txt"
 
+  - name: "Expansion with noglob"
+    test_files:
+      - path: "file1.txt"
+      - path: "file2.txt"
+    stdin: |
+      set -f
+      echo "*.txt:" *.txt
+
   - name: "Multiple file expansion"
     test_files:
       - path: "file1.txt"
@@ -25,6 +33,13 @@ cases:
     test_files:
       - path: "file1.txt"
     stdin: "echo *.jpg"
+
+  - name: "Expansion with no matches + nullglob"
+    test_files:
+      - path: "file1.txt"
+    stdin: |
+      shopt -s nullglob
+      echo "*.jpg:" *.jpg
 
   - name: "Expansion with special characters"
     test_files:


### PR DESCRIPTION
Adds tests for `noglob` and `nullglob` options; makes sure both work.

Resolves #229 