### PR TITLE
perf: remove setup operations from microbenchmarks

### DIFF
--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -30,7 +30,7 @@ name = "brush-completion-tests"
 path = "tests/completion_tests.rs"
 
 [features]
-default = ["basic", "reedline"]
+default = ["basic", "reedline", "minimal"]
 basic = ["brush-interactive/basic"]
 minimal = ["brush-interactive/minimal"]
 reedline = ["brush-interactive/reedline"]


### PR DESCRIPTION
This makes no changes to the code-under-analysis; the perf deltas that show in the PR report are due to the changes in the definitions of the benchmarks.