### PR TITLE
feat(non-posix): implement `time` keyword

### DIFF
--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -50,7 +50,6 @@ mod set;
 mod shift;
 mod shopt;
 mod test;
-#[cfg(unix)]
 mod times;
 mod trap;
 mod true_;

--- a/brush-core/src/builtins/factory.rs
+++ b/brush-core/src/builtins/factory.rs
@@ -219,7 +219,6 @@ pub(crate) fn get_default_builtins(
         "readonly".into(),
         special_decl_builtin::<declare::DeclareCommand>(),
     );
-    #[cfg(unix)]
     m.insert("times".into(), special_builtin::<times::TimesCommand>());
 
     //

--- a/brush-core/src/builtins/times.rs
+++ b/brush-core/src/builtins/times.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::io::Write;
 
-use crate::{builtins, commands, error};
+use crate::{builtins, commands, error, timing};
 
 /// Report on usage time.
 #[derive(Parser)]
@@ -12,65 +12,23 @@ impl builtins::Command for TimesCommand {
         &self,
         context: commands::ExecutionContext<'_>,
     ) -> Result<builtins::ExitCode, error::Error> {
-        let self_usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_SELF)?;
-
+        let (self_user, self_system) = crate::sys::resource::get_self_user_and_system_time()?;
         writeln!(
             context.stdout(),
             "{} {}",
-            format_time(self_usage.user_time()),
-            format_time(self_usage.system_time()),
+            timing::format_duration_non_posixly(&self_user),
+            timing::format_duration_non_posixly(&self_system),
         )?;
 
-        let children_usage =
-            nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_CHILDREN)?;
-
+        let (children_user, children_system) =
+            crate::sys::resource::get_children_user_and_system_time()?;
         writeln!(
             context.stdout(),
             "{} {}",
-            format_time(children_usage.user_time()),
-            format_time(children_usage.system_time()),
+            timing::format_duration_non_posixly(&children_user),
+            timing::format_duration_non_posixly(&children_system),
         )?;
 
         Ok(builtins::ExitCode::Success)
-    }
-}
-
-fn format_time(time: nix::sys::time::TimeVal) -> String {
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::cast_possible_truncation)]
-    let duration = std::time::Duration::new(time.tv_sec() as u64, time.tv_usec() as u32 * 1000);
-    let minutes = duration.as_secs() / 60;
-    let seconds = duration.as_secs() % 60;
-    let millis = duration.subsec_millis();
-    format!("{minutes}m{seconds}.{millis:03}s")
-}
-
-#[cfg(test)]
-mod tests {
-    use nix::sys::time::TimeValLike;
-
-    use super::*;
-
-    #[test]
-    fn test_format_time() {
-        fn ms_to_timeval(ms: i64) -> nix::sys::time::TimeVal {
-            nix::sys::time::TimeVal::milliseconds(ms)
-        }
-
-        fn us_to_timeval(us: i64) -> nix::sys::time::TimeVal {
-            nix::sys::time::TimeVal::microseconds(us)
-        }
-
-        assert_eq!(format_time(ms_to_timeval(0)), "0m0.000s");
-        assert_eq!(format_time(ms_to_timeval(1)), "0m0.001s");
-        assert_eq!(format_time(ms_to_timeval(123)), "0m0.123s");
-        assert_eq!(format_time(ms_to_timeval(1234)), "0m1.234s");
-        assert_eq!(format_time(ms_to_timeval(12345)), "0m12.345s");
-        assert_eq!(format_time(ms_to_timeval(123456)), "2m3.456s");
-        assert_eq!(format_time(ms_to_timeval(1234567)), "20m34.567s");
-
-        assert_eq!(format_time(us_to_timeval(1)), "0m0.000s");
-        assert_eq!(format_time(us_to_timeval(999)), "0m0.000s");
-        assert_eq!(format_time(us_to_timeval(1000)), "0m0.001s");
     }
 }

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -188,6 +188,10 @@ pub enum Error {
     /// Maximum function call depth was exceeded.
     #[error("maximum function call depth exceeded")]
     MaxFunctionCallDepthExceeded,
+
+    /// System time error.
+    #[error("system time error: {0}")]
+    TimeError(#[from] std::time::SystemTimeError),
 }
 
 /// Convenience function for returning an error for unimplemented functionality.

--- a/brush-core/src/keywords.rs
+++ b/brush-core/src/keywords.rs
@@ -24,8 +24,10 @@ fn get_keywords(sh_mode_only: bool) -> HashSet<String> {
     if !sh_mode_only {
         keywords.insert(String::from("[["));
         keywords.insert(String::from("]]"));
+        keywords.insert(String::from("coproc"));
         keywords.insert(String::from("function"));
         keywords.insert(String::from("select"));
+        keywords.insert(String::from("time"));
     }
 
     keywords

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -29,6 +29,7 @@ mod shell;
 mod sys;
 mod terminal;
 mod tests;
+mod timing;
 mod trace_categories;
 mod traps;
 mod variables;

--- a/brush-core/src/sys.rs
+++ b/brush-core/src/sys.rs
@@ -28,6 +28,7 @@ pub(crate) mod fs;
 pub(crate) use platform::network;
 pub(crate) use platform::pipes;
 pub(crate) use platform::process;
+pub(crate) use platform::resource;
 pub(crate) use platform::signal;
 pub(crate) use platform::terminal;
 pub(crate) use platform::users;

--- a/brush-core/src/sys/stubs.rs
+++ b/brush-core/src/sys/stubs.rs
@@ -8,6 +8,7 @@ pub(crate) mod fs;
 pub(crate) mod network;
 pub(crate) mod pipes;
 pub(crate) mod process;
+pub(crate) mod resource;
 pub(crate) mod signal;
 pub(crate) mod terminal;
 pub(crate) mod users;

--- a/brush-core/src/sys/stubs/resource.rs
+++ b/brush-core/src/sys/stubs/resource.rs
@@ -1,0 +1,13 @@
+use crate::error;
+
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn get_self_user_and_system_time(
+) -> Result<(std::time::Duration, std::time::Duration), error::Error> {
+    Ok((std::time::Duration::ZERO, std::time::Duration::ZERO))
+}
+
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn get_children_user_and_system_time(
+) -> Result<(std::time::Duration, std::time::Duration), error::Error> {
+    Ok((std::time::Duration::ZERO, std::time::Duration::ZERO))
+}

--- a/brush-core/src/sys/unix.rs
+++ b/brush-core/src/sys/unix.rs
@@ -2,6 +2,7 @@ pub(crate) use crate::sys::os_pipe as pipes;
 pub(crate) mod fs;
 pub(crate) mod network;
 pub(crate) use crate::sys::tokio_process as process;
+pub(crate) mod resource;
 pub(crate) mod signal;
 pub(crate) mod terminal;
 pub(crate) mod users;

--- a/brush-core/src/sys/unix/resource.rs
+++ b/brush-core/src/sys/unix/resource.rs
@@ -1,0 +1,27 @@
+use crate::error;
+
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn get_self_user_and_system_time(
+) -> Result<(std::time::Duration, std::time::Duration), error::Error> {
+    let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_SELF)?;
+    Ok((
+        convert_rusage_time(usage.user_time()),
+        convert_rusage_time(usage.system_time()),
+    ))
+}
+
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn get_children_user_and_system_time(
+) -> Result<(std::time::Duration, std::time::Duration), error::Error> {
+    let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_CHILDREN)?;
+    Ok((
+        convert_rusage_time(usage.user_time()),
+        convert_rusage_time(usage.system_time()),
+    ))
+}
+
+fn convert_rusage_time(time: nix::sys::time::TimeVal) -> std::time::Duration {
+    #[allow(clippy::cast_sign_loss)]
+    #[allow(clippy::cast_possible_truncation)]
+    std::time::Duration::new(time.tv_sec() as u64, time.tv_usec() as u32 * 1000)
+}

--- a/brush-core/src/sys/wasm.rs
+++ b/brush-core/src/sys/wasm.rs
@@ -2,6 +2,7 @@ pub(crate) use crate::sys::stubs::fs;
 pub(crate) use crate::sys::stubs::network;
 pub(crate) use crate::sys::stubs::pipes;
 pub(crate) use crate::sys::stubs::process;
+pub(crate) use crate::sys::stubs::resource;
 pub(crate) use crate::sys::stubs::signal;
 pub(crate) use crate::sys::stubs::terminal;
 pub(crate) use crate::sys::stubs::users;

--- a/brush-core/src/sys/windows.rs
+++ b/brush-core/src/sys/windows.rs
@@ -1,6 +1,7 @@
 pub(crate) use crate::sys::os_pipe as pipes;
 pub(crate) use crate::sys::stubs::fs;
 pub(crate) mod network;
+pub(crate) use crate::sys::stubs::resource;
 
 pub(crate) mod signal {
     pub(crate) use crate::sys::stubs::signal::*;

--- a/brush-core/src/timing.rs
+++ b/brush-core/src/timing.rs
@@ -1,0 +1,124 @@
+use crate::error;
+
+struct StopwatchTime {
+    now: std::time::SystemTime,
+    self_user: std::time::Duration,
+    self_system: std::time::Duration,
+    children_user: std::time::Duration,
+    children_system: std::time::Duration,
+}
+
+impl StopwatchTime {
+    fn minus(&self, other: &StopwatchTime) -> Result<StopwatchTiming, error::Error> {
+        let user = (self.self_user - other.self_user) + (self.children_user - other.children_user);
+        let system =
+            (self.self_system - other.self_system) + (self.children_system - other.children_system);
+
+        Ok(StopwatchTiming {
+            wall: self.now.duration_since(other.now)?,
+            user,
+            system,
+        })
+    }
+}
+
+pub(crate) struct Stopwatch {
+    start: StopwatchTime,
+}
+
+impl Stopwatch {
+    pub fn stop(&self) -> Result<StopwatchTiming, error::Error> {
+        let end = get_current_stopwatch_time()?;
+        end.minus(&self.start)
+    }
+}
+pub(crate) struct StopwatchTiming {
+    pub wall: std::time::Duration,
+    pub user: std::time::Duration,
+    pub system: std::time::Duration,
+}
+
+pub(crate) fn start_timing() -> Result<Stopwatch, error::Error> {
+    Ok(Stopwatch {
+        start: get_current_stopwatch_time()?,
+    })
+}
+
+fn get_current_stopwatch_time() -> Result<StopwatchTime, error::Error> {
+    let now = std::time::SystemTime::now();
+    let (self_user, self_system) = crate::sys::resource::get_self_user_and_system_time()?;
+    let (children_user, children_system) =
+        crate::sys::resource::get_children_user_and_system_time()?;
+
+    Ok(StopwatchTime {
+        now,
+        self_user,
+        self_system,
+        children_user,
+        children_system,
+    })
+}
+
+pub(crate) fn format_duration_non_posixly(duration: &std::time::Duration) -> String {
+    let minutes = duration.as_secs() / 60;
+    let seconds = duration.as_secs() % 60;
+    let millis = duration.subsec_millis();
+    format!("{minutes}m{seconds}.{millis:03}s")
+}
+
+pub(crate) fn format_duration_posixly(duration: &std::time::Duration) -> String {
+    let seconds = duration.as_secs();
+    let ten_millis = duration.subsec_millis() / 10;
+    format!("{seconds}.{ten_millis:02}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_format_time() {
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_millis(0)),
+            "0m0.000s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_millis(1)),
+            "0m0.001s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_millis(123)),
+            "0m0.123s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_millis(1234)),
+            "0m1.234s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_millis(12345)),
+            "0m12.345s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_millis(123456)),
+            "2m3.456s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_millis(1234567)),
+            "20m34.567s"
+        );
+
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_micros(1)),
+            "0m0.000s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_micros(999)),
+            "0m0.000s"
+        );
+        assert_eq!(
+            format_duration_non_posixly(&Duration::from_micros(1000)),
+            "0m0.001s"
+        );
+    }
+}

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -96,12 +96,26 @@ impl Display for AndOr {
     }
 }
 
+/// The type of timing requested for a pipeline.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub enum PipelineTimed {
+    /// The pipeline should be timed with bash-like output.
+    Timed,
+    /// The pipeline should be timed with POSIX-like output.
+    TimedWithPosixOutput,
+}
+
 /// A pipeline of commands, where each command's output is passed as standard input
 /// to the command that follows it.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct Pipeline {
+    /// Indicates whether the pipeline's execution should be timed with reported
+    /// timings in output.
+    pub timed: Option<PipelineTimed>,
     /// Indicates whether the result of the overall pipeline should be the logical
     /// negation of the result of the pipeline.
     pub bang: bool,


### PR DESCRIPTION
This implements `time`, which in the bash world is a special keyword usable at the beginning of pipelines--not a built-in.