### PR TITLE
fix: default PS1 and PS2 in interactive mode

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -627,6 +627,17 @@ impl Shell {
         random_var.treat_as_integer();
         self.env.set_global("SRANDOM", random_var)?;
 
+        // PS1 / PS2
+        if options.interactive {
+            if !self.env.is_set("PS1") {
+                self.env.set_global("PS1", ShellVariable::new(r#"\s-\v\$ "#.into()))?;
+            }
+
+            if !self.env.is_set("PS2") {
+                self.env.set_global("PS2", ShellVariable::new("> ".into()))?;
+            }
+        }
+
         // PS4
         if !self.env.is_set("PS4") {
             self.env

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -630,11 +630,13 @@ impl Shell {
         // PS1 / PS2
         if options.interactive {
             if !self.env.is_set("PS1") {
-                self.env.set_global("PS1", ShellVariable::new(r#"\s-\v\$ "#.into()))?;
+                self.env
+                    .set_global("PS1", ShellVariable::new(r#"\s-\v\$ "#.into()))?;
             }
 
             if !self.env.is_set("PS2") {
-                self.env.set_global("PS2", ShellVariable::new("> ".into()))?;
+                self.env
+                    .set_global("PS2", ShellVariable::new("> ".into()))?;
             }
         }
 

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -631,7 +631,7 @@ impl Shell {
         if options.interactive {
             if !self.env.is_set("PS1") {
                 self.env
-                    .set_global("PS1", ShellVariable::new(r#"\s-\v\$ "#.into()))?;
+                    .set_global("PS1", ShellVariable::new(r"\s-\v\$ ".into()))?;
             }
 
             if !self.env.is_set("PS2") {

--- a/brush-parser/src/arithmetic.rs
+++ b/brush-parser/src/arithmetic.rs
@@ -104,7 +104,7 @@ peg::parser! {
             // Literal with explicit radix (format: <base>#<literal>)
             radix:decimal_literal() "#" s:$(['0'..='9' | 'a'..='z' | 'A'..='Z']+) {?
                 // TODO: Support bases larger than 36. from_str_radix can't handle that.
-                if radix < 2 || radix > 36 {
+                if !(2..=36).contains(&radix) {
                     return Err("invalid base");
                 }
 


### PR DESCRIPTION
In interactive mode, we need to initialize `PS1` and `PS2` (if unset).

Some profile/rc scripts look at the existence of `PS1` as a signal that the shell is running interactively.