### PR TITLE
fix: better error when cwd is gone

### DIFF
--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -442,7 +442,15 @@ pub(crate) fn execute_external_command(
                 sys::terminal::move_self_to_foreground()?;
             }
 
-            if context.shell.options.sh_mode {
+            if !context.shell.working_dir.exists() {
+                // We may have failed because the working directory doesn't exist.
+                writeln!(
+                    stderr,
+                    "{}: working directory does not exist: {}",
+                    context.shell.shell_name.as_ref().unwrap_or(&String::new()),
+                    context.shell.working_dir.display()
+                )?;
+            } else if context.shell.options.sh_mode {
                 writeln!(
                     stderr,
                     "{}: {}: {}: not found",

--- a/brush-shell/tests/cases/simple_commands.yaml
+++ b/brush-shell/tests/cases/simple_commands.yaml
@@ -25,3 +25,15 @@ cases:
     stdin: |
       ./non-existent-command 2>/dev/null
       echo "Result: $?"
+
+  - name: "Simple command with non-existent cwd"
+    # N.B. We intentionally fail here because there's no safe way to pick an
+    # alternate working directory that we are okay with. To our knowledge,
+    # there's no easy way to hold onto the current working directory past
+    # its deletion.
+    known_failure: true
+    stdin: |
+      mkdir test-dir
+      cd test-dir
+      rmdir $(pwd)
+      ls


### PR DESCRIPTION
For now, we focus on improving the error messages. We considered falling back to using an alternate working directory when we detect that the CWD is no longer present, but any dir we pick could be problematic. (Consider the idea of `rm -rf ..` being invoked and us running it in some fallback dir.)

Addresses #366 