### PR TITLE
chore: pin workflows to specific ubuntu versions

### DIFF
--- a/.github/workflows/ci-reports.yaml
+++ b/.github/workflows/ci-reports.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   report:
     name: "Report"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Find workflow run
         id: find-run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           # Build for x86_64/linux target on native host.
-          - host: "ubuntu-latest"
+          - host: "ubuntu-24.04"
             target: ""
             os: "linux"
             arch: "x86_64"
@@ -45,7 +45,7 @@ jobs:
             binary_name: "brush"
             extra_build_args: ""
           # Build for aarch64/linux target on x86_64/linux host.
-          - host: "ubuntu-latest"
+          - host: "ubuntu-24.04"
             target: "aarch64-unknown-linux-gnu"
             os: "linux"
             arch: "aarch64"
@@ -53,7 +53,7 @@ jobs:
             binary_name: "brush"
             extra_build_args: ""
           # Build for WASI-0.2 target on x86_64/linux host.
-          - host: "ubuntu-latest"
+          - host: "ubuntu-24.04"
             target: "wasm32-wasip2"
             os: "wasi-0.2"
             arch: "wasm32"
@@ -61,7 +61,7 @@ jobs:
             binary_name: "brush.wasm"
             extra_build_args: "--no-default-features --features minimal"
           # Build for x86_64/windows target on x86_64/linux host.
-          - host: "ubuntu-latest"
+          - host: "ubuntu-24.04"
             target: "x86_64-pc-windows-gnu"
             os: "windows"
             arch: "x86_64"
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - host: "ubuntu-latest"
+          - host: "ubuntu-24.04"
             variant: "linux"
             artifact_suffix: ""
             name_suffix: "(linux)"
@@ -241,7 +241,7 @@ jobs:
   # Static analysis of the code.
   check:
     name: "Source code checks"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -285,7 +285,7 @@ jobs:
   # Check for unneeded dependencies.
   check-deps:
     name: "Check for unneeded dependencies"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -307,7 +307,7 @@ jobs:
   benchmark:
     if: github.event_name == 'pull_request'
     name: "Benchmarks"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -371,7 +371,7 @@ jobs:
             prereqs_command: "pacman -Sy --noconfirm bash-completion iputils grep less sed util-linux"
 
     name: "OS target tests (${{ matrix.description }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     needs: build
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,11 @@ jobs:
       matrix:
         include:
           # Build for x86_64/linux target on native host.
-          - host: "ubuntu-24.04"
+          # N.B. We intentionally pin to Ubuntu 22.04 for now to increase
+          # the range of distros that will be able to run the produced binaries.
+          # Newer release of Ubuntu upgrade glibc to a point not yet supported
+          # by some latest stable versions of distros.
+          - host: "ubuntu-22.04"
             target: ""
             os: "linux"
             arch: "x86_64"

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: "Build devcontainer"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: read
@@ -35,7 +35,7 @@ jobs:
 
   build_and_publish:
     name: "Build and publish devcontainer"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
   # Check links in docs
   check-links:
     name: "Check links"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
   # Generate docs content
   generate-docs:
     name: "Generate usage docs"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
`ubuntu-latest` is going to get upgraded to `ubuntu-24.04` shortly, but we'd rather intentionally upgrade and work through any issues rather than having them "show up one day".

This PR pins all workflows to`ubuntu-24.04` with the one notable exception of the native x86_64/Linux build, which we pin to `ubuntu-22.04`. We do this intentionally because 24.04 brings in a newer version of `glibc` and decreased compatibility for produced rust binaries.