### PR TITLE
chore: fix rng warnings

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1564,15 +1564,15 @@ fn repeated_char_str(c: char, count: usize) -> String {
 }
 
 fn get_random_value(_shell: &Shell) -> ShellValue {
-    let mut rng = rand::thread_rng();
-    let num = rng.gen_range(0..32768);
+    let mut rng = rand::rng();
+    let num = rng.random_range(0..32768);
     let str = num.to_string();
     str.into()
 }
 
 fn get_srandom_value(_shell: &Shell) -> ShellValue {
-    let mut rng = rand::thread_rng();
-    let num: u32 = rng.gen();
+    let mut rng = rand::rng();
+    let num: u32 = rng.random();
     let str = num.to_string();
     str.into()
 }

--- a/brush-shell/tests/cases/well_known_vars.yaml
+++ b/brush-shell/tests/cases/well_known_vars.yaml
@@ -126,6 +126,15 @@ cases:
         echo "LINENO: $LINENO"
       done
 
+  - name: "RANDOM"
+    stdin: |
+      first=${RANDOM}
+      second=${RANDOM}
+
+      [[ $first != $second ]] && echo "Confirmed RANDOM at least isn't static"
+      [[ $first -ge 0 && $first -lt 32768 ]] && echo "RANDOM value is within expected range"
+      [[ $second -ge 0 && $second -lt 32768 ]] && echo "RANDOM value is within expected range"
+
   - name: "SHELLOPTS"
     stdin: |
       echo "SHELLOPTS: $SHELLOPTS"
@@ -135,3 +144,10 @@ cases:
       echo "SHLVL: $SHLVL"
       bash -c 'echo "bash SHLVL: $SHLVL"'
       $0 -c 'echo "nested SHLVL: $SHLVL"'
+
+  - name: "SRANDOM"
+    stdin: |
+      first=${SRANDOM}
+      second=${SRANDOM}
+
+      [[ $first != $second ]] && echo "Confirmed SRANDOM at least isn't static"


### PR DESCRIPTION
There are new warnings from deprecated rng functions; this fixes those warnings and adds some *extremely minimal* coverage of `$RANDOM` and `$SRANDOM` in the compat tests.