### PR TITLE
fix(builtins): fix read builtin ignoring tab chars

### DIFF
--- a/brush-core/src/builtins/read.rs
+++ b/brush-core/src/builtins/read.rs
@@ -219,7 +219,7 @@ impl ReadCommand {
             }
 
             // Ignore other control characters without including them in the input.
-            if ch.is_ascii_control() {
+            if ch.is_ascii_control() && !ch.is_ascii_whitespace() {
                 continue;
             }
 

--- a/brush-shell/tests/cases/builtins/read.yaml
+++ b/brush-shell/tests/cases/builtins/read.yaml
@@ -36,3 +36,9 @@ cases:
       while IFS= read line; do
           echo "LINE: '$line'"
       done <<<"${content}"
+
+  - name: "read text with tabs and custom IFS"
+    stdin: |
+      while IFS="" read myvar; do
+          echo "myvar1: |${myvar}|"
+      done < <(printf "a\tb\nc d\te\n")


### PR DESCRIPTION
Some ASCII whitespace characters (e.g., `\t`) are also considered control characters. Don't ignore *all* of them in `read`.