### PR TITLE
docs: add how to use via nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ If you don't have `rust` installed, we recommend installing it via [`rustup`](ht
 (If you *are* interested in having a binary release, then please let us know in the 'Discussions' area of this
 project or by filing a feature request in 'Issues'.)
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/brush.svg)](https://repology.org/project/brush/versions)
+
+If you are a Nix user, you can also use the registered version.
+
+```bash
+nix run 'github:NixOS/nixpkgs/nixpkgs-unstable#brush' -- --version
+```
+
 When you run `brush`, it should look exactly as `bash` would on your system since it processes `.bashrc` and
 other usual configuration. If you'd like to customize the look of `brush` to distinguish it from the other shells
 installed on your system, then you can also author a `~/.brushrc` file.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![CI workflow badge](https://github.com/reubeno/brush/actions/workflows/ci.yaml/badge.svg)](https://github.com/reubeno/brush/actions/workflows/ci.yaml)
 [![Devcontainer workflow badge](https://github.com/reubeno/brush/actions/workflows/devcontainer.yaml/badge.svg)](https://github.com/reubeno/brush/actions/workflows/devcontainer.yaml)
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/brush.svg)](https://repology.org/project/brush/versions)
+
 ## About
 
 `brush` (**B**o(u)rn(e) **RU**sty **SH**ell) is a [POSIX-](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html) and [bash-](https://www.gnu.org/software/bash/)compatible shell,
@@ -45,8 +47,6 @@ If you don't have `rust` installed, we recommend installing it via [`rustup`](ht
 
 (If you *are* interested in having a binary release, then please let us know in the 'Discussions' area of this
 project or by filing a feature request in 'Issues'.)
-
-[![Packaging status](https://repology.org/badge/vertical-allrepos/brush.svg)](https://repology.org/project/brush/versions)
 
 If you are a Nix user, you can also use the registered version.
 


### PR DESCRIPTION
I have added the package definition in https://github.com/NixOS/nixpkgs/pull/382795.
I hope this will make it easy to use by visitors without the build step. A binary cache of Nix might be an alternative solution for https://github.com/reubeno/brush/issues/69.