### PR TITLE
fix: reset default prompt color

### DIFF
--- a/brush-interactive/src/reedline/prompt.rs
+++ b/brush-interactive/src/reedline/prompt.rs
@@ -48,7 +48,7 @@ impl reedline::Prompt for InteractivePrompt {
     }
 
     fn get_prompt_color(&self) -> reedline::Color {
-        reedline::Color::Magenta
+        reedline::Color::Reset
     }
 
     fn get_prompt_multiline_color(&self) -> nu_ansi_term::Color {


### PR DESCRIPTION
Use plain "reset" color for default prompt color.