### PR TITLE
feat(options): implement noclobber option (a.k.a. -C)

### DIFF
--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -191,6 +191,8 @@ impl RuntimeOptions {
         // There's a set of options enabled by default for all shells.
         let mut options = Self {
             interactive: create_options.interactive,
+            disallow_overwriting_regular_files_via_output_redirection: create_options
+                .disallow_overwriting_regular_files_via_output_redirection,
             do_not_execute_commands: create_options.do_not_execute_commands,
             enable_command_history: create_options.interactive,
             enable_job_control: create_options.interactive,

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -123,6 +123,8 @@ pub struct CreateOptions {
     pub disabled_shopt_options: Vec<String>,
     /// Enabled shopt options.
     pub enabled_shopt_options: Vec<String>,
+    /// Disallow overwriting regular files via output redirection.
+    pub disallow_overwriting_regular_files_via_output_redirection: bool,
     /// Do not execute commands.
     pub do_not_execute_commands: bool,
     /// Whether the shell is interactive.

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -45,6 +45,10 @@ pub struct CommandLineArgs {
     #[clap(long = "version", action = clap::ArgAction::Version)]
     pub version: Option<bool>,
 
+    /// Enable noclobber shell option.
+    #[arg(short = 'C')]
+    pub disallow_overwriting_regular_files_via_output_redirection: bool,
+
     /// Execute the provided command and then exit.
     #[arg(short = 'c', value_name = "COMMAND")]
     pub command: Option<String>,

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -199,6 +199,8 @@ async fn instantiate_shell(
     let options = brush_interactive::Options {
         shell: brush_core::CreateOptions {
             disabled_shopt_options: args.disabled_shopt_options.clone(),
+            disallow_overwriting_regular_files_via_output_redirection: args
+                .disallow_overwriting_regular_files_via_output_redirection,
             enabled_shopt_options: args.enabled_shopt_options.clone(),
             do_not_execute_commands: args.do_not_execute_commands,
             login: args.login || argv0.as_ref().map_or(false, |a0| a0.starts_with('-')),

--- a/brush-shell/tests/cases/options.yaml
+++ b/brush-shell/tests/cases/options.yaml
@@ -14,6 +14,32 @@ cases:
       env | grep newvar
       env | grep unexported
 
+  - name: "set -C"
+    ignore_stderr: true
+    stdin: |
+      touch existing-file
+
+      set -C
+
+      echo hi > non-existing-file
+      echo "Result (non existing): $?"
+      echo "File contents: $(cat non-existing-file)"
+      echo
+
+      echo hi > /dev/null
+      echo "Result (device file): $?"
+      echo
+
+      echo hi > existing-file
+      echo "Result (existing file): $?"
+      echo "File contents: $(cat existing-file)"
+      echo
+
+      echo hi >| existing-file
+      echo "Result (clobber): $?"
+      echo "File contents: $(cat existing-file)"
+      echo
+
   - name: "set -x"
     stdin: |
       set -x


### PR DESCRIPTION
* Adds support for `-C` on command line, via `set`, etc.
* Adds basic compat tests to check.