### PR TITLE
fix: propagate execution parameters more thoroughly

### DIFF
--- a/brush-core/benches/shell.rs
+++ b/brush-core/benches/shell.rs
@@ -26,7 +26,8 @@ mod unix {
     }
 
     async fn expand_string(shell: &mut brush_core::Shell, s: &str) {
-        let _ = shell.basic_expand_string(s).await.unwrap();
+        let params = shell.default_exec_params();
+        let _ = shell.basic_expand_string(&params, s).await.unwrap();
     }
 
     fn eval_arithmetic_expr(shell: &mut brush_core::Shell, expr: &str) {

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -24,7 +24,13 @@ impl builtins::Command for PrintfCommand {
         let result = self.evaluate(&context)?;
 
         if let Some(variable_name) = &self.output_variable {
-            expansion::assign_to_named_parameter(context.shell, variable_name, result).await?;
+            expansion::assign_to_named_parameter(
+                context.shell,
+                &context.params,
+                variable_name,
+                result,
+            )
+            .await?;
         } else {
             write!(context.stdout(), "{result}")?;
             context.stdout().flush()?;

--- a/brush-core/src/builtins/test.rs
+++ b/brush-core/src/builtins/test.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::io::Write;
 
-use crate::{builtins, commands, error, tests, Shell};
+use crate::{builtins, commands, error, tests, ExecutionParameters, Shell};
 
 /// Evaluate test expression.
 #[derive(Parser)]
@@ -30,7 +30,7 @@ impl builtins::Command for TestCommand {
             args = &args[0..args.len() - 1];
         }
 
-        if execute_test(context.shell, args)? {
+        if execute_test(context.shell, &context.params, args)? {
             Ok(builtins::ExitCode::Success)
         } else {
             Ok(builtins::ExitCode::Custom(1))
@@ -38,8 +38,12 @@ impl builtins::Command for TestCommand {
     }
 }
 
-fn execute_test(shell: &mut Shell, args: &[String]) -> Result<bool, error::Error> {
+fn execute_test(
+    shell: &mut Shell,
+    params: &ExecutionParameters,
+    args: &[String],
+) -> Result<bool, error::Error> {
     let test_command =
         brush_parser::test_command::parse(args).map_err(error::Error::TestCommandParseError)?;
-    tests::eval_test_expr(&test_command, shell)
+    tests::eval_test_expr(&test_command, shell, params)
 }

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -521,7 +521,7 @@ pub(crate) async fn invoke_shell_function(
     // Apply any redirects specified at function definition-time.
     if let Some(redirects) = redirects {
         for redirect in &redirects.0 {
-            interp::setup_redirect(&mut context.params, context.shell, redirect).await?;
+            interp::setup_redirect(context.shell, &mut context.params, redirect).await?;
         }
     }
 

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -244,7 +244,9 @@ impl Spec {
         // Generate completions based on any provided actions (and on words).
         let mut candidates = self.generate_action_completions(shell, context).await?;
         if let Some(word_list) = &self.word_list {
-            let words = crate::expansion::full_expand_and_split_str(shell, word_list).await?;
+            let params = shell.default_exec_params();
+            let words =
+                crate::expansion::full_expand_and_split_str(shell, &params, word_list).await?;
             for word in words {
                 if word.starts_with(context.token_to_complete) {
                     candidates.insert(word);
@@ -607,8 +609,10 @@ impl Spec {
         }
 
         // Run the command.
+        let params = shell.default_exec_params();
         let output =
-            commands::invoke_command_in_subshell_and_get_output(&mut shell, command_line).await?;
+            commands::invoke_command_in_subshell_and_get_output(&mut shell, &params, command_line)
+                .await?;
 
         // Split results.
         let mut candidates = IndexSet::new();
@@ -1052,8 +1056,9 @@ async fn get_file_completions(
 ) -> IndexSet<String> {
     // Basic-expand the token-to-be-completed; it won't have been expanded to this point.
     let mut throwaway_shell = shell.clone();
+    let params = throwaway_shell.default_exec_params();
     let expanded_token = throwaway_shell
-        .basic_expand_string(token_to_complete)
+        .basic_expand_string(&params, token_to_complete)
         .await
         .unwrap_or_else(|_err| token_to_complete.to_owned());
 

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -8,37 +8,40 @@ use crate::{
         users,
     },
     variables::{self, ArrayLiteral},
-    Shell,
+    ExecutionParameters, Shell,
 };
 
 #[async_recursion::async_recursion]
 pub(crate) async fn eval_extended_test_expr(
     expr: &ast::ExtendedTestExpr,
     shell: &mut Shell,
+    params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
     #[allow(clippy::single_match_else)]
     match expr {
         ast::ExtendedTestExpr::UnaryTest(op, operand) => {
-            apply_unary_predicate(op, operand, shell).await
+            apply_unary_predicate(op, operand, shell, params).await
         }
         ast::ExtendedTestExpr::BinaryTest(op, left, right) => {
-            apply_binary_predicate(op, left, right, shell).await
+            apply_binary_predicate(op, left, right, shell, params).await
         }
         ast::ExtendedTestExpr::And(left, right) => {
-            let result = eval_extended_test_expr(left, shell).await?
-                && eval_extended_test_expr(right, shell).await?;
+            let result = eval_extended_test_expr(left, shell, params).await?
+                && eval_extended_test_expr(right, shell, params).await?;
             Ok(result)
         }
         ast::ExtendedTestExpr::Or(left, right) => {
-            let result = eval_extended_test_expr(left, shell).await?
-                || eval_extended_test_expr(right, shell).await?;
+            let result = eval_extended_test_expr(left, shell, params).await?
+                || eval_extended_test_expr(right, shell, params).await?;
             Ok(result)
         }
         ast::ExtendedTestExpr::Not(expr) => {
-            let result = !eval_extended_test_expr(expr, shell).await?;
+            let result = !eval_extended_test_expr(expr, shell, params).await?;
             Ok(result)
         }
-        ast::ExtendedTestExpr::Parenthesized(expr) => eval_extended_test_expr(expr, shell).await,
+        ast::ExtendedTestExpr::Parenthesized(expr) => {
+            eval_extended_test_expr(expr, shell, params).await
+        }
     }
 }
 
@@ -46,8 +49,9 @@ async fn apply_unary_predicate(
     op: &ast::UnaryPredicate,
     operand: &ast::Word,
     shell: &mut Shell,
+    params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
-    let expanded_operand = expansion::basic_expand_word(shell, operand).await?;
+    let expanded_operand = expansion::basic_expand_word(shell, params, operand).await?;
 
     if shell.options.print_commands_and_arguments {
         shell.trace_command(std::format!(
@@ -186,12 +190,13 @@ async fn apply_binary_predicate(
     left: &ast::Word,
     right: &ast::Word,
     shell: &mut Shell,
+    params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
     #[allow(clippy::single_match_else)]
     match op {
         ast::BinaryPredicate::StringMatchesRegex => {
-            let s = expansion::basic_expand_word(shell, left).await?;
-            let regex = expansion::basic_expand_regex(shell, right).await?;
+            let s = expansion::basic_expand_word(shell, params, left).await?;
+            let regex = expansion::basic_expand_regex(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {s} {op} {right} ]]"))?;
@@ -227,8 +232,8 @@ async fn apply_binary_predicate(
             Ok(matches)
         }
         ast::BinaryPredicate::StringExactlyMatchesString => {
-            let left = expansion::basic_expand_word(shell, left).await?;
-            let right = expansion::basic_expand_word(shell, right).await?;
+            let left = expansion::basic_expand_word(shell, params, left).await?;
+            let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -237,8 +242,8 @@ async fn apply_binary_predicate(
             Ok(left == right)
         }
         ast::BinaryPredicate::StringDoesNotExactlyMatchString => {
-            let left = expansion::basic_expand_word(shell, left).await?;
-            let right = expansion::basic_expand_word(shell, right).await?;
+            let left = expansion::basic_expand_word(shell, params, left).await?;
+            let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -247,8 +252,8 @@ async fn apply_binary_predicate(
             Ok(left != right)
         }
         ast::BinaryPredicate::StringContainsSubstring => {
-            let s = expansion::basic_expand_word(shell, left).await?;
-            let substring = expansion::basic_expand_word(shell, right).await?;
+            let s = expansion::basic_expand_word(shell, params, left).await?;
+            let substring = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {s} {op} {substring} ]]"))?;
@@ -266,8 +271,8 @@ async fn apply_binary_predicate(
             "extended test binary predicate LeftFileIsOlderOrDoesNotExistWhenRightDoes",
         ),
         ast::BinaryPredicate::LeftSortsBeforeRight => {
-            let left = expansion::basic_expand_word(shell, left).await?;
-            let right = expansion::basic_expand_word(shell, right).await?;
+            let left = expansion::basic_expand_word(shell, params, left).await?;
+            let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -277,8 +282,8 @@ async fn apply_binary_predicate(
             Ok(left < right)
         }
         ast::BinaryPredicate::LeftSortsAfterRight => {
-            let left = expansion::basic_expand_word(shell, left).await?;
-            let right = expansion::basic_expand_word(shell, right).await?;
+            let left = expansion::basic_expand_word(shell, params, left).await?;
+            let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -288,8 +293,10 @@ async fn apply_binary_predicate(
             Ok(left > right)
         }
         ast::BinaryPredicate::ArithmeticEqualTo => {
-            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
-            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
+            let left =
+                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+            let right =
+                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -298,8 +305,10 @@ async fn apply_binary_predicate(
             Ok(left == right)
         }
         ast::BinaryPredicate::ArithmeticNotEqualTo => {
-            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
-            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
+            let left =
+                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+            let right =
+                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -308,8 +317,10 @@ async fn apply_binary_predicate(
             Ok(left != right)
         }
         ast::BinaryPredicate::ArithmeticLessThan => {
-            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
-            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
+            let left =
+                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+            let right =
+                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -318,8 +329,10 @@ async fn apply_binary_predicate(
             Ok(left < right)
         }
         ast::BinaryPredicate::ArithmeticLessThanOrEqualTo => {
-            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
-            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
+            let left =
+                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+            let right =
+                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -328,8 +341,10 @@ async fn apply_binary_predicate(
             Ok(left <= right)
         }
         ast::BinaryPredicate::ArithmeticGreaterThan => {
-            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
-            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
+            let left =
+                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+            let right =
+                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -338,8 +353,10 @@ async fn apply_binary_predicate(
             Ok(left > right)
         }
         ast::BinaryPredicate::ArithmeticGreaterThanOrEqualTo => {
-            let left = arithmetic::expand_and_eval(shell, left.value.as_str(), false).await?;
-            let right = arithmetic::expand_and_eval(shell, right.value.as_str(), false).await?;
+            let left =
+                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+            let right =
+                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
                 shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
@@ -352,14 +369,14 @@ async fn apply_binary_predicate(
         // operand (treated as a shell pattern).
         // TODO: implement case-insensitive matching if relevant via shopt options (nocasematch).
         ast::BinaryPredicate::StringExactlyMatchesPattern => {
-            let s = expansion::basic_expand_word(shell, left).await?;
-            let pattern = expansion::basic_expand_pattern(shell, right)
+            let s = expansion::basic_expand_word(shell, params, left).await?;
+            let pattern = expansion::basic_expand_pattern(shell, params, right)
                 .await?
                 .set_extended_globbing(shell.options.extended_globbing)
                 .set_case_insensitive(shell.options.case_insensitive_conditionals);
 
             if shell.options.print_commands_and_arguments {
-                let expanded_right = expansion::basic_expand_word(shell, right).await?;
+                let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
                 let escaped_right = escape::quote_if_needed(
                     expanded_right.as_str(),
                     escape::QuoteMode::BackslashEscape,
@@ -370,14 +387,14 @@ async fn apply_binary_predicate(
             pattern.exactly_matches(s.as_str())
         }
         ast::BinaryPredicate::StringDoesNotExactlyMatchPattern => {
-            let s = expansion::basic_expand_word(shell, left).await?;
-            let pattern = expansion::basic_expand_pattern(shell, right)
+            let s = expansion::basic_expand_word(shell, params, left).await?;
+            let pattern = expansion::basic_expand_pattern(shell, params, right)
                 .await?
                 .set_extended_globbing(shell.options.extended_globbing)
                 .set_case_insensitive(shell.options.case_insensitive_conditionals);
 
             if shell.options.print_commands_and_arguments {
-                let expanded_right = expansion::basic_expand_word(shell, right).await?;
+                let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
                 let escaped_right = escape::quote_if_needed(
                     expanded_right.as_str(),
                     escape::QuoteMode::BackslashEscape,

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -60,7 +60,7 @@ async fn apply_unary_predicate(
         ))?;
     }
 
-    apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell)
+    apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell, params)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -68,6 +68,7 @@ pub(crate) fn apply_unary_predicate_to_str(
     op: &ast::UnaryPredicate,
     operand: &str,
     shell: &mut Shell,
+    params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
     #[allow(clippy::match_single_binding)]
     match op {
@@ -123,7 +124,7 @@ pub(crate) fn apply_unary_predicate_to_str(
         }
         ast::UnaryPredicate::FdIsOpenTerminal => {
             if let Ok(fd) = operand.parse::<u32>() {
-                if let Some(open_file) = shell.open_files.files.get(&fd) {
+                if let Some(open_file) = params.open_files.files.get(&fd) {
                     Ok(open_file.is_term())
                 } else {
                     Ok(false)

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -482,8 +482,7 @@ impl ExecuteInPipeline for ast::Command {
                 // Set up any additional redirects.
                 if let Some(redirects) = redirects {
                     for redirect in &redirects.0 {
-                        setup_redirect(&mut params.open_files, pipeline_context.shell, redirect)
-                            .await?;
+                        setup_redirect(&mut params, pipeline_context.shell, redirect).await?;
                     }
                 }
 
@@ -508,7 +507,9 @@ impl ExecuteInPipeline for ast::Command {
             }
             ast::Command::ExtendedTest(e) => {
                 let result =
-                    if extendedtests::eval_extended_test_expr(e, pipeline_context.shell).await? {
+                    if extendedtests::eval_extended_test_expr(e, pipeline_context.shell, &params)
+                        .await?
+                    {
                         0
                     } else {
                         1
@@ -573,7 +574,8 @@ impl Execute for ast::ForClauseCommand {
         let mut expanded_values = vec![];
         if let Some(unexpanded_values) = &self.values {
             for value in unexpanded_values {
-                let mut expanded = expansion::full_expand_and_split_word(shell, value).await?;
+                let mut expanded =
+                    expansion::full_expand_and_split_word(shell, params, value).await?;
                 expanded_values.append(&mut expanded);
             }
         } else {
@@ -644,7 +646,7 @@ impl Execute for ast::CaseClauseCommand {
             shell.trace_command(std::format!("case {} in", &self.value))?;
         }
 
-        let expanded_value = expansion::basic_expand_word(shell, &self.value).await?;
+        let expanded_value = expansion::basic_expand_word(shell, params, &self.value).await?;
         let mut result: ExecutionResult = ExecutionResult::success();
         let mut force_execute_next_case = false;
 
@@ -654,7 +656,7 @@ impl Execute for ast::CaseClauseCommand {
             } else {
                 let mut matches = false;
                 for pattern in &case.patterns {
-                    let expanded_pattern = expansion::basic_expand_pattern(shell, pattern)
+                    let expanded_pattern = expansion::basic_expand_pattern(shell, params, pattern)
                         .await?
                         .set_extended_globbing(shell.options.extended_globbing)
                         .set_case_insensitive(shell.options.case_insensitive_conditionals);
@@ -790,9 +792,9 @@ impl Execute for ast::ArithmeticCommand {
     async fn execute(
         &self,
         shell: &mut Shell,
-        _params: &ExecutionParameters,
+        params: &ExecutionParameters,
     ) -> Result<ExecutionResult, error::Error> {
-        let value = self.expr.eval(shell, true).await?;
+        let value = self.expr.eval(shell, params, true).await?;
         let result = if value != 0 {
             ExecutionResult::success()
         } else {
@@ -814,12 +816,12 @@ impl Execute for ast::ArithmeticForClauseCommand {
     ) -> Result<ExecutionResult, error::Error> {
         let mut result = ExecutionResult::success();
         if let Some(initializer) = &self.initializer {
-            initializer.eval(shell, true).await?;
+            initializer.eval(shell, params, true).await?;
         }
 
         loop {
             if let Some(condition) = &self.condition {
-                if condition.eval(shell, true).await? == 0 {
+                if condition.eval(shell, params, true).await? == 0 {
                     break;
                 }
             }
@@ -847,7 +849,7 @@ impl Execute for ast::ArithmeticForClauseCommand {
             }
 
             if let Some(updater) = &self.updater {
-                updater.eval(shell, true).await?;
+                updater.eval(shell, params, true).await?;
             }
         }
 
@@ -908,7 +910,7 @@ impl ExecuteInPipeline for ast::SimpleCommand {
         {
             match item {
                 CommandPrefixOrSuffixItem::IoRedirect(redirect) => {
-                    if setup_redirect(&mut params.open_files, context.shell, redirect)
+                    if setup_redirect(&mut params, context.shell, redirect)
                         .await?
                         .is_none()
                     {
@@ -943,14 +945,15 @@ impl ExecuteInPipeline for ast::SimpleCommand {
                             // This looks like an assignment, and the command being invoked is a
                             // well-known builtin that takes arguments that need to function like
                             // assignments (but which are processed by the builtin).
-                            let expanded = expand_assignment(context.shell, assignment).await?;
+                            let expanded =
+                                expand_assignment(context.shell, &params, assignment).await?;
                             args.push(CommandArg::Assignment(expanded));
                         } else {
                             // This *looks* like an assignment, but it's really a string we should
                             // fully treat as a regular looking
                             // argument.
                             let mut next_args =
-                                expansion::full_expand_and_split_word(context.shell, word)
+                                expansion::full_expand_and_split_word(context.shell, &params, word)
                                     .await?
                                     .into_iter()
                                     .map(CommandArg::String)
@@ -961,7 +964,7 @@ impl ExecuteInPipeline for ast::SimpleCommand {
                 }
                 CommandPrefixOrSuffixItem::Word(arg) => {
                     let mut next_args =
-                        expansion::full_expand_and_split_word(context.shell, arg).await?;
+                        expansion::full_expand_and_split_word(context.shell, &params, arg).await?;
 
                     if args.is_empty() {
                         if let Some(cmd_name) = next_args.first() {
@@ -1013,6 +1016,7 @@ impl ExecuteInPipeline for ast::SimpleCommand {
                 apply_assignment(
                     assignment,
                     context.shell,
+                    &params,
                     true,
                     Some(EnvironmentScope::Command),
                     EnvironmentScope::Command,
@@ -1095,6 +1099,7 @@ impl ExecuteInPipeline for ast::SimpleCommand {
                 apply_assignment(
                     assignment,
                     context.shell,
+                    &params,
                     false,
                     None,
                     EnvironmentScope::Global,
@@ -1113,11 +1118,12 @@ impl ExecuteInPipeline for ast::SimpleCommand {
 
 async fn expand_assignment(
     shell: &mut Shell,
+    params: &ExecutionParameters,
     assignment: &ast::Assignment,
 ) -> Result<ast::Assignment, error::Error> {
-    let value = expand_assignment_value(shell, &assignment.value).await?;
+    let value = expand_assignment_value(shell, params, &assignment.value).await?;
     Ok(ast::Assignment {
-        name: basic_expand_assignment_name(shell, &assignment.name).await?,
+        name: basic_expand_assignment_name(shell, params, &assignment.name).await?,
         value,
         append: assignment.append,
     })
@@ -1125,16 +1131,17 @@ async fn expand_assignment(
 
 async fn basic_expand_assignment_name(
     shell: &mut Shell,
+    params: &ExecutionParameters,
     name: &ast::AssignmentName,
 ) -> Result<ast::AssignmentName, error::Error> {
     match name {
         ast::AssignmentName::VariableName(name) => {
-            let expanded = expansion::basic_expand_str(shell, name).await?;
+            let expanded = expansion::basic_expand_str(shell, params, name).await?;
             Ok(ast::AssignmentName::VariableName(expanded))
         }
         ast::AssignmentName::ArrayElementName(name, index) => {
-            let expanded_name = expansion::basic_expand_str(shell, name).await?;
-            let expanded_index = expansion::basic_expand_str(shell, index).await?;
+            let expanded_name = expansion::basic_expand_str(shell, params, name).await?;
+            let expanded_index = expansion::basic_expand_str(shell, params, index).await?;
             Ok(ast::AssignmentName::ArrayElementName(
                 expanded_name,
                 expanded_index,
@@ -1145,11 +1152,12 @@ async fn basic_expand_assignment_name(
 
 async fn expand_assignment_value(
     shell: &mut Shell,
+    params: &ExecutionParameters,
     value: &ast::AssignmentValue,
 ) -> Result<ast::AssignmentValue, error::Error> {
     let expanded = match value {
         ast::AssignmentValue::Scalar(s) => {
-            let expanded_word = expansion::basic_expand_word(shell, s).await?;
+            let expanded_word = expansion::basic_expand_word(shell, params, s).await?;
             ast::AssignmentValue::Scalar(ast::Word {
                 value: expanded_word,
             })
@@ -1158,12 +1166,14 @@ async fn expand_assignment_value(
             let mut expanded_values = vec![];
             for (key, value) in arr {
                 if let Some(k) = key {
-                    let expanded_key = expansion::basic_expand_word(shell, k).await?.into();
-                    let expanded_value = expansion::basic_expand_word(shell, value).await?.into();
+                    let expanded_key = expansion::basic_expand_word(shell, params, k).await?.into();
+                    let expanded_value = expansion::basic_expand_word(shell, params, value)
+                        .await?
+                        .into();
                     expanded_values.push((Some(expanded_key), expanded_value));
                 } else {
                     let split_expanded_value =
-                        expansion::full_expand_and_split_word(shell, value).await?;
+                        expansion::full_expand_and_split_word(shell, params, value).await?;
                     for expanded_value in split_expanded_value {
                         expanded_values.push((None, expanded_value.into()));
                     }
@@ -1181,6 +1191,7 @@ async fn expand_assignment_value(
 async fn apply_assignment(
     assignment: &ast::Assignment,
     shell: &mut Shell,
+    params: &ExecutionParameters,
     mut export: bool,
     required_scope: Option<EnvironmentScope>,
     creation_scope: EnvironmentScope,
@@ -1194,7 +1205,7 @@ async fn apply_assignment(
             name
         }
         ast::AssignmentName::ArrayElementName(name, index) => {
-            let expanded = expansion::basic_expand_str(shell, index).await?;
+            let expanded = expansion::basic_expand_str(shell, params, index).await?;
             array_index = Some(expanded);
             name
         }
@@ -1203,7 +1214,7 @@ async fn apply_assignment(
     // Expand the values.
     let new_value = match &assignment.value {
         ast::AssignmentValue::Scalar(unexpanded_value) => {
-            let value = expansion::basic_expand_word(shell, unexpanded_value).await?;
+            let value = expansion::basic_expand_word(shell, params, unexpanded_value).await?;
             ShellValueLiteral::Scalar(value)
         }
         ast::AssignmentValue::Array(unexpanded_values) => {
@@ -1211,17 +1222,19 @@ async fn apply_assignment(
             for (unexpanded_key, unexpanded_value) in unexpanded_values {
                 let key = match unexpanded_key {
                     Some(unexpanded_key) => {
-                        Some(expansion::basic_expand_word(shell, unexpanded_key).await?)
+                        Some(expansion::basic_expand_word(shell, params, unexpanded_key).await?)
                     }
                     None => None,
                 };
 
                 if key.is_some() {
-                    let value = expansion::basic_expand_word(shell, unexpanded_value).await?;
+                    let value =
+                        expansion::basic_expand_word(shell, params, unexpanded_value).await?;
                     elements.push((key, value));
                 } else {
                     let values =
-                        expansion::full_expand_and_split_word(shell, unexpanded_value).await?;
+                        expansion::full_expand_and_split_word(shell, params, unexpanded_value)
+                            .await?;
                     for value in values {
                         elements.push((None, value));
                     }
@@ -1250,7 +1263,7 @@ async fn apply_assignment(
 
         if will_be_indexed_array {
             array_index = Some(
-                arithmetic::expand_and_eval(shell, idx.as_str(), false)
+                arithmetic::expand_and_eval(shell, params, idx.as_str(), false)
                     .await?
                     .to_string(),
             );
@@ -1349,13 +1362,14 @@ fn setup_pipeline_redirection(
 
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn setup_redirect(
-    open_files: &'_ mut OpenFiles,
+    params: &'_ mut ExecutionParameters,
     shell: &mut Shell,
     redirect: &ast::IoRedirect,
 ) -> Result<Option<u32>, error::Error> {
     match redirect {
         ast::IoRedirect::OutputAndError(f, append) => {
-            let mut expanded_fields = expansion::full_expand_and_split_word(shell, f).await?;
+            let mut expanded_fields =
+                expansion::full_expand_and_split_word(shell, params, f).await?;
             if expanded_fields.len() != 1 {
                 return Err(error::Error::InvalidRedirection);
             }
@@ -1379,8 +1393,8 @@ pub(crate) async fn setup_redirect(
             let stdout_file = OpenFile::File(opened_file);
             let stderr_file = stdout_file.try_dup()?;
 
-            open_files.files.insert(1, stdout_file);
-            open_files.files.insert(2, stderr_file);
+            params.open_files.files.insert(1, stdout_file);
+            params.open_files.files.insert(2, stderr_file);
 
             Ok(Some(1))
         }
@@ -1392,7 +1406,7 @@ pub(crate) async fn setup_redirect(
                     let mut options = std::fs::File::options();
 
                     let mut expanded_fields =
-                        expansion::full_expand_and_split_word(shell, f).await?;
+                        expansion::full_expand_and_split_word(shell, params, f).await?;
 
                     if expanded_fields.len() != 1 {
                         return Err(error::Error::InvalidRedirection);
@@ -1470,7 +1484,7 @@ pub(crate) async fn setup_redirect(
 
                     fd_num = specified_fd_num.unwrap_or(default_fd_if_unspecified);
 
-                    if let Some(f) = open_files.files.get(fd) {
+                    if let Some(f) = params.open_files.files.get(fd) {
                         target_file = f.try_dup()?;
                     } else {
                         tracing::error!("{}: Bad file descriptor", fd);
@@ -1485,14 +1499,17 @@ pub(crate) async fn setup_redirect(
                         | ast::IoFileRedirectKind::ReadAndWrite
                         | ast::IoFileRedirectKind::Clobber => {
                             let (substitution_fd, substitution_file) = setup_process_substitution(
-                                open_files,
+                                &mut params.open_files,
                                 shell,
                                 substitution_kind,
                                 subshell_cmd,
                             )?;
 
                             target_file = substitution_file.try_dup()?;
-                            open_files.files.insert(substitution_fd, substitution_file);
+                            params
+                                .open_files
+                                .files
+                                .insert(substitution_fd, substitution_file);
 
                             fd_num = specified_fd_num
                                 .unwrap_or_else(|| get_default_fd_for_redirect_kind(kind));
@@ -1502,7 +1519,7 @@ pub(crate) async fn setup_redirect(
                 }
             }
 
-            open_files.files.insert(fd_num, target_file);
+            params.open_files.files.insert(fd_num, target_file);
             Ok(Some(fd_num))
         }
         ast::IoRedirect::HereDocument(fd_num, io_here) => {
@@ -1511,26 +1528,26 @@ pub(crate) async fn setup_redirect(
 
             // Expand if required.
             let io_here_doc = if io_here.requires_expansion {
-                expansion::basic_expand_word(shell, &io_here.doc).await?
+                expansion::basic_expand_word(shell, params, &io_here.doc).await?
             } else {
                 io_here.doc.flatten()
             };
 
             let f = setup_open_file_with_contents(io_here_doc.as_str())?;
 
-            open_files.files.insert(fd_num, f);
+            params.open_files.files.insert(fd_num, f);
             Ok(Some(fd_num))
         }
         ast::IoRedirect::HereString(fd_num, word) => {
             // If not specified, default to stdin (fd 0).
             let fd_num = fd_num.unwrap_or(0);
 
-            let mut expanded_word = expansion::basic_expand_word(shell, word).await?;
+            let mut expanded_word = expansion::basic_expand_word(shell, params, word).await?;
             expanded_word.push('\n');
 
             let f = setup_open_file_with_contents(expanded_word.as_str())?;
 
-            open_files.files.insert(fd_num, f);
+            params.open_files.files.insert(fd_num, f);
             Ok(Some(fd_num))
         }
     }

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -33,7 +33,7 @@ pub struct Shell {
     /// Trap handler configuration for the shell.
     pub traps: traps::TrapHandlerConfig,
     /// Manages files opened and accessible via redirection operators.
-    pub open_files: openfiles::OpenFiles,
+    open_files: openfiles::OpenFiles,
     /// The current working directory.
     pub working_dir: PathBuf,
     /// The shell environment, containing shell variables.

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -942,9 +942,10 @@ impl Shell {
     /// * `s` - The string to expand.
     pub async fn basic_expand_string<S: AsRef<str>>(
         &mut self,
+        params: &ExecutionParameters,
         s: S,
     ) -> Result<String, error::Error> {
-        let result = expansion::basic_expand_str(self, s.as_ref()).await?;
+        let result = expansion::basic_expand_str(self, params, s.as_ref()).await?;
         Ok(result)
     }
 
@@ -956,9 +957,10 @@ impl Shell {
     /// * `s` - The string to expand and split.
     pub async fn full_expand_and_split_string<S: AsRef<str>>(
         &mut self,
+        params: &ExecutionParameters,
         s: S,
     ) -> Result<Vec<String>, error::Error> {
-        let result = expansion::full_expand_and_split_str(self, s.as_ref()).await?;
+        let result = expansion::full_expand_and_split_str(self, params, s.as_ref()).await?;
         Ok(result)
     }
 
@@ -981,13 +983,9 @@ impl Shell {
         script_path: &Path,
         args: I,
     ) -> Result<ExecutionResult, error::Error> {
-        self.parse_and_execute_script_file(
-            script_path,
-            args,
-            &self.default_exec_params(),
-            ScriptCallType::Executed,
-        )
-        .await
+        let params = self.default_exec_params();
+        self.parse_and_execute_script_file(script_path, args, &params, ScriptCallType::Executed)
+            .await
     }
 
     async fn run_parsed_result(
@@ -1116,7 +1114,8 @@ impl Shell {
         let formatted_prompt = prompt::expand_prompt(self, prompt_spec.into_owned())?;
 
         // Now expand.
-        expansion::basic_expand_str(self, &formatted_prompt).await
+        let params = self.default_exec_params();
+        expansion::basic_expand_str(self, &params, &formatted_prompt).await
     }
 
     /// Returns the exit status of the last command executed in this shell.

--- a/brush-core/src/tests.rs
+++ b/brush-core/src/tests.rs
@@ -1,22 +1,23 @@
-use crate::{error, extendedtests, Shell};
+use crate::{error, extendedtests, ExecutionParameters, Shell};
 
 pub(crate) fn eval_test_expr(
     expr: &brush_parser::ast::TestExpr,
     shell: &mut Shell,
+    params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
     match expr {
         brush_parser::ast::TestExpr::False => Ok(false),
         brush_parser::ast::TestExpr::Literal(s) => Ok(!s.is_empty()),
         brush_parser::ast::TestExpr::And(left, right) => {
-            Ok(eval_test_expr(left, shell)? && eval_test_expr(right, shell)?)
+            Ok(eval_test_expr(left, shell, params)? && eval_test_expr(right, shell, params)?)
         }
         brush_parser::ast::TestExpr::Or(left, right) => {
-            Ok(eval_test_expr(left, shell)? || eval_test_expr(right, shell)?)
+            Ok(eval_test_expr(left, shell, params)? || eval_test_expr(right, shell, params)?)
         }
-        brush_parser::ast::TestExpr::Not(expr) => Ok(!eval_test_expr(expr, shell)?),
-        brush_parser::ast::TestExpr::Parenthesized(expr) => eval_test_expr(expr, shell),
+        brush_parser::ast::TestExpr::Not(expr) => Ok(!eval_test_expr(expr, shell, params)?),
+        brush_parser::ast::TestExpr::Parenthesized(expr) => eval_test_expr(expr, shell, params),
         brush_parser::ast::TestExpr::UnaryTest(op, operand) => {
-            extendedtests::apply_unary_predicate_to_str(op, operand, shell)
+            extendedtests::apply_unary_predicate_to_str(op, operand, shell, params)
         }
         brush_parser::ast::TestExpr::BinaryTest(op, left, right) => {
             extendedtests::apply_binary_predicate_to_strs(op, left.as_str(), right.as_str(), shell)

--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -101,13 +101,11 @@ cases:
       echo $(echo hi >&3) 3>output.txt
 
   - name: "Redirection in command substitution in braces to non-standard fd"
-    known_failure: true # https://github.com/reubeno/brush/issues/358
     ignore_stderr: true
     stdin: |
       { : $(echo hi >&3); } 3>output.txt
 
   - name: "Redirection in command substitution in subshell to non-standard fd"
-    known_failure: true # https://github.com/reubeno/brush/issues/358
     ignore_stderr: true
     stdin: |
       ( : $(echo hi >&3); ) 3>output.txt


### PR DESCRIPTION
Address cases where command substitution environments don't correctly inherit the open files of the containing command.

_Caveat: I'm not thrilled about how much code needed to be touched, but this at least *fixes* a known defect. Hopefully we can clean it up subsequently._