### PR TITLE
feat(env): introduce dynamic vars backed by rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "darling"
@@ -1312,13 +1312,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1980,9 +1980,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.8.0",
  "errno",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336a0c23cf42a38d9eaa7cd22c7040d04e1228a19a933890805ffd00a16437d2"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.13.2"
+version = "12.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8150eae9699e3c73a3e6431dc1f80d87748797c0457336af23e94c1de619ed24"
+checksum = "13a4dfe4bbeef59c1f32fc7524ae7c95b9e1de5e79a43ce1604e181081d71b0c"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2192,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.13.2"
+version = "12.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f4a9846f7a8933b6d198c022faa2c9bd89e1a970bed9d9a98d25708bf8de17"
+checksum = "98cf6a95abff97de4d7ff3473f33cacd38f1ddccad5c1feab435d6760300e3b6"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -2472,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2517,9 +2517,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom",
 ]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you feel so inclined, we'd love contributions toward any of the above, with b
 
 ## Testing strategy
 
-This project is primarily tested by comparing its behavior with other existing shells, leveraging the latter as test oracles. The integration tests implemented in this repo include [525+ test cases](brush-shell/tests/cases) run on both this shell and an oracle, comparing standard output and exit codes.
+This project is primarily tested by comparing its behavior with other existing shells, leveraging the latter as test oracles. The integration tests implemented in this repo include [550+ test cases](brush-shell/tests/cases) run on both this shell and an oracle, comparing standard output and exit codes.
 
 For more details, please consult the [reference documentation on integration testing](docs/reference/integration-testing.md).
 

