### PR TITLE
build: partially revert recent arm64 changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,11 +48,12 @@ jobs:
             required_tools: ""
             binary_name: "brush"
             extra_build_args: ""
-          # Build for aarch64/linux target on native host.
-          - host: "ubuntu-24.04-arm"
-            target: ""
+          # Build for aarch64/linux target on x86_64/Linux host.
+          - host: "ubuntu-24.04"
+            target: "aarch64-unknown-linux-gnu"
             os: "linux"
             arch: "aarch64"
+            required_tools: "gcc-aarch64-linux-gnu"
             binary_name: "brush"
             extra_build_args: ""
           # Build for WASI-0.2 target on x86_64/linux host.
@@ -134,11 +135,12 @@ jobs:
             name_suffix: "(linux/x86_64)"
             homebrew_supported: true
 
-          - host: "ubuntu-24.04-arm"
-            variant: "linux-aarch64"
-            artifact_suffix: "linux-aarch64"
-            name_suffix: "(linux/aarch64)"
-            homebrew_supported: false
+          # TODO: Reenable this once compiler ICEs have been resolved.
+          # - host: "ubuntu-24.04-arm"
+          #   variant: "linux-aarch64"
+          #   artifact_suffix: "linux-aarch64"
+          #   name_suffix: "(linux/aarch64)"
+          #   homebrew_supported: false
 
           - host: "macos-latest"
             variant: "macos"


### PR DESCRIPTION
We've been running into internal compiler errors compiling for arm64 since #335 . For now, we'll revert most of that change to unblock other work.