### PR TITLE
fix(patterns): fix incorrect parse of char ranges

### DIFF
--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -642,10 +642,8 @@ impl Spec {
             ("COMP_CWORD", context.token_index.to_string().into()),
         ];
 
-        if tracing::enabled!(target: trace_categories::COMPLETION, tracing::Level::DEBUG) {
-            tracing::debug!(target: trace_categories::COMPLETION, "[calling completion func '{function_name}']: {}",
-                vars_and_values.iter().map(|(k, v)| std::format!("{k}={v}")).collect::<Vec<String>>().join(" "));
-        }
+        tracing::debug!(target: trace_categories::COMPLETION, "[calling completion func '{function_name}']: {}",
+            vars_and_values.iter().map(|(k, v)| std::format!("{k}={v}")).collect::<Vec<String>>().join(" "));
 
         let mut vars_to_remove = vec![];
         for (var, value) in vars_and_values {
@@ -673,6 +671,7 @@ impl Spec {
         shell.traps.handler_depth += 1;
 
         let invoke_result = shell.invoke_function(function_name, &args).await;
+        tracing::debug!(target: trace_categories::COMPLETION, "[completion function '{function_name}' returned: {invoke_result:?}]");
 
         shell.traps.handler_depth -= 1;
 

--- a/brush-parser/src/pattern.rs
+++ b/brush-parser/src/pattern.rs
@@ -55,7 +55,7 @@ peg::parser! {
             ['\\'] [c] { c.to_string() }
 
         rule bracket_expression() -> String =
-            "[" invert:(("!")?) members:bracket_member()+ "]" {
+            "[" invert:(invert_char()?) members:bracket_member()+ "]" {
                 let mut members = members;
                 if invert.is_some() {
                     members.insert(0, String::from("^"));
@@ -63,6 +63,9 @@ peg::parser! {
 
                 std::format!("[{}]", members.join(""))
             }
+
+        rule invert_char() -> bool =
+            ['!' | '^'] { true }
 
         rule bracket_member() -> String =
             char_class_expression() /
@@ -76,7 +79,7 @@ peg::parser! {
             "alnum" / "alpha" / "blank" / "cntrl" / "digit" / "graph" / "lower" / "print" / "punct" / "space" / "upper"/ "xdigit"
 
         rule char_range() -> String =
-            range:$([_] "-" [_]) { range.to_owned() }
+            range:$([_] "-" [c if c != ']']) { range.to_owned() }
 
         rule char_list() -> String =
             chars:$([c if c != ']']+) { escape_char_class_char_list(chars) }

--- a/brush-shell/tests/cases/patterns.yaml
+++ b/brush-shell/tests/cases/patterns.yaml
@@ -291,12 +291,25 @@ cases:
       myfunc abc
       myfunc "*"
 
+  - name: "Pattern matching: character ranges"
+    stdin: |
+      [[ "x" == [a-z] ]] && echo "1. Matched"
+      [[ "x" == [0-9] ]] && echo "2. Matched"
+      [[ "-" == [---] ]] && echo "3. Matched"
+
   - name: "Pattern matching: character sets"
     stdin: |
-      [[ "x" == [a-z] ]]       && echo "1. Matched"
-      [[ "x" == [xyz] ]]       && echo "2. Matched"
-      [[ "1" == [[:digit:]] ]] && echo "3. Matched"
-      [[ "(" == [\(]  ]]       && echo "4. Matched"
+      [[ "x" == [abc]  ]] && echo "1. Matched"
+      [[ "x" == [xyz]  ]] && echo "2. Matched"
+      [[ "x" == [^xyz] ]] && echo "3. Matched"
+      [[ "x" == [!xyz] ]] && echo "4. Matched"
+      [[ "(" == [\(]   ]] && echo "5. Matched"
+      [[ "+" == [+-]   ]] && echo "6. Matched"
+
+  - name: "Pattern matching: character classes"
+    stdin: |
+      [[ "1" == [[:digit:]] ]] && echo "1. Matched"
+      [[ "1" == [[:alpha:]] ]] && echo "2. Matched"
 
   - name: "Pattern matching: case sensitivity"
     stdin: |


### PR DESCRIPTION
* Don't allow an unescaped `']'` to be treated as the end range of a character range. This fixes patterns using, for example, `[+-]`.
* Allow either `^` or `!` to invert a character set.
* Make it easier to debug internal errors showing up during completion attempts.