### PR TITLE
fix(completion): handle -o {default,dirnames,plusdirs}

### DIFF
--- a/brush-interactive/src/completion.rs
+++ b/brush-interactive/src/completion.rs
@@ -72,7 +72,7 @@ fn postprocess_completion_candidate(
         }
     }
     if options.no_autoquote_filenames {
-        tracing::debug!(target: trace_categories::COMPLETION, "don't autoquote filenames");
+        tracing::debug!(target: trace_categories::COMPLETION, "UNIMPLEMENTED: don't autoquote filenames");
     }
     if completing_end_of_line && !options.no_trailing_space_at_end_of_line {
         if !options.treat_as_filenames || !candidate.ends_with(std::path::MAIN_SEPARATOR) {

--- a/brush-shell/tests/cases/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/builtins/compgen.yaml
@@ -136,3 +136,40 @@ cases:
     stdin: |
       echo "[Take 1]"
       compgen -W 'somebody something' -X '&b*' some
+
+  - name: "compgen -o dirnames"
+    stdin: |
+      echo "[Take 1]"
+      compgen -W 'completion' -o dirnames -- c | sort
+
+      echo "[Take 2]"
+      mkdir subdir
+      touch subfile
+      compgen -W 'completion' -o dirnames -- s | sort
+
+  - name: "compgen -o default"
+    stdin: |
+      echo "[Take 1]"
+      compgen -W 'completion' -o default -- c | sort
+
+      echo "[Take 2]"
+      mkdir subdir
+      touch subfile
+      compgen -W 'completion' -o default -- s | sort
+
+  - name: "compgen -o bashdefault"
+    stdin: |
+      echo "[Take 1]"
+      compgen -W 'completion' -o bashdefault -- c | sort
+
+      echo "[Take 2]"
+      mkdir subdir
+      touch subfile
+      compgen -W 'completion' -o bashdefault -- s | sort
+
+  - name: "compgen -o plusdirs"
+    stdin: |
+      echo "[Take 1]"
+      touch cfile
+      mkdir cdir
+      compgen -W 'completion' -o plusdirs -o default -S suffix -- c | sort

--- a/brush-shell/tests/cases/builtins/complete.yaml
+++ b/brush-shell/tests/cases/builtins/complete.yaml
@@ -59,3 +59,11 @@ cases:
         complete -A ${action} mycmd
         complete -p mycmd
       done
+
+  - name: "Roundtrip: complete -o options"
+    stdin: |
+      for opt in bashdefault default dirnames filenames noquote nosort nospace plusdirs; do
+        echo "--- Testing option: ${opt} ------------------"
+        complete -o ${opt} mycmd_${opt}
+        complete -p mycmd_${opt}
+      done


### PR DESCRIPTION
* Fills out handling of `default`, `dirnames`, and `plusdirs` options for completion.
* Adds a few basic compat tests for this logic.

Notably, this makes `git diff -- <start_of_file_path>` complete to something sensibly.