### PR TITLE
fix(extglob): correct handling of extglobs with empty branches

### DIFF
--- a/brush-shell/tests/cases/builtins/declare.yaml
+++ b/brush-shell/tests/cases/builtins/declare.yaml
@@ -24,20 +24,22 @@ cases:
 
   - name: "Display vars with interesting chars"
     stdin: |
-      (testvar=$'a\nb' && declare -p testvar && declare | grep testvar=)
-      echo "-------------------------"
       (testvar="\"abc\"" && declare -p testvar && declare | grep testvar=)
       echo "-------------------------"
       (testvar="a b c" && declare -p testvar && declare | grep testvar=)
       echo "-------------------------"
       (testvar="'" && declare -p testvar && declare | grep testvar=)
+
+  - name: "Display vars with interesting chars 2"
+    min_oracle_version: 5.2 # some sequences render differently in older shell versions
+    stdin: |
+      (testvar=$'a\nb' && declare -p testvar && declare | grep testvar=)
       echo "-------------------------"
       (testvar=$'\x03' && declare -p testvar && declare | grep testvar=)
       echo "-------------------------"
       (testvar=$'\x08' && declare -p testvar && declare | grep testvar=)
       echo "-------------------------"
       (testvar=$(printf '\033[34mabc\033[0m') && declare -p testvar && declare | grep testvar=)
-      echo "-------------------------"
 
   - name: "Declare integer"
     stdin: |

--- a/brush-shell/tests/cases/builtins/read.yaml
+++ b/brush-shell/tests/cases/builtins/read.yaml
@@ -78,5 +78,6 @@ cases:
       (echo 'x,,y,z'; echo 'w,v'; echo ''; echo ''; echo 'm') | (IFS=',' read -d "" -a READ; declare -p READ)
 
   - name: "read with empty delimiter"
+    min_oracle_version: 5.2 # \n renders differently in older shell versions
     stdin: |
       echo x | (read -d ""; declare -p REPLY)

--- a/brush-shell/tests/cases/patterns/filename_expansion.yaml
+++ b/brush-shell/tests/cases/patterns/filename_expansion.yaml
@@ -159,6 +159,7 @@ cases:
       echo "1: " @(abc|abd).txt
       echo "2: " @(abc.txt)
       echo "3: " @(abc)
+      echo "4: " @(|abc.txt)
 
   - name: "Pathname expansion: Optional patterns"
     ignore_stderr: true


### PR DESCRIPTION
Corrects parsing of `extglob` patterns such as `@(|text)`.