### PR TITLE
fix(builtins): correct read handling of IFS/space

### DIFF
--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -389,14 +389,14 @@ impl CompleteCommand {
             write!(
                 s,
                 " -G {}",
-                escape::force_quote(glob_pattern, escape::QuoteMode::Quote)
+                escape::force_quote(glob_pattern, escape::QuoteMode::SingleQuote)
             )?;
         }
         if let Some(word_list) = &spec.word_list {
             write!(
                 s,
                 " -W {}",
-                escape::force_quote(word_list, escape::QuoteMode::Quote)
+                escape::force_quote(word_list, escape::QuoteMode::SingleQuote)
             )?;
         }
         if let Some(function_name) = &spec.function_name {
@@ -406,28 +406,28 @@ impl CompleteCommand {
             write!(
                 s,
                 " -C {}",
-                escape::force_quote(command, escape::QuoteMode::Quote)
+                escape::force_quote(command, escape::QuoteMode::SingleQuote)
             )?;
         }
         if let Some(filter_pattern) = &spec.filter_pattern {
             write!(
                 s,
                 " -X {}",
-                escape::force_quote(filter_pattern, escape::QuoteMode::Quote)
+                escape::force_quote(filter_pattern, escape::QuoteMode::SingleQuote)
             )?;
         }
         if let Some(prefix) = &spec.prefix {
             write!(
                 s,
                 " -P {}",
-                escape::force_quote(prefix, escape::QuoteMode::Quote)
+                escape::force_quote(prefix, escape::QuoteMode::SingleQuote)
             )?;
         }
         if let Some(suffix) = &spec.suffix {
             write!(
                 s,
                 " -S {}",
-                escape::force_quote(suffix, escape::QuoteMode::Quote)
+                escape::force_quote(suffix, escape::QuoteMode::SingleQuote)
             )?;
         }
 

--- a/brush-core/src/builtins/export.rs
+++ b/brush-core/src/builtins/export.rs
@@ -94,12 +94,12 @@ impl builtins::Command for ExportCommand {
             // Enumerate variables, sorted by key.
             for (name, variable) in context.shell.env.iter().sorted_by_key(|v| v.0) {
                 if variable.is_exported() {
-                    writeln!(
-                        context.stdout(),
-                        "declare -x {}=\"{}\"",
-                        name,
-                        variable.value().to_cow_str(context.shell)
-                    )?;
+                    let value = variable.value().try_get_cow_str(context.shell);
+                    if let Some(value) = value {
+                        writeln!(context.stdout(), "declare -x {name}=\"{value}\"")?;
+                    } else {
+                        writeln!(context.stdout(), "declare -x {name}")?;
+                    }
                 }
             }
         }

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -171,14 +171,14 @@ impl From<&String> for CommandArg {
 impl CommandArg {
     pub fn quote_for_tracing(&self) -> Cow<'_, str> {
         match self {
-            CommandArg::String(s) => escape::quote_if_needed(s, escape::QuoteMode::Quote),
+            CommandArg::String(s) => escape::quote_if_needed(s, escape::QuoteMode::SingleQuote),
             CommandArg::Assignment(a) => {
                 let mut s = a.name.to_string();
                 let op = if a.append { "+=" } else { "=" };
                 s.push_str(op);
                 s.push_str(&escape::quote_if_needed(
                     a.value.to_string().as_str(),
-                    escape::QuoteMode::Quote,
+                    escape::QuoteMode::SingleQuote,
                 ));
                 s.into()
             }

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -604,7 +604,7 @@ impl Spec {
         for arg in args {
             command_line.push(' ');
 
-            let escaped_arg = escape::quote_if_needed(arg, escape::QuoteMode::Quote);
+            let escaped_arg = escape::quote_if_needed(arg, escape::QuoteMode::SingleQuote);
             command_line.push_str(escaped_arg.as_ref());
         }
 

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -56,7 +56,7 @@ async fn apply_unary_predicate(
     if shell.options.print_commands_and_arguments {
         shell.trace_command(std::format!(
             "[[ {op} {} ]]",
-            escape::quote_if_needed(&expanded_operand, escape::QuoteMode::Quote)
+            escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
         ))?;
     }
 

--- a/brush-shell/tests/cases/builtins/declare.yaml
+++ b/brush-shell/tests/cases/builtins/declare.yaml
@@ -14,13 +14,30 @@ common_test_files:
       }
 
 cases:
-  - name: "Dump vars"
+  - name: "Display vars"
     stdin: |
       declare myvar=something
       declare -p myvar
 
       myarr=(a b c)
       declare -p myarr
+
+  - name: "Display vars with interesting chars"
+    stdin: |
+      (testvar=$'a\nb' && declare -p testvar && declare | grep testvar=)
+      echo "-------------------------"
+      (testvar="\"abc\"" && declare -p testvar && declare | grep testvar=)
+      echo "-------------------------"
+      (testvar="a b c" && declare -p testvar && declare | grep testvar=)
+      echo "-------------------------"
+      (testvar="'" && declare -p testvar && declare | grep testvar=)
+      echo "-------------------------"
+      (testvar=$'\x03' && declare -p testvar && declare | grep testvar=)
+      echo "-------------------------"
+      (testvar=$'\x08' && declare -p testvar && declare | grep testvar=)
+      echo "-------------------------"
+      (testvar=$(printf '\033[34mabc\033[0m') && declare -p testvar && declare | grep testvar=)
+      echo "-------------------------"
 
   - name: "Declare integer"
     stdin: |

--- a/brush-shell/tests/cases/builtins/read.yaml
+++ b/brush-shell/tests/cases/builtins/read.yaml
@@ -4,10 +4,10 @@ cases:
     test_files:
       - path: "data.txt"
         contents: |
-          a
-          b
+          a 1
+          b 2
     stdin: |
-      while read name; do echo "Hello, $name"; done < data.txt
+      while read name num; do echo "Hello, $name => $num"; done < data.txt
 
   - name: "Basic read usage from pipe"
     stdin: |
@@ -42,3 +42,41 @@ cases:
       while IFS="" read myvar; do
           echo "myvar1: |${myvar}|"
       done < <(printf "a\tb\nc d\te\n")
+
+  - name: "read with empty entries"
+    stdin: |
+      (echo "x"; echo ""; echo "y"; echo ""; echo "") | while read line; do echo "LINE: '$line'"; done
+      echo 'x,,y,z' | (IFS=',' read READ1 READ2 READ3 READ4; declare -p READ1; declare -p READ2; declare -p READ3; declare -p READ4)
+
+  - name: "read -a with empty lines"
+    stdin: |
+      (echo "hi"; echo ""; echo "there"; echo ""; echo "you") | (read -a READ; declare -p READ)
+      (echo -e "hi\t\tthere\t\tyou") | (read -a READ -d $'\t'; declare -p READ)
+
+  - name: "read -a with empty interior field"
+    stdin: |
+      echo -e -n "hi||there||you" | (IFS='|' read -a READ; declare -p READ)
+      echo -e -n "hi  there  you " | (IFS=' ' read -a READ; declare -p READ)
+      echo -e -n "hi  there  you " | (read -a READ; declare -p READ)
+
+  - name: "read -a with empty leading field"
+    stdin: |
+      echo -e -n "|hi|there|you" | (IFS='|' read -a READ; declare -p READ)
+
+  - name: "read -a with empty trailing field"
+    known_failure: true # Needs further investigation
+    stdin: |
+      echo -e -n "hi|there|you|" | (IFS='|' read -a READ; declare -p READ)
+
+  - name: "read -a with empty entries + empty delimiter"
+    stdin: |
+      (echo "hi"; echo ""; echo "there"; echo ""; echo "you") | (read -a READ -d ''; declare -p READ)
+      echo -e -n "hi\n\nthere\n\nyou\n" | (read -a READ -d ''; declare -p READ)
+
+  - name: "read -a with empty entries + empty delimiter + custom IFS"
+    stdin: |
+      (echo 'x,,y,z'; echo 'w,v'; echo ''; echo ''; echo 'm') | (IFS=',' read -d "" -a READ; declare -p READ)
+
+  - name: "read with empty delimiter"
+    stdin: |
+      echo x | (read -d ""; declare -p REPLY)


### PR DESCRIPTION
* Adds a handful of compat test cases for `read`, with a specific focus on IFS handling and `-d` handling.
* Fixes multiple issues with `read` to get tests to pass; notably, implementing support for `-d ''` (i.e., empty delimiter) and correcting semantics with how IFS space characters delimit.
* Along the way, corrected discrepancies with how `declare` et al. format certain strings (e.g., upgrading to ANSI-C quoting when the string includes control characters, including newlines).