### PR TITLE
feat(arithmetic): support explicit base#literal in arithmetic

### DIFF
--- a/brush-shell/tests/cases/arithmetic.yaml
+++ b/brush-shell/tests/cases/arithmetic.yaml
@@ -18,6 +18,18 @@ cases:
       echo "$((0x10))"
       echo "$((0x010))"
 
+  - name: "Arithmetic literals with explicit bases"
+    stdin: |
+      echo "$((2#1010))"
+      echo "$((8#16))"
+      echo "$((16#faf))"
+      echo "$((36#vvv))"
+
+  - name: "Arithmetic literals with base 64 encoding"
+    known_failure: true # Not currently handled.
+    stdin: |
+      echo "$((64#zzz))"
+
   - name: "Parentheses"
     stdin: |
       echo "$(((10)))"


### PR DESCRIPTION
Implements support for arithmetic literals like `2#1010` and `16#32f`.

The native Rust facility to parsing integers with an explicit radix only supports base 2-36. That's pretty reasonable, but `bash` technically supports up through base 64. For now, we do our best with the native facilities.