### PR TITLE
fix(arithmetic): recursively evaluate var references

### DIFF
--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -157,8 +157,10 @@ fn deref_lvalue(shell: &mut Shell, lvalue: &ast::ArithmeticTarget) -> Result<i64
         }
     };
 
-    let value: i64 = value_str.parse().unwrap_or(0);
-    Ok(value)
+    let parsed_value = brush_parser::arithmetic::parse(value_str.as_ref())
+        .map_err(|_err| EvalError::ParseError(value_str.to_string()))?;
+
+    parsed_value.eval(shell)
 }
 
 #[allow(clippy::unnecessary_wraps)]

--- a/brush-shell/tests/cases/arithmetic.yaml
+++ b/brush-shell/tests/cases/arithmetic.yaml
@@ -77,9 +77,26 @@ cases:
   - name: "Variable references"
     stdin: |
       x=10
-
       echo "x => $((x))"
       echo "x + 1 => $((x+1))"
+
+      y=
+      echo "y => $((y))"
+      echo "y + 1 => $((y+1))"
+
+      z=notnumber
+      echo "z => $((z))"
+      echo "z + 1 => $((z+1))"
+
+  - name: "Complex variable references"
+    stdin: |
+      x=10
+      y=20
+      z=x+y
+      a=z+z
+
+      echo "z => $((z))"
+      echo "a => $((a))"
 
   - name: "Nested expressions"
     stdin: |
@@ -118,6 +135,12 @@ cases:
 
       echo "--x == $((--x))"
       echo "x is now $x"
+
+  - name: "Assignment with references"
+    stdin: |
+      x=10+3
+      echo "y = x => $((y = x))"
+      echo "y is now $y"
 
   - name: "Assignments in logical boolean expressions"
     known_failure: false


### PR DESCRIPTION
In an arithmetic expression, we need to recursively parse and evaluate the body of any bare variable references.

Resolves #345.