### PR TITLE
feat(options): implement dotglob semantics

### DIFF
--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -260,6 +260,7 @@ impl Spec {
             let expansions = pattern.expand(
                 shell.working_dir.as_path(),
                 Some(&patterns::Pattern::accept_all_expand_filter),
+                &patterns::FilenameExpansionOptions::default(),
             )?;
 
             for expansion in expansions {
@@ -1062,7 +1063,11 @@ async fn get_file_completions(
         .set_case_insensitive(shell.options.case_insensitive_pathname_expansion);
 
     pattern
-        .expand(shell.working_dir.as_path(), Some(&path_filter))
+        .expand(
+            shell.working_dir.as_path(),
+            Some(&path_filter),
+            &patterns::FilenameExpansionOptions::default(),
+        )
         .unwrap_or_default()
         .into_iter()
         .collect()

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -581,10 +581,15 @@ impl<'a> WordExpander<'a> {
             .set_extended_globbing(self.parser_options.enable_extended_globbing)
             .set_case_insensitive(self.shell.options.case_insensitive_pathname_expansion);
 
+        let options = patterns::FilenameExpansionOptions {
+            require_dot_in_pattern_to_match_dot_files: !self.shell.options.glob_matches_dotfiles,
+        };
+
         let expansions = pattern
             .expand(
                 self.shell.working_dir.as_path(),
                 Some(&patterns::Pattern::accept_all_expand_filter),
+                &options,
             )
             .unwrap_or_default();
 

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -976,7 +976,11 @@ impl Shell {
                     .set_case_insensitive(self.options.case_insensitive_pathname_expansion);
 
             // TODO: Pass through quoting.
-            if let Ok(entries) = pattern.expand(&self.working_dir, Some(&is_executable)) {
+            if let Ok(entries) = pattern.expand(
+                &self.working_dir,
+                Some(&is_executable),
+                &patterns::FilenameExpansionOptions::default(),
+            ) {
                 for entry in entries {
                     executables.push(PathBuf::from(entry));
                 }

--- a/brush-shell/tests/cases/patterns/filename_expansion.yaml
+++ b/brush-shell/tests/cases/patterns/filename_expansion.yaml
@@ -197,7 +197,7 @@ cases:
       echo "test.*"
 
   - name: "Pathname expansion: dot files (no dotglob)"
-    known_failure: true # https://github.com/reubeno/brush/issues/328
+    min_oracle_version: 5.2
     stdin: |
       touch .file
       touch .dir
@@ -210,7 +210,7 @@ cases:
       echo "./.*: " ./.*
 
   - name: "Pathname expansion: dot files (with dotglob)"
-    skip: true # TODO: passes on *some* platforms but not others (due to . and ..); needs investigation
+    min_oracle_version: 5.2
     stdin: |
       touch .file
       touch .dir


### PR DESCRIPTION
Ensures that filename expansion complies with `dotglob` option setting. The tests added are marked for bash 5.2+ as the oracle, since we're seeing different results from earlier versions of bash related to enumeration of `.` and `..`.

Resolves #328 