### PR TITLE
feat: add parser selection

### DIFF
--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -37,6 +37,6 @@ mod variables;
 pub use commands::ExecutionContext;
 pub use error::Error;
 pub use interp::{ExecutionParameters, ExecutionResult};
-pub use shell::{CreateOptions, Shell};
+pub use shell::{CreateOptions, ParserImplementation, Shell};
 pub use terminal::TerminalControl;
 pub use variables::{ShellValue, ShellVariable};

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -178,6 +178,18 @@ pub struct CreateOptions {
     pub verbose: bool,
     /// Maximum function call depth.
     pub max_function_call_depth: Option<usize>,
+    /// The parser implementation to use.
+    pub parser: ParserImplementation,
+}
+
+/// Represents the parser implementation.
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+pub enum ParserImplementation {
+    #[default]
+    /// The peg parser implementation
+    Peg,
+    /// The winnow parser implementation
+    Winnow,
 }
 
 /// Represents an executing script.

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -11,10 +11,12 @@ pub mod word;
 
 mod error;
 mod parser;
+mod parser2;
 mod tokenizer;
 
 pub use error::{ParseError, TestCommandParseError, WordParseError};
 pub use parser::{parse_tokens, Parser, ParserOptions, SourceInfo};
+pub use parser2::Parser as WinnowParser;
 pub use tokenizer::{
     tokenize_str, tokenize_str_with_options, uncached_tokenize_str, unquote_str, SourcePosition,
     Token, TokenLocation, TokenizerOptions,

--- a/brush-parser/src/parser2.rs
+++ b/brush-parser/src/parser2.rs
@@ -1,0 +1,2 @@
+/// Implements parsing for shell programs using winnow.
+pub struct Parser {}

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -1,3 +1,4 @@
+use brush_core::ParserImplementation;
 use clap::{builder::styling, Parser};
 use std::io::IsTerminal;
 
@@ -23,6 +24,22 @@ pub enum InputBackend {
     Reedline,
     Basic,
     Minimal,
+}
+
+#[derive(Clone, Default, clap::ValueEnum)]
+pub enum ParserBackend {
+    #[default]
+    Peg,
+    Winnow,
+}
+
+impl From<ParserBackend> for ParserImplementation {
+    fn from(backend: ParserBackend) -> ParserImplementation {
+        match backend {
+            ParserBackend::Peg => ParserImplementation::Peg,
+            ParserBackend::Winnow => ParserImplementation::Winnow,
+        }
+    }
 }
 
 /// Parsed command-line arguments for the brush shell.
@@ -129,6 +146,10 @@ pub struct CommandLineArgs {
     /// Input backend.
     #[clap(long = "input-backend")]
     pub input_backend: Option<InputBackend>,
+
+    /// Parser implementation.
+    #[clap(long = "parser-backend")]
+    pub parser_backend: Option<ParserBackend>,
 
     /// Enable debug logging for classes of tracing events.
     #[clap(long = "log-enable", value_name = "EVENT")]

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -218,6 +218,7 @@ async fn instantiate_shell(
             sh_mode: args.sh_mode,
             verbose: args.verbose,
             max_function_call_depth: None,
+            parser: args.parser_backend.clone().unwrap_or_default().into(),
         },
         disable_bracketed_paste: args.disable_bracketed_paste,
         disable_color: args.disable_color,


### PR DESCRIPTION
This PR adds support for selecting the parser implementation based on https://github.com/reubeno/brush/pull/283#issuecomment-2532562558. I was having trouble running the compat tests under NixOS though - not sure what I'm missing since it doesn't seem to give backtrace:

```
     Running tests/compat_tests.rs (target/debug/deps/brush_compat_tests-6c008899565a1736)
Error: No such file or directory (os error 2)
error: test failed, to rerun pass `--test brush-compat-tests`

Caused by:
  process didn't exit successfully: `/home/theo/src/brush/target/debug/deps/brush_compat_tests-6c008899565a1736` (exit status: 1)
```