### PR TITLE
chore: remove unneeded string cloning for arithmetic eval

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -6,6 +6,7 @@ use brush_parser::word::ParameterTransformOp;
 use brush_parser::word::SubstringMatchKind;
 use itertools::Itertools;
 
+use crate::arithmetic;
 use crate::arithmetic::ExpandAndEvaluate;
 use crate::commands;
 use crate::env;
@@ -1334,10 +1335,9 @@ impl<'a> WordExpander<'a> {
         let index_to_use = if for_set_associative_array {
             self.basic_expand_to_str(index).await?
         } else {
-            let index_expr = ast::UnexpandedArithmeticExpr {
-                value: index.to_owned(),
-            };
-            self.expand_arithmetic_expr(index_expr).await?
+            arithmetic::expand_and_eval(self.shell, index, false)
+                .await?
+                .to_string()
         };
 
         Ok(index_to_use)

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -2,8 +2,7 @@ use brush_parser::ast;
 use std::path::Path;
 
 use crate::{
-    arithmetic::ExpandAndEvaluate,
-    env, error, escape, expansion, namedoptions, patterns,
+    arithmetic, env, error, escape, expansion, namedoptions, patterns,
     sys::{
         fs::{MetadataExt, PathExt},
         users,
@@ -269,14 +268,8 @@ async fn apply_binary_predicate(
             Ok(left > right)
         }
         ast::BinaryPredicate::ArithmeticEqualTo => {
-            let unexpanded_left = ast::UnexpandedArithmeticExpr {
-                value: left.value.clone(),
-            };
-            let unexpanded_right = ast::UnexpandedArithmeticExpr {
-                value: right.value.clone(),
-            };
-            let left = unexpanded_left.eval(shell, false).await?;
-            let right = unexpanded_right.eval(shell, false).await?;
+            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
+            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -285,14 +278,8 @@ async fn apply_binary_predicate(
             Ok(left == right)
         }
         ast::BinaryPredicate::ArithmeticNotEqualTo => {
-            let unexpanded_left = ast::UnexpandedArithmeticExpr {
-                value: left.value.clone(),
-            };
-            let unexpanded_right = ast::UnexpandedArithmeticExpr {
-                value: right.value.clone(),
-            };
-            let left = unexpanded_left.eval(shell, false).await?;
-            let right = unexpanded_right.eval(shell, false).await?;
+            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
+            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -301,14 +288,8 @@ async fn apply_binary_predicate(
             Ok(left != right)
         }
         ast::BinaryPredicate::ArithmeticLessThan => {
-            let unexpanded_left = ast::UnexpandedArithmeticExpr {
-                value: left.value.clone(),
-            };
-            let unexpanded_right = ast::UnexpandedArithmeticExpr {
-                value: right.value.clone(),
-            };
-            let left = unexpanded_left.eval(shell, false).await?;
-            let right = unexpanded_right.eval(shell, false).await?;
+            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
+            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -317,14 +298,8 @@ async fn apply_binary_predicate(
             Ok(left < right)
         }
         ast::BinaryPredicate::ArithmeticLessThanOrEqualTo => {
-            let unexpanded_left = ast::UnexpandedArithmeticExpr {
-                value: left.value.clone(),
-            };
-            let unexpanded_right = ast::UnexpandedArithmeticExpr {
-                value: right.value.clone(),
-            };
-            let left = unexpanded_left.eval(shell, false).await?;
-            let right = unexpanded_right.eval(shell, false).await?;
+            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
+            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -333,14 +308,8 @@ async fn apply_binary_predicate(
             Ok(left <= right)
         }
         ast::BinaryPredicate::ArithmeticGreaterThan => {
-            let unexpanded_left = ast::UnexpandedArithmeticExpr {
-                value: left.value.clone(),
-            };
-            let unexpanded_right = ast::UnexpandedArithmeticExpr {
-                value: right.value.clone(),
-            };
-            let left = unexpanded_left.eval(shell, false).await?;
-            let right = unexpanded_right.eval(shell, false).await?;
+            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
+            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -349,14 +318,8 @@ async fn apply_binary_predicate(
             Ok(left > right)
         }
         ast::BinaryPredicate::ArithmeticGreaterThanOrEqualTo => {
-            let unexpanded_left = ast::UnexpandedArithmeticExpr {
-                value: left.value.clone(),
-            };
-            let unexpanded_right = ast::UnexpandedArithmeticExpr {
-                value: right.value.clone(),
-            };
-            let left = unexpanded_left.eval(shell, false).await?;
-            let right = unexpanded_right.eval(shell, false).await?;
+            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
+            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -9,7 +9,7 @@ use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::arithmetic::ExpandAndEvaluate;
+use crate::arithmetic::{self, ExpandAndEvaluate};
 use crate::commands::{self, CommandArg, CommandSpawnResult};
 use crate::env::{EnvironmentLookup, EnvironmentScope};
 use crate::openfiles::{OpenFile, OpenFiles};
@@ -1219,8 +1219,7 @@ async fn apply_assignment(
 
         if will_be_indexed_array {
             array_index = Some(
-                ast::UnexpandedArithmeticExpr { value: idx.clone() }
-                    .eval(shell, false)
+                arithmetic::expand_and_eval(shell, idx.as_str(), false)
                     .await?
                     .to_string(),
             );


### PR DESCRIPTION
When we have a string that needs to be interpreted as an unexpanded arithmetic expression, there's no reason to wrap it in a struct that insists on an owned copy; we can directly pass through the `&str` to the core logic that's performing expansion and evaluation.