### PR TITLE
fix: correct issues with `!` extglobs and compgen -X

### DIFF
--- a/brush-shell/tests/cases/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/builtins/compgen.yaml
@@ -137,6 +137,32 @@ cases:
       echo "[Take 1]"
       compgen -W 'somebody something' -X '&b*' some
 
+  - name: "compgen -X with extglob"
+    stdin: |
+      touch README
+      shopt -s extglob
+
+      echo "[Take 1]"
+      compgen -f READ
+
+      echo "[Take 2]"
+      compgen -f -X "READ" READ
+
+      echo "[Take 3]"
+      compgen -f -X "README" READ
+
+      echo "[Take 4]"
+      compgen -f -X "!(READ)" READ
+
+      echo "[Take 5]"
+      compgen -f -X "!(README)" READ
+
+      echo "[Take 6]"
+      compgen -f -X "!!(READ)" READ
+
+      echo "[Take 7]"
+      compgen -f -X "!!(README)" READ
+
   - name: "compgen -o dirnames"
     stdin: |
       echo "[Take 1]"

--- a/brush-shell/tests/cases/patterns.yaml
+++ b/brush-shell/tests/cases/patterns.yaml
@@ -211,7 +211,19 @@ cases:
       - path: "def.txt"
     stdin: |
       shopt -s extglob
-      echo !(a*)
+      echo "1: " !(a*)
+      echo "2: " !(abc.txt)
+      echo "3: " !(abc)
+      echo "4: " !(*)
+
+  - name: "Pathname expansion: Degenerate inverted pattern"
+    test_files:
+      - path: "abc.txt"
+      - path: "abd.txt"
+      - path: "def.txt"
+    stdin: |
+      shopt -s extglob
+      echo !()
 
   - name: "Pathname expansion: Extended patterns"
     ignore_stderr: true
@@ -220,7 +232,9 @@ cases:
       - path: "abd.txt"
     stdin: |
       shopt -s extglob
-      echo @(abc|abd).txt
+      echo "1: " @(abc|abd).txt
+      echo "2: " @(abc.txt)
+      echo "3: " @(abc)
 
   - name: "Pathname expansion: Optional patterns"
     ignore_stderr: true

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -324,7 +324,7 @@ async fn complete_path_args_to_well_known_programs() -> Result<()> {
     // Complete.
     let results = test_shell.complete_end_of_line("tar tvf ./item").await?;
 
-    assert_eq!(results, ["./item1", "./item2"]);
+    assert_eq!(results, ["./item2"]);
 
     Ok(())
 }


### PR DESCRIPTION
Fixes multiple issues with extglob pattern matching support, particularly with `!(...)` patterns. Additional changes for use of patterns as filter expressions in completion (notably, fixes to inversion).

### Updates to pattern parsing:

* [`brush-parser/src/pattern.rs`](diffhunk://#diff-6d3d15c993f8181f7e8182d68c72fca77a48114f71a359773d73da6745bff401L95-R107): Refactored the `extended_glob_body` rule to simplify the parsing of extended glob patterns and adjusted how negative lookaheads are handled in the regex generation. [[1]](diffhunk://#diff-6d3d15c993f8181f7e8182d68c72fca77a48114f71a359773d73da6745bff401L95-R107) [[2]](diffhunk://#diff-6d3d15c993f8181f7e8182d68c72fca77a48114f71a359773d73da6745bff401L111-L113) [[3]](diffhunk://#diff-6d3d15c993f8181f7e8182d68c72fca77a48114f71a359773d73da6745bff401L127-R135)

### Addition of test cases:

* [`brush-core/src/patterns.rs`](diffhunk://#diff-587f52b950161b074c8f0d6fdfc109f08e3219129404be142ff7044a80e054e7R645-R814): Added extensive test cases to verify the behavior of pattern matching with and without extended globbing, covering various scenarios including basic, advanced, and degenerate cases.
* [`brush-shell/tests/cases/builtins/compgen.yaml`](diffhunk://#diff-ac8a33134165ee0507555d187652a2598ed84d27c738103ea229aca7ac3918b0R140-R165): Added new test cases for the `compgen` command with extended globbing enabled.
* [`brush-shell/tests/cases/patterns.yaml`](diffhunk://#diff-ef3eac8b325b892c963ee64fa69882c13500bca63f5dd27ef9fa995b45a804d6L214-R226): Added new test cases for pathname expansion with extended globbing, including degenerate inverted patterns. [[1]](diffhunk://#diff-ef3eac8b325b892c963ee64fa69882c13500bca63f5dd27ef9fa995b45a804d6L214-R226) [[2]](diffhunk://#diff-ef3eac8b325b892c963ee64fa69882c13500bca63f5dd27ef9fa995b45a804d6L223-R237)

### Other changes:

* [`brush-shell/tests/completion_tests.rs`](diffhunk://#diff-858dab8c31079d18f10be31944b5aac5a7869a059bb68a16593fa12f0aac465eL327-R327): Adjusted the expected results in the `complete_path_args_to_well_known_programs` test to reflect the updated completion logic.