### PR TITLE
Expand contents of PS4 when tracing

### DIFF
--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -92,6 +92,7 @@ pub(crate) async fn expand_and_eval(
     if trace_if_needed && shell.options.print_commands_and_arguments {
         shell
             .trace_command(std::format!("(( {expr} ))"))
+            .await
             .map_err(|_err| EvalError::TraceError)?;
     }
 

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -54,10 +54,12 @@ async fn apply_unary_predicate(
     let expanded_operand = expansion::basic_expand_word(shell, params, operand).await?;
 
     if shell.options.print_commands_and_arguments {
-        shell.trace_command(std::format!(
-            "[[ {op} {} ]]",
-            escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
-        ))?;
+        shell
+            .trace_command(std::format!(
+                "[[ {op} {} ]]",
+                escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
+            ))
+            .await?;
     }
 
     apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell, params)
@@ -200,7 +202,9 @@ async fn apply_binary_predicate(
             let regex = expansion::basic_expand_regex(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {s} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {s} {op} {right} ]]"))
+                    .await?;
             }
 
             let (matches, captures) = match regex.matches(s.as_str()) {
@@ -237,7 +241,9 @@ async fn apply_binary_predicate(
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left == right)
@@ -247,7 +253,9 @@ async fn apply_binary_predicate(
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left != right)
@@ -257,7 +265,9 @@ async fn apply_binary_predicate(
             let substring = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {s} {op} {substring} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {s} {op} {substring} ]]"))
+                    .await?;
             }
 
             Ok(s.contains(substring.as_str()))
@@ -276,7 +286,9 @@ async fn apply_binary_predicate(
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             // TODO: According to docs, should be lexicographical order of the current locale.
@@ -287,7 +299,9 @@ async fn apply_binary_predicate(
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             // TODO: According to docs, should be lexicographical order of the current locale.
@@ -300,7 +314,9 @@ async fn apply_binary_predicate(
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left == right)
@@ -312,7 +328,9 @@ async fn apply_binary_predicate(
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left != right)
@@ -324,7 +342,9 @@ async fn apply_binary_predicate(
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left < right)
@@ -336,7 +356,9 @@ async fn apply_binary_predicate(
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left <= right)
@@ -348,7 +370,9 @@ async fn apply_binary_predicate(
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left > right)
@@ -360,7 +384,9 @@ async fn apply_binary_predicate(
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
             if shell.options.print_commands_and_arguments {
-                shell.trace_command(std::format!("[[ {left} {op} {right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .await?;
             }
 
             Ok(left >= right)
@@ -382,7 +408,9 @@ async fn apply_binary_predicate(
                     expanded_right.as_str(),
                     escape::QuoteMode::BackslashEscape,
                 );
-                shell.trace_command(std::format!("[[ {s} {op} {escaped_right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {s} {op} {escaped_right} ]]"))
+                    .await?;
             }
 
             pattern.exactly_matches(s.as_str())
@@ -400,7 +428,9 @@ async fn apply_binary_predicate(
                     expanded_right.as_str(),
                     escape::QuoteMode::BackslashEscape,
                 );
-                shell.trace_command(std::format!("[[ {s} {op} {escaped_right} ]]"))?;
+                shell
+                    .trace_command(std::format!("[[ {s} {op} {escaped_right} ]]"))
+                    .await?;
             }
 
             let eq = pattern.exactly_matches(s.as_str())?;

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -609,13 +609,17 @@ impl Execute for ast::ForClauseCommand {
         for value in expanded_values {
             if shell.options.print_commands_and_arguments {
                 if let Some(unexpanded_values) = &self.values {
-                    shell.trace_command(std::format!(
-                        "for {} in {}",
-                        self.variable_name,
-                        unexpanded_values.iter().join(" ")
-                    ))?;
+                    shell
+                        .trace_command(std::format!(
+                            "for {} in {}",
+                            self.variable_name,
+                            unexpanded_values.iter().join(" ")
+                        ))
+                        .await?;
                 } else {
-                    shell.trace_command(std::format!("for {}", self.variable_name,))?;
+                    shell
+                        .trace_command(std::format!("for {}", self.variable_name,))
+                        .await?;
                 }
             }
 
@@ -666,7 +670,9 @@ impl Execute for ast::CaseClauseCommand {
         // N.B. One would think it makes sense to trace the expanded value being switched
         // on, but that's not it.
         if shell.options.print_commands_and_arguments {
-            shell.trace_command(std::format!("case {} in", &self.value))?;
+            shell
+                .trace_command(std::format!("case {} in", &self.value))
+                .await?;
         }
 
         let expanded_value = expansion::basic_expand_word(shell, params, &self.value).await?;
@@ -1054,7 +1060,8 @@ impl ExecuteInPipeline for ast::SimpleCommand {
             if context.shell.options.print_commands_and_arguments {
                 context
                     .shell
-                    .trace_command(args.iter().map(|arg| arg.quote_for_tracing()).join(" "))?;
+                    .trace_command(args.iter().map(|arg| arg.quote_for_tracing()).join(" "))
+                    .await?;
             }
 
             // TODO: This is adding more complexity here; should be factored out into an appropriate
@@ -1273,7 +1280,9 @@ async fn apply_assignment(
 
     if shell.options.print_commands_and_arguments {
         let op = if assignment.append { "+=" } else { "=" };
-        shell.trace_command(std::format!("{}{op}{new_value}", assignment.name))?;
+        shell
+            .trace_command(std::format!("{}{op}{new_value}", assignment.name))
+            .await?;
     }
 
     // See if we need to eval an array index.

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1510,7 +1510,7 @@ impl Shell {
         &mut self,
         command: S,
     ) -> Result<(), error::Error> {
-        let ps4 = self.as_mut().expand_prompt_var("PS4", "+ ").await?;
+        let ps4 = self.as_mut().expand_prompt_var("PS4", "").await?;
 
         let mut prefix = ps4.to_string();
 

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1506,8 +1506,11 @@ impl Shell {
     /// # Arguments
     ///
     /// * `command` - The command to trace.
-    pub(crate) fn trace_command<S: AsRef<str>>(&self, command: S) -> Result<(), std::io::Error> {
-        let ps4 = self.get_env_str("PS4").unwrap_or_else(|| "".into());
+    pub(crate) async fn trace_command<S: AsRef<str>>(
+        &mut self,
+        command: S,
+    ) -> Result<(), error::Error> {
+        let ps4 = self.as_mut().expand_prompt_var("PS4", "+ ").await?;
 
         let mut prefix = ps4.to_string();
 
@@ -1518,7 +1521,8 @@ impl Shell {
             }
         }
 
-        writeln!(self.stderr(), "{prefix}{}", command.as_ref())
+        writeln!(self.stderr(), "{prefix}{}", command.as_ref())?;
+        Ok(())
     }
 
     /// Returns the keywords that are reserved by the shell.

--- a/brush-shell/tests/cases/builtins/ps4.yaml
+++ b/brush-shell/tests/cases/builtins/ps4.yaml
@@ -1,0 +1,8 @@
+name: "Builtins: PS4"
+cases:
+  - name: "PS4 expansion"
+    stdin: |
+      PS4='+$FUNCNAME '
+      bar() { true; }
+      foo() { set -x; bar; set +x; }
+      foo


### PR DESCRIPTION
This PR calls `expand_prompt_var()` on the contents of PS4 within `trace_command()`.  The addition necessitates `trace_command()` become `async` and calls to it use `await`.  A new test case checks expansion against an oracle.