### PR TITLE
fix(arithmetic): fixes for nested parenthesis parsing in arithmetic

### DIFF
--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 
 [features]
 fuzz-testing = ["dep:arbitrary"]
+debug-tracing = ["peg/trace"]
 
 [dependencies]
 arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }

--- a/brush-shell/tests/cases/arithmetic.yaml
+++ b/brush-shell/tests/cases/arithmetic.yaml
@@ -20,13 +20,24 @@ cases:
 
   - name: "Parentheses"
     stdin: |
-      echo "$(( (10) ))"
       echo "$(((10)))"
+      echo "$((((10))))"
+      echo "$(((((10)))))"
 
-  - name: "Unquoted parentheses"
-    stdin: |
-      echo $(( (10) ))
-      echo $(((10)))
+      echo "$(( (10) ))"
+      echo "$(( (1+2) ))"
+      echo "$(( (1 + 2) ))"
+
+      echo "$(( ((1+2)) ))"
+      echo "$(( ((1 + 2)) ))"
+
+      echo "$(((1+2)*3))"
+      echo "$(((1 + 2) * 3))"
+      echo "$(( (1 + 2) * 3 ))"
+
+      echo "$((((1+2)*3)))"
+      echo "$(( ((1 + 2) * 3) ))"
+      echo "$(( ( (1 + 2) * 3 ) ))"
 
   - name: "Basic quoted arithmetic"
     stdin: |


### PR DESCRIPTION
* Fixes parsing of certain cases of nested parenthetical expressions in arithmetic
* Adds compat tests and unit tests for arithmetic parsing of these and similar cases
* Adds new feature flag (`"debug-tracing"`) to the `brush-parser` crate for debugging the rust-peg based parsers; supports integration with `pegviz` for easier visualization.

Resolves #343 