### PR TITLE
fix: improve panic handling output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "clap",
  "colored",
  "const_format",
+ "crossterm",
  "descape",
  "diff",
  "expectrl",

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -62,6 +62,7 @@ brush-interactive = { version = "^0.2.15", path = "../brush-interactive", featur
     "basic",
     "reedline",
 ] }
+crossterm = "0.28.1"
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "sync"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This (hopefully) finally makes sure that the output from `brush`'s panic handler (whether it be the Rust default or the one set up by `human_panic`) is readable, even when we panicked in the middle of `reedline` taking input.

In the worst case, when we panic -- say, in the middle of displaying the completion menu as happens in #406 -- the terminal is in raw mode and `reedline::Reedline`'s internal painter has some buffered terminal control sequences that haven't yet flushed. At best, the error output is unreadable because emitting `\n` doesn't reset the terminal's column to 0; at worst, the error output is lost entirely because the aforementioned control sequences get flushed at an inconvenient time and wipe out the output.

To address this, we:

1. Do what many other Rust-based console programs do: install a panic handler that uses `crossterm` to disable raw mode, reset some basics (e.g., cursor visibility), and then call the previously registered handler.

2. Make sure that the shell's singleton instance of `reedline::Reedline` doesn't get dropped. This is unpleasant, but without this part of the change, everything would go find during panic handling yet the `reedline::Reedline` instance would get dropped, which results in its painter flushing some pending output to `stdout` and effectively erasing the panic message. I couldn't find a better solution with the current implementation of `reedline` other than to, well, `std::mem::forget()` the `Reedline` instance so its `drop()` impl wouldn't get run.