### PR TITLE
fix: correct path tests on empty strings

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1364,7 +1364,7 @@ impl Shell {
     ///
     /// * `path` - The path to get the absolute form of.
     pub fn get_absolute_path(&self, path: &Path) -> PathBuf {
-        if path.is_absolute() {
+        if path.as_os_str().is_empty() || path.is_absolute() {
             path.to_owned()
         } else {
             self.working_dir.join(path)

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -8,11 +8,36 @@ cases:
       [[ -c /dev/null ]] && echo "-c correctly checked /dev/null"
       [[ -c /tmp ]] || echo "-c correctly checked /tmp"
 
-      [[ -d /tmp ]] && echo "-d correctly checked /tmp"
-      [[ -d /dev/null ]] || echo "-d correctly checked /dev/null"
+  - name: "Existence tests"
+    stdin: |
+      [[ -e '' ]] || echo "-e correctly identified empty string as non-existent"
+
+      [[ -e non-existent ]] || echo "-e correctly identified non-existent path"
+      [[ ! -e non-existent ]] && echo "! -e correctly identified non-existent path"
+
+      touch test-file
+      [[ -e test-file ]] && echo "-e correctly identified existing non-dir"
+
+      mkdir test-dir
+      [[ -e test-dir ]] && echo "-d correctly identified existing dir"
+
+  - name: "Directory tests"
+    stdin: |
+      [[ -d '' ]] || echo "-d correctly identified empty string as non-existent"
+
+      [[ -d non-existent ]] || echo "-d correctly identified non-existent path"
+      [[ ! -d non-existent ]] && echo "! -d correctly identified non-existent path"
+
+      touch test-file
+      [[ -d test-file ]] || echo "-d correctly identified non-dir file"
+
+      mkdir test-dir
+      [[ -d test-dir ]] && echo "-d correctly identified existing dir"
 
   - name: "File regular tests"
     stdin: |
+      [[ -f '' ]] || echo "-f correctly identified empty string as non-existent"
+
       [[ -f non-existent ]] || echo "-f correctly identified non-existent path"
       [[ ! -f non-existent ]] && echo "! -f correctly identified non-existent path"
 


### PR DESCRIPTION
Ensure that, for example, `[[ -e '' ]]` does *not* return 0.

The trouble here is that `Shell::get_absolute_path()` had returned a valid, absolute path when given a `Path` constructed from `""`. This fixes that at the root by explicitly checking for a `Path` whose `.as_os_str()` is empty.