--- a/brush-core/src/builtins/cd.rs
+++ b/brush-core/src/builtins/cd.rs
@@ -49,7 +49,7 @@ impl builtins::Command for CdCommand {
             // `cd -', equivalent to `cd $OLDPWD'
             if target_dir.as_os_str() == "-" {
                 should_print = true;
-                if let Some(oldpwd) = context.shell.env.get_str("OLDPWD") {
+                if let Some(oldpwd) = context.shell.get_env_str("OLDPWD") {
                     PathBuf::from(oldpwd.to_string())
                 } else {
                     writeln!(context.stderr(), "OLDPWD not set")?;
@@ -61,7 +61,7 @@ impl builtins::Command for CdCommand {
             }
         // `cd' without arguments is equivalent to `cd $HOME'
         } else {
-            if let Some(home_var) = context.shell.env.get_str("HOME") {
+            if let Some(home_var) = context.shell.get_env_str("HOME") {
                 PathBuf::from(home_var.to_string())
             } else {
                 writeln!(context.stderr(), "HOME not set")?;

--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -203,7 +203,7 @@ impl DeclareCommand {
                 Ok(false)
             }
         } else if let Some(variable) = context.shell.env.get_using_policy(name, lookup) {
-            let mut cs = variable.get_attribute_flags();
+            let mut cs = variable.get_attribute_flags(context.shell);
             if cs.is_empty() {
                 cs.push('-');
             }
@@ -467,7 +467,7 @@ impl DeclareCommand {
             .sorted_by_key(|v| v.0)
         {
             if self.print {
-                let mut cs = variable.get_attribute_flags();
+                let mut cs = variable.get_attribute_flags(context.shell);
                 if cs.is_empty() {
                     cs.push('-');
                 }

--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -219,7 +219,7 @@ impl DeclareCommand {
                 "declare -{cs} {name}{separator_str}{}",
                 variable
                     .value()
-                    .format(variables::FormatStyle::DeclarePrint)?
+                    .format(variables::FormatStyle::DeclarePrint, context.shell)?
             )?;
 
             Ok(true)
@@ -483,13 +483,15 @@ impl DeclareCommand {
                     "declare -{cs} {name}{separator_str}{}",
                     variable
                         .value()
-                        .format(variables::FormatStyle::DeclarePrint)?
+                        .format(variables::FormatStyle::DeclarePrint, context.shell)?
                 )?;
             } else {
                 writeln!(
                     context.stdout(),
                     "{name}={}",
-                    variable.value().format(variables::FormatStyle::Basic)?
+                    variable
+                        .value()
+                        .format(variables::FormatStyle::Basic, context.shell)?
                 )?;
             }
         }

--- a/brush-core/src/builtins/export.rs
+++ b/brush-core/src/builtins/export.rs
@@ -98,7 +98,7 @@ impl builtins::Command for ExportCommand {
                         context.stdout(),
                         "declare -x {}=\"{}\"",
                         name,
-                        variable.value().to_cow_string()
+                        variable.value().to_cow_str(context.shell)
                     )?;
                 }
             }

--- a/brush-core/src/builtins/getopts.rs
+++ b/brush-core/src/builtins/getopts.rs
@@ -67,8 +67,7 @@ impl builtins::Command for GetOptsCommand {
         // If unset, assume OPTIND is 1.
         let mut next_index: usize = context
             .shell
-            .env
-            .get_str("OPTIND")
+            .get_env_str("OPTIND")
             .unwrap_or(Cow::Borrowed("1"))
             .parse()?;
 
@@ -92,8 +91,7 @@ impl builtins::Command for GetOptsCommand {
                 const DEFAULT_NEXT_CHAR_INDEX: usize = 1;
                 let next_char_index = context
                     .shell
-                    .env
-                    .get_str(VAR_GETOPTS_NEXT_CHAR_INDEX)
+                    .get_env_str(VAR_GETOPTS_NEXT_CHAR_INDEX)
                     .map_or(DEFAULT_NEXT_CHAR_INDEX, |s| {
                         s.parse().unwrap_or(DEFAULT_NEXT_CHAR_INDEX)
                     });

--- a/brush-core/src/builtins/set.rs
+++ b/brush-core/src/builtins/set.rs
@@ -400,7 +400,8 @@ fn display_all(context: &commands::ExecutionContext<'_>) -> Result<(), error::Er
         writeln!(
             context.stdout(),
             "{name}={}",
-            var.value().format(variables::FormatStyle::Basic)?,
+            var.value()
+                .format(variables::FormatStyle::Basic, context.shell)?,
         )?;
     }
 

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -226,7 +226,7 @@ pub(crate) fn compose_std_command<S: AsRef<OsStr>>(
     if !empty_env {
         for (name, var) in shell.env.iter() {
             if var.is_exported() {
-                let value_as_str = var.value().to_cow_string();
+                let value_as_str = var.value().to_cow_str(shell);
                 cmd.env(name, value_as_str.as_ref());
             }
         }

--- a/brush-core/src/env.rs
+++ b/brush-core/src/env.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::error;
+use crate::shell;
 use crate::variables::{self, ShellValue, ShellValueUnsetType, ShellVariable};
 
 /// Represents the policy for looking up variables in a shell environment.
@@ -179,9 +180,10 @@ impl ShellEnvironment {
     /// # Arguments
     ///
     /// * `name` - The name of the variable to retrieve.
-    pub fn get_str<S: AsRef<str>>(&self, name: S) -> Option<Cow<'_, str>> {
+    /// * `shell` - The shell owning the environment.
+    pub fn get_str<S: AsRef<str>>(&self, name: S, shell: &shell::Shell) -> Option<Cow<'_, str>> {
         self.get(name.as_ref())
-            .map(|(_, v)| v.value().to_cow_string())
+            .map(|(_, v)| v.value().to_cow_str(shell))
     }
 
     /// Checks if a variable of the given name is set in the environment.

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -949,7 +949,7 @@ impl<'a> WordExpander<'a> {
                     .try_resolve_parameter_to_variable(&parameter, indirect)
                     .await?
                 {
-                    Ok(var.get_attribute_flags().into())
+                    Ok(var.get_attribute_flags(self.shell).into())
                 } else {
                     Ok(String::new().into())
                 }
@@ -966,7 +966,7 @@ impl<'a> WordExpander<'a> {
                     let assignable_value_str =
                         var.value().to_assignable_str(index.as_deref(), self.shell);
 
-                    let mut attr_str = var.get_attribute_flags();
+                    let mut attr_str = var.get_attribute_flags(self.shell);
                     if attr_str.is_empty() {
                         attr_str.push('-');
                     }
@@ -974,7 +974,6 @@ impl<'a> WordExpander<'a> {
                     match var.value() {
                         ShellValue::IndexedArray(_)
                         | ShellValue::AssociativeArray(_)
-                        | ShellValue::Random
                         // TODO(dynamic): confirm this
                         | ShellValue::Dynamic { .. } => {
                             let equals_or_nothing = if assignable_value_str.is_empty() {
@@ -1379,7 +1378,7 @@ impl<'a> WordExpander<'a> {
                 Ok(Expansion::from(self.shell.last_exit_status.to_string()))
             }
             brush_parser::word::SpecialParameter::CurrentOptionFlags => {
-                Ok(Expansion::from(self.shell.current_option_flags()))
+                Ok(Expansion::from(self.shell.options.get_option_flags()))
             }
             brush_parser::word::SpecialParameter::ProcessId => {
                 Ok(Expansion::from(std::process::id().to_string()))

--- a/brush-core/src/pathcache.rs
+++ b/brush-core/src/pathcache.rs
@@ -1,3 +1,4 @@
+use crate::{error, variables};
 use std::path::PathBuf;
 
 /// A cache of paths associated with names.
@@ -29,6 +30,17 @@ impl PathCache {
     /// * `name` - The name to set.
     pub fn set<S: AsRef<str>>(&mut self, name: S, path: PathBuf) {
         self.cache.insert(name.as_ref().to_string(), path);
+    }
+
+    /// Projects the cache into a shell value.
+    pub fn to_value(&self) -> Result<variables::ShellValue, error::Error> {
+        let pairs = self
+            .cache
+            .iter()
+            .map(|(k, v)| (Some(k.to_owned()), v.to_string_lossy().to_string()))
+            .collect::<Vec<_>>();
+
+        variables::ShellValue::associative_array_from_literals(variables::ArrayLiteral(pairs))
     }
 
     /// Removes the path associated with the given name, if there is one.

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1075,46 +1075,47 @@ impl Shell {
 
     /// Composes the shell's post-input, pre-command prompt, applying all appropriate expansions.
     pub async fn compose_precmd_prompt(&mut self) -> Result<String, error::Error> {
-        self.expand_prompt_var_in_subshell("PS0", "").await
+        self.expand_prompt_var("PS0", "").await
     }
 
     /// Composes the shell's prompt, applying all appropriate expansions.
     pub async fn compose_prompt(&mut self) -> Result<String, error::Error> {
-        self.expand_prompt_var_in_subshell("PS1", self.default_prompt())
-            .await
+        self.expand_prompt_var("PS1", self.default_prompt()).await
     }
 
     /// Compose's the shell's alternate-side prompt, applying all appropriate expansions.
     #[allow(clippy::unused_async)]
     pub async fn compose_alt_side_prompt(&mut self) -> Result<String, error::Error> {
         // This is a brush extension.
-        self.expand_prompt_var_in_subshell("BRUSH_PS_ALT", "").await
+        self.expand_prompt_var("BRUSH_PS_ALT", "").await
     }
 
     /// Composes the shell's continuation prompt.
     pub async fn compose_continuation_prompt(&mut self) -> Result<String, error::Error> {
-        self.expand_prompt_var_in_subshell("PS2", "> ").await
+        self.expand_prompt_var("PS2", "> ").await
     }
 
-    async fn expand_prompt_var_in_subshell(
+    async fn expand_prompt_var(
         &mut self,
         var_name: &str,
         default: &str,
     ) -> Result<String, error::Error> {
-        // Create subshell.
-        let mut subshell = self.clone();
+        //
+        // TODO(prompt): bash appears to do this in a subshell; we need to investigate
+        // if that's required.
+        //
 
         // Retrieve the spec.
-        let prompt_spec = subshell.parameter_or_default(var_name, default);
+        let prompt_spec = self.parameter_or_default(var_name, default);
         if prompt_spec.is_empty() {
             return Ok(String::new());
         }
 
         // Expand it.
-        let formatted_prompt = prompt::expand_prompt(&subshell, prompt_spec.into_owned())?;
+        let formatted_prompt = prompt::expand_prompt(self, prompt_spec.into_owned())?;
 
         // Now expand.
-        expansion::basic_expand_str(&mut subshell, &formatted_prompt).await
+        expansion::basic_expand_str(self, &formatted_prompt).await
     }
 
     /// Returns the exit status of the last command executed in this shell.

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -442,12 +442,19 @@ impl Shell {
         )?;
 
         // GROUPS
-        let groups = sys::users::get_user_group_ids().unwrap_or_default();
+        // N.B. We could compute this up front, but we choose to make it dynamic so that we
+        // don't have to make costly system calls if the user never accesses it.
         self.env.set_global(
             "GROUPS",
-            ShellVariable::new(ShellValue::indexed_array_from_strings(
-                groups.into_iter().map(|gid| gid.to_string()),
-            )),
+            ShellVariable::new(ShellValue::Dynamic {
+                getter: |_shell| {
+                    let groups = sys::users::get_user_group_ids().unwrap_or_default();
+                    ShellValue::indexed_array_from_strings(
+                        groups.into_iter().map(|gid| gid.to_string()),
+                    )
+                },
+                setter: |_| (),
+            }),
         )?;
 
         // TODO(vars): implement HISTCMD

--- a/brush-core/src/sys/stubs/users.rs
+++ b/brush-core/src/sys/stubs/users.rs
@@ -25,6 +25,10 @@ pub(crate) fn get_current_username() -> Result<String, error::Error> {
     error::unimp("get current username")
 }
 
+pub(crate) fn get_user_group_ids() -> Result<Vec<u32>, error::Error> {
+    Ok(vec![])
+}
+
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
     Ok(vec![])
 }

--- a/brush-core/src/sys/unix/users.rs
+++ b/brush-core/src/sys/unix/users.rs
@@ -40,6 +40,13 @@ pub(crate) fn get_current_username() -> Result<String, error::Error> {
     Ok(username.to_string_lossy().to_string())
 }
 
+pub(crate) fn get_user_group_ids() -> Result<Vec<u32>, error::Error> {
+    let username = uzers::get_current_username().ok_or_else(|| error::Error::NoCurrentUser)?;
+    let gid = uzers::get_current_gid();
+    let groups = uzers::get_user_groups(&username, gid).unwrap_or_default();
+    Ok(groups.into_iter().map(|g| g.gid()).collect())
+}
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
     // TODO: uzers::all_users() is available but unsafe

--- a/brush-core/src/sys/windows/users.rs
+++ b/brush-core/src/sys/windows/users.rs
@@ -31,6 +31,11 @@ pub(crate) fn get_current_username() -> Result<String, error::Error> {
     Ok(username)
 }
 
+pub(crate) fn get_user_group_ids() -> Result<Vec<u32>, error::Error> {
+    // TODO: implement some version of this for Windows
+    Ok(vec![])
+}
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
     // TODO: implement some version of this for Windows

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::{Display, Write};
 
+use crate::shell::Shell;
 use crate::{error, escape};
 
 /// A shell variable.
@@ -179,7 +180,10 @@ impl ShellVariable {
             }
             _ => {
                 let mut new_values = BTreeMap::new();
-                new_values.insert(0, self.value.to_cow_string().to_string());
+                new_values.insert(
+                    0,
+                    self.value.to_cow_str_without_dynamic_support().to_string(),
+                );
                 self.value = ShellValue::IndexedArray(new_values);
                 Ok(())
             }
@@ -195,7 +199,10 @@ impl ShellVariable {
             }
             _ => {
                 let mut new_values: BTreeMap<String, String> = BTreeMap::new();
-                new_values.insert(String::from("0"), self.value.to_cow_string().to_string());
+                new_values.insert(
+                    String::from("0"),
+                    self.value.to_cow_str_without_dynamic_support().to_string(),
+                );
                 self.value = ShellValue::AssociativeArray(new_values);
                 Ok(())
             }
@@ -208,6 +215,7 @@ impl ShellVariable {
     ///
     /// * `value` - The value to assign to the variable.
     /// * `append` - Whether or not to append the value to the preexisting value.
+    #[allow(clippy::too_many_lines)]
     pub fn assign(&mut self, value: ShellValueLiteral, append: bool) -> Result<(), error::Error> {
         if self.is_readonly() {
             return Err(error::Error::ReadonlyVariable);
@@ -282,7 +290,8 @@ impl ShellVariable {
                     }
                 },
                 ShellValue::Unset(_) => unreachable!("covered in conversion above"),
-                ShellValue::Random => Ok(()),
+                // TODO(dynamic): implement appending to dynamic vars
+                ShellValue::Random | ShellValue::Dynamic { .. } => Ok(()),
             }
         } else {
             match (&self.value, value) {
@@ -306,7 +315,8 @@ impl ShellVariable {
                         ShellValueUnsetType::IndexedArray | ShellValueUnsetType::Untyped,
                     )
                     | ShellValue::String(_)
-                    | ShellValue::Random,
+                    | ShellValue::Random
+                    | ShellValue::Dynamic { .. },
                     ShellValueLiteral::Array(literal_values),
                 ) => {
                     self.value = ShellValue::indexed_array_from_literals(literal_values)?;
@@ -325,7 +335,8 @@ impl ShellVariable {
                 }
 
                 // Drop other updates to random values.
-                (ShellValue::Random, _) => Ok(()),
+                // TODO(dynamic): Allow updates to dynamic values
+                (ShellValue::Random | ShellValue::Dynamic { .. }, _) => Ok(()),
 
                 // Assign a scalar value to a scalar or unset (and untyped) variable.
                 (ShellValue::String(_) | ShellValue::Unset(_), ShellValueLiteral::Scalar(s)) => {
@@ -461,6 +472,7 @@ impl ShellVariable {
                 let key = index.parse::<u64>().unwrap_or(0);
                 Ok(values.remove(&key).is_some())
             }
+            ShellValue::Dynamic { .. } => Ok(false),
         }
     }
 
@@ -507,6 +519,9 @@ impl ShellVariable {
     }
 }
 
+type DynamicValueGetter = fn(&Shell) -> ShellValue;
+type DynamicValueSetter = fn(&Shell) -> ();
+
 /// A shell value.
 #[derive(Clone, Debug)]
 pub enum ShellValue {
@@ -520,6 +535,13 @@ pub enum ShellValue {
     IndexedArray(BTreeMap<u64, String>),
     /// A special value that yields a different random number each time its read.
     Random,
+    /// A value that is dynamically computed.
+    Dynamic {
+        /// Function that can query the value.
+        getter: DynamicValueGetter,
+        /// Function that receives value update requests.
+        setter: DynamicValueSetter,
+    },
 }
 
 /// The type of an unset shell value.
@@ -716,7 +738,7 @@ impl ShellValue {
     /// # Arguments
     ///
     /// * `style` - The style to use for formatting the value.
-    pub fn format(&self, style: FormatStyle) -> Result<Cow<'_, str>, error::Error> {
+    pub fn format(&self, style: FormatStyle, shell: &Shell) -> Result<Cow<'_, str>, error::Error> {
         match self {
             ShellValue::Unset(_) => Ok("".into()),
             ShellValue::String(s) => {
@@ -758,6 +780,11 @@ impl ShellValue {
                 Ok(result.into())
             }
             ShellValue::Random => Ok(std::format!("\"{}\"", get_random_str()).into()),
+            ShellValue::Dynamic { getter, .. } => {
+                let dynamic_value = getter(shell);
+                let result = dynamic_value.format(style, shell)?.to_string();
+                Ok(result.into())
+            }
         }
     }
 
@@ -767,7 +794,7 @@ impl ShellValue {
     ///
     /// * `index` - The index at which to retrieve the value.
     #[allow(clippy::unnecessary_wraps)]
-    pub fn get_at(&self, index: &str) -> Result<Option<Cow<'_, str>>, error::Error> {
+    pub fn get_at(&self, index: &str, shell: &Shell) -> Result<Option<Cow<'_, str>>, error::Error> {
         match self {
             ShellValue::Unset(_) => Ok(None),
             ShellValue::String(s) => {
@@ -785,32 +812,50 @@ impl ShellValue {
                 Ok(values.get(&key).map(|s| Cow::Borrowed(s.as_str())))
             }
             ShellValue::Random => Ok(Some(Cow::Owned(get_random_str()))),
+            ShellValue::Dynamic { getter, .. } => {
+                let dynamic_value = getter(shell);
+                let result = dynamic_value.get_at(index, shell)?;
+                Ok(result.map(|s| s.to_string().into()))
+            }
         }
     }
 
     /// Returns the keys of the elements in this variable.
-    pub fn get_element_keys(&self) -> Vec<String> {
+    pub fn get_element_keys(&self, shell: &Shell) -> Vec<String> {
         match self {
             ShellValue::Unset(_) => vec![],
             ShellValue::String(_) | ShellValue::Random => vec!["0".to_owned()],
             ShellValue::AssociativeArray(array) => array.keys().map(|k| k.to_owned()).collect(),
             ShellValue::IndexedArray(array) => array.keys().map(|k| k.to_string()).collect(),
+            ShellValue::Dynamic { getter, .. } => getter(shell).get_element_keys(shell),
         }
     }
 
     /// Returns the values of the elements in this variable.
-    pub fn get_element_values(&self) -> Vec<String> {
+    pub fn get_element_values(&self, shell: &Shell) -> Vec<String> {
         match self {
             ShellValue::Unset(_) => vec![],
             ShellValue::String(s) => vec![s.to_owned()],
             ShellValue::AssociativeArray(array) => array.values().map(|v| v.to_owned()).collect(),
             ShellValue::IndexedArray(array) => array.values().map(|v| v.to_owned()).collect(),
             ShellValue::Random => vec![get_random_str()],
+            ShellValue::Dynamic { getter, .. } => getter(shell).get_element_values(shell),
         }
     }
 
     /// Converts this value to a string.
-    pub fn to_cow_string(&self) -> Cow<'_, str> {
+    pub fn to_cow_str(&self, shell: &Shell) -> Cow<'_, str> {
+        match self {
+            ShellValue::Dynamic { getter, .. } => {
+                let dynamic_value = getter(shell);
+                let result = dynamic_value.to_cow_str(shell).to_string();
+                result.into()
+            }
+            _ => self.to_cow_str_without_dynamic_support(),
+        }
+    }
+
+    fn to_cow_str_without_dynamic_support(&self) -> Cow<'_, str> {
         match self {
             ShellValue::Unset(_) => Cow::Borrowed(""),
             ShellValue::String(s) => Cow::Borrowed(s.as_str()),
@@ -821,6 +866,7 @@ impl ShellValue {
                 .get(&0)
                 .map_or_else(|| Cow::Borrowed(""), |s| Cow::Borrowed(s.as_str())),
             ShellValue::Random => Cow::Owned(get_random_str()),
+            ShellValue::Dynamic { .. } => "".into(),
         }
     }
 
@@ -829,22 +875,25 @@ impl ShellValue {
     /// # Arguments
     ///
     /// * `index` - The index at which to retrieve the value, if indexing is to be performed.
-    pub fn to_assignable_str(&self, index: Option<&str>) -> String {
+    pub fn to_assignable_str(&self, index: Option<&str>, shell: &Shell) -> String {
         match self {
             ShellValue::Unset(_) => String::new(),
             ShellValue::String(s) => quote_str_for_assignment(s.as_str()),
             ShellValue::AssociativeArray(_) | ShellValue::IndexedArray(_) => {
                 if let Some(index) = index {
-                    if let Ok(Some(value)) = self.get_at(index) {
+                    if let Ok(Some(value)) = self.get_at(index, shell) {
                         quote_str_for_assignment(value.as_ref())
                     } else {
                         String::new()
                     }
                 } else {
-                    self.format(FormatStyle::DeclarePrint).unwrap().into_owned()
+                    self.format(FormatStyle::DeclarePrint, shell)
+                        .unwrap()
+                        .into_owned()
                 }
             }
             ShellValue::Random => quote_str_for_assignment(get_random_str().as_str()),
+            ShellValue::Dynamic { getter, .. } => getter(shell).to_assignable_str(index, shell),
         }
     }
 }

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -118,7 +118,7 @@ pub trait InteractiveShell {
             shell_mut.check_for_completed_jobs()?;
 
             // If there's a variable called PROMPT_COMMAND, then run it first.
-            if let Some(prompt_cmd) = shell_mut.env.get_str("PROMPT_COMMAND") {
+            if let Some(prompt_cmd) = shell_mut.get_env_str("PROMPT_COMMAND") {
                 // Save (and later restore) the last exit status.
                 let prev_last_result = shell_mut.last_exit_status;
 

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -121,12 +121,15 @@ pub trait InteractiveShell {
             if let Some(prompt_cmd) = shell_mut.get_env_str("PROMPT_COMMAND") {
                 // Save (and later restore) the last exit status.
                 let prev_last_result = shell_mut.last_exit_status;
+                let prev_last_pipeline_statuses = shell_mut.last_pipeline_statuses.clone();
 
                 let params = shell_mut.default_exec_params();
 
                 shell_mut
                     .run_string(prompt_cmd.into_owned(), &params)
                     .await?;
+
+                shell_mut.last_pipeline_statuses = prev_last_pipeline_statuses;
                 shell_mut.last_exit_status = prev_last_result;
             }
 

--- a/brush-shell/tests/cases/basic.yaml
+++ b/brush-shell/tests/cases/basic.yaml
@@ -21,13 +21,5 @@ cases:
           exit 22
     args: ["./script.sh"]
 
-  - name: "Basic defaulted PATH var"
-    stdin: |
-      if [[ -z "$PATH" ]]; then
-        echo "PATH is not set or is empty"
-      else
-        echo "PATH is set and non-empty"
-      fi
-
   - name: "Ensure ~ is resolvable"
     stdin: "test ~"

--- a/brush-shell/tests/cases/status.yaml
+++ b/brush-shell/tests/cases/status.yaml
@@ -1,0 +1,35 @@
+name: "Status tests"
+cases:
+  - name: "Basic status"
+    stdin: |
+      cat /non/existent >/dev/null
+      echo "[1] Status: $?; pipe status: ${PIPESTATUS[@]}"
+
+  - name: "Parse error status"
+    known_failure: true # Needs investigation
+    ignore_stderr: true
+    stdin: |
+      # Generate parse error
+      for f done
+      echo "[2] Status: $?; pipe status: ${PIPESTATUS[@]}"
+
+  - name: "Pipeline status"
+    stdin: |
+      /non/existent/program 2>/dev/null | cat
+      echo "Status: $?; pipe status: ${PIPESTATUS[@]}"
+
+  - name: "Command substitution status"
+    stdin: |
+      x=$(echo hi | wc -l)
+      echo "[1] Status: $?; pipe status: ${PIPESTATUS[@]}"
+
+      x=$(cat /non/existent 2>/dev/null)
+      echo "[2] Status: $?; pipe status: ${PIPESTATUS[@]}"
+
+  - name: "Subshell status"
+    stdin: |
+      (echo hi | wc -l)
+      echo "[1] Status: $?; pipe status: ${PIPESTATUS[@]}"
+
+      (cat /non/existent 2>/dev/null)
+      echo "[2] Status: $?; pipe status: ${PIPESTATUS[@]}"

--- a/brush-shell/tests/cases/well_known_vars.yaml
+++ b/brush-shell/tests/cases/well_known_vars.yaml
@@ -1,0 +1,107 @@
+name: "Well-known variable tests"
+cases:
+  - name: "Basic defaulted PATH var"
+    stdin: |
+      if [[ -z "$PATH" ]]; then
+        echo "PATH is not set or is empty"
+      else
+        echo "PATH is set and non-empty"
+      fi
+
+  - name: "Basic variables"
+    known_failure: true # Not fully implemented
+    stdin: |
+      declare -p > ./vars.txt
+      # Filter out variables set by test infrastructure.
+      cat vars.txt | grep '^declare ' | grep -v LLVM | sed -e 's/=.*//'
+      rm vars.txt
+
+  - name: "Static well-known variables"
+    stdin: |
+      echo "EUID: $EUID"
+      echo "UID: $UID"
+
+      [[ $BASHPID == $$ ]]
+      echo 'BASHPID == \$$: ' $?
+
+      [[ $BASH_ARGV0 == $0 ]]
+      echo 'BASH_ARGV0 == $0: ' $?
+
+      [[ $MACHTYPE == ${BASH_VERSINFO[5]} ]]
+      echo 'MACHTYPE == ${BASH_VERSINFO[5]: ' $?
+
+  - name: "BASH_ALIASES"
+    stdin: |
+      echo "Initial BASH_ALIASES: " ${BASH_ALIASES[@]}
+      alias x=y
+      echo "Updated BASH_ALIASES: " ${BASH_ALIASES[@]}
+      unalias x
+      echo "Final BASH_ALIASES: " ${BASH_ALIASES[@]}
+
+  - name: "BASHOPTS"
+    known_failure: true # Need to normalize which options are enabled in oracle
+    stdin: |
+      # Workaround for brush forcing on extglob
+      shopt -u extglob
+
+      echo "BASHOPTS: $BASHOPTS"
+
+  - name: "BASH_SUBSHELL"
+    stdin: |
+      echo "Initial BASH_SUBSHELL: $BASH_SUBSHELL"
+      (echo "Subshell BASH_SUBSHELL: $BASH_SUBSHELL")
+      ( 
+        ( echo "Nested subshell BASH_SUBSHELL: $BASH_SUBSHELL"  )
+      )
+
+      echo $(echo "Command substitution BASH_SUBSHELL: $BASH_SUBSHELL")
+
+  - name: "BASH_VERSINFO"
+    stdin: |
+      shopt -s extglob
+
+      echo "len(BASH_VERSINFO): " ${#BASH_VERSINFO[@]}
+
+      # Only inspect the first 4 elements.
+      for ((i = 0; i < 4; i++)); do
+        cleaned=${BASH_VERSINFO[i]//+([0-9])/d}
+        echo "Cleaned BASH_VERSINFO[$i]: $cleaned"
+      done
+
+  - name: "BASH_VERSION"
+    stdin: |
+      shopt -s extglob
+
+      # Replace specific numbers with placeholder text.
+      cleaned=${BASH_VERSION//+([0-9])/d}
+      echo "Cleaned BASH_VERSION: $cleaned"
+
+  - name: "EPOCHSECONDS"
+    stdin: |
+      external=$(date +%s)
+
+      es1=${EPOCHSECONDS}
+      [[ $es1 =~ ^[0-9]+$ ]] && echo "EPOCHSECONDS is a number"
+
+      es2=${EPOCHSECONDS}
+      [[ $es2 =~ ^[0-9]+$ ]] && echo "EPOCHSECONDS is still a number"
+
+      (( es1 >= external )) && echo "Time is moving forward"
+      (( es1 >= es2 )) && echo "Time is moving forward within the shell"
+
+  - name: "GROUPS"
+    skip: true # TODO: macOS failure needs investigation (passes elsewhere)
+    stdin: |
+      (for group in ${GROUPS[@]}; do
+        echo $group
+      done) | sort
+
+  - name: "SHELLOPTS"
+    stdin: |
+      echo "SHELLOPTS: $SHELLOPTS"
+
+  - name: "SHLVL"
+    stdin: |
+      echo "SHLVL: $SHLVL"
+      bash -c 'echo "bash SHLVL: $SHLVL"'
+      $0 -c 'echo "nested SHLVL: $SHLVL"'


### PR DESCRIPTION
 Implements the ideas in #233, with `$RANDOM` as an initial case. The main downside here is requiring that a `&Shell` be passed into various `ShellVariable` functions

Adds various other standard variables that are now easier for us to implement and keep in sync with fields in the `Shell` object.

Notably, this lacks support for handling mutation of these dynamic values. We'll need to implement this in the future.