### PR TITLE
perf: adjust compile flags for runtime performance

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 resolver = "2"
-members = ["brush-shell", "brush-parser", "brush-core", "brush-interactive", "fuzz", "xtask"]
+members = [
+    "brush-shell",
+    "brush-parser",
+    "brush-core",
+    "brush-interactive",
+    "fuzz",
+    "xtask",
+]
 default-members = ["brush-shell"]
 
 [workspace.package]
@@ -42,6 +49,6 @@ struct_excessive_bools = "allow"
 
 [profile.release]
 strip = "debuginfo"
-opt-level = "z"
-lto = true
+lto = "fat"
 codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
* Tell `rustc` to target the CPU that it's running on; this brings the trade-off that compiled binaries may not be appropriate for execution on arbitrary target systems. For now, we're okay with that since we don't publish binaries. We may need to revisit this in the future.

* Set lto setting to `fat`

* Configure panicking on abort (no unwinding)