### PR TITLE
fix(completion): better handle native errors in completion funcs

### DIFF
--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -681,7 +681,10 @@ impl Spec {
             let _ = shell.env.unset(var_name);
         }
 
-        let result = invoke_result?;
+        let result = invoke_result.unwrap_or_else(|e| {
+            tracing::warn!(target: trace_categories::COMPLETION, "error while running completion function '{function_name}': {e}");
+            1 // Report back a non-zero exit code.
+        });
 
         // When the function returns the special value 124, then it's a request
         // for us to restart the completion process.


### PR DESCRIPTION
This should hopefully make it quicker to track down completion errors in the future. It should also allow completion to degrade a bit more gracefully in this case.