### PR TITLE
fix: improve substring ops with multi-byte chars

### DIFF
--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -401,9 +401,8 @@ pub fn parse_parameter(
     word: &str,
     options: &ParserOptions,
 ) -> Result<Parameter, error::WordParseError> {
-    let pieces = expansion_parser::parameter(word, options)
-        .map_err(|err| error::WordParseError::Parameter(word.to_owned(), err))?;
-    Ok(pieces)
+    expansion_parser::parameter(word, options)
+        .map_err(|err| error::WordParseError::Parameter(word.to_owned(), err))
 }
 
 peg::parser! {

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -658,6 +658,12 @@ cases:
       echo "\${var:-1:1}: ${var:-1:1}"
       echo "\${var:-3:1}: ${var:-3:1}"
 
+  - name: "Substring on string with multi-byte chars"
+    known_failure: true
+    stdin: |
+      var="7❌🖌️✅😂🔴⛔ABC"
+      echo "${var:2}" | hexdump -C
+
   - name: "Substring operator on arrays"
     stdin: |
       set abcde fghij klmno pqrst uvwxy z

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -1122,8 +1122,8 @@ impl TestCase {
 
         Ok(RunResult {
             exit_status: cmd_result.status,
-            stdout: String::from_utf8(cmd_result.stdout)?,
-            stderr: String::from_utf8(cmd_result.stderr)?,
+            stdout: String::from_utf8_lossy(cmd_result.stdout.as_slice()).to_string(),
+            stderr: String::from_utf8_lossy(cmd_result.stderr.as_slice()).to_string(),
             duration,
         })
     }


### PR DESCRIPTION
There is more to understand with respect to differences from `bash`'s output, but with this change `brush` no longer generates an error when trying to slice into a string somewhere other than at a character boundary.