### PR TITLE
fix(redirection): allow continuing past redir errors

### DIFF
--- a/brush-core/src/builtins/mapfile.rs
+++ b/brush-core/src/builtins/mapfile.rs
@@ -72,6 +72,7 @@ impl builtins::Command for MapFileCommand {
         }
 
         let input_file = context
+            .params
             .fd(self.fd)
             .ok_or_else(|| error::Error::BadFileDescriptor(self.fd))?;
 

--- a/brush-core/src/builtins/read.rs
+++ b/brush-core/src/builtins/read.rs
@@ -82,6 +82,7 @@ impl builtins::Command for ReadCommand {
         let input_stream = if let Some(fd_num) = self.fd_num_to_read {
             let fd_num = fd_num as u32;
             context
+                .params
                 .fd(fd_num)
                 .ok_or_else(|| error::Error::BadFileDescriptor(fd_num))?
         } else {

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -115,27 +115,17 @@ pub struct ExecutionContext<'a> {
 impl ExecutionContext<'_> {
     /// Returns the standard input file; usable with `write!` et al.
     pub fn stdin(&self) -> openfiles::OpenFile {
-        self.fd(0).unwrap()
+        self.params.stdin()
     }
 
     /// Returns the standard output file; usable with `write!` et al.
     pub fn stdout(&self) -> openfiles::OpenFile {
-        self.fd(1).unwrap()
+        self.params.stdout()
     }
 
     /// Returns the standard error file; usable with `write!` et al.
     pub fn stderr(&self) -> openfiles::OpenFile {
-        self.fd(2).unwrap()
-    }
-
-    /// Returns the file descriptor with the given number.
-    #[allow(clippy::unwrap_in_result)]
-    pub fn fd(&self, fd: u32) -> Option<openfiles::OpenFile> {
-        self.params
-            .open_files
-            .files
-            .get(&fd)
-            .map(|f| f.try_dup().unwrap())
+        self.params.stderr()
     }
 
     pub(crate) fn should_cmd_lead_own_process_group(&self) -> bool {

--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -109,3 +109,8 @@ cases:
     ignore_stderr: true
     stdin: |
       ( : $(echo hi >&3); ) 3>output.txt
+
+  - name: "Redirection failure"
+    ignore_stderr: true
+    stdin: |
+      echo hi > /non-existent-dir/file.txt; echo following-command


### PR DESCRIPTION
Redirection failure is an error that will cause the command to fail, but subsequent commands in a compound command, say, should be executed normally.

Resolves #341.