### PR TITLE
fix(for): correct semantics for "for" without "in"

### DIFF
--- a/brush-shell/tests/cases/compound_cmds/for.yaml
+++ b/brush-shell/tests/cases/compound_cmds/for.yaml
@@ -4,9 +4,35 @@ cases:
     stdin: |
       for f in 1 2 3; do echo $f; done
 
+  - name: "Multi-line for loop"
+    stdin: |
+      for f in 1 2 3; do
+        echo $f
+      done
+
   - name: "Empty for loop"
     stdin: |
       for f in; do echo $f; done
+
+  - name: "for loop without in"
+    stdin: |
+      set -- a b c
+
+      echo "Loop 1"
+      for f; do echo $f; done
+
+      echo "Loop 2: no semicolon"
+      for f do echo $f; done
+
+  - name: "for loop without in but spaces"
+    stdin: |
+      set -- a "b c" d
+
+      echo "Loop 1"
+      for f; do echo $f; done
+
+      echo "Loop 2: no semicolon"
+      for f do echo $f; done
 
   - name: "Break in for loop"
     stdin: |


### PR DESCRIPTION
When `in` is not specified with a `for` clause, we need to enumerate positional arguments instead (i.e., $@).

This scenario was getting parsed correctly, but not correctly interpreted.

Resolves #342. Thanks to @ko1nksm for identifying the problem and filing a bug report on it!