### PR TITLE
fix: implement date and time in prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "brush-parser",
  "cached",
  "cfg-if",
+ "chrono",
  "clap",
  "command-fds",
  "criterion",
@@ -475,8 +476,10 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1579,9 +1582,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "os_info"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ca711d8b83edbb00b44d504503cd247c9c0bd8b0fa2694f2a1a3d8165379ce"
+checksum = "eb6651f4be5e39563c4fe5cc8326349eb99a25d805a3493f791d5bfd0269e430"
 dependencies = [
  "log",
  "serde",

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1.83"
 brush-parser = { version = "^0.2.11", path = "../brush-parser" }
 cached = "0.54.0"
 cfg-if = "1.0.0"
+chrono = "0.4.39"
 clap = { version = "4.5.21", features = ["derive", "wrap_help"] }
 fancy-regex = "0.14.0"
 futures = "0.3.31"

--- a/brush-core/benches/shell.rs
+++ b/brush-core/benches/shell.rs
@@ -76,6 +76,13 @@ mod unix {
         c.bench_function("expand_one_string", |b| {
             b.iter(|| black_box(expand_one_string()));
         });
+        c.bench_function("for_loop", |b| {
+            b.to_async(tokio()).iter(|| {
+                black_box(run_one_command(
+                    "for ((i = 0; i < 100000; i++)); do :; done",
+                ))
+            });
+        });
     }
 }
 

--- a/brush-parser/src/prompt.rs
+++ b/brush-parser/src/prompt.rs
@@ -123,7 +123,7 @@ peg::parser! {
             s:$((!special_sequence() [c])+) { PromptPiece::Literal(s.to_owned()) }
 
         rule date_format() -> String =
-            s:$(!"}" [c]+) { s.to_owned() }
+            s:$([c if c != '}']*) { s.to_owned() }
 
         rule octal_number() -> u32 =
             s:$(['0'..='9']*<3,3>) {? u32::from_str_radix(s, 8).or(Err("invalid octal number")) }

--- a/brush-shell/tests/cases/prompt.yaml
+++ b/brush-shell/tests/cases/prompt.yaml
@@ -54,3 +54,39 @@ cases:
 
       prompt='\V'
       [[ "${prompt@P}" == ^\d+\.\d+\.\d+$ ]] && echo "Release is correct"
+
+  - name: "Simple date"
+    stdin: |
+      prompt='\d'
+      [[ "${prompt@P}" == $(date +'%a %b %d') ]] && echo '\d date matches'
+
+  - name: "Date format with plain string"
+    stdin: |
+      prompt='\D{something}'
+      echo "Date format with plain string: '${prompt@P}'"
+
+  - name: "Date format with year"
+    stdin: |
+      prompt='\d{%Y}'
+      echo "Date format with year: '${prompt@P}'"
+
+  - name: "Time format: @"
+    stdin: |
+      prompt='\@'
+      expanded=${prompt@P}
+      roundtripped=$(date --date="${expanded}" +'%I:%M %p')
+      [[ ${expanded} == ${roundtripped} ]] && echo "Time matches"
+
+  - name: "Time format: T"
+    stdin: |
+      prompt='\T'
+      expanded=${prompt@P}
+      roundtripped=$(date --date="${expanded}" +'%I:%M:%S')
+      [[ ${expanded} == ${roundtripped} ]] && echo "Time matches"
+
+  - name: "Time format: t"
+    stdin: |
+      prompt='\t'
+      expanded=${prompt@P}
+      roundtripped=$(date --date="${expanded}" +'%H:%M:%S')
+      [[ ${expanded} == ${roundtripped} ]] && echo "Time matches"


### PR DESCRIPTION
Fills out implementation and adds tests for the follow escape sequences in prompt strings:

* `\d`
* `\D`
* `\t`
* `\T`
* `\@`