### PR TITLE
test: add more linux distros to test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -469,6 +469,9 @@ jobs:
     runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     needs: build
+    env:
+      # Reference: https://github.com/Azure/azure-cli/issues/29835
+      GNUPGHOME: /root/.gnupg
     steps:
       # Install prerequisites *first*; may need some of them for checkout itself.
       - name: Install prerequisites
@@ -481,9 +484,7 @@ jobs:
         run: |
           # Hacks to get the mounted nodejs by github actions work as its dynamically linked
           # https://github.com/actions/checkout/issues/334#issuecomment-716068696
-          mkdir -p ~/.config/nix
-          echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf
-          nix build --no-link --max-jobs 2 --cores 0 'nixpkgs#stdenv.cc.cc.lib' 'nixpkgs#glibc'
+          nix --extra-experimental-features nix-command --extra-experimental-features flakes build --no-link --max-jobs 2 --cores 0 'nixpkgs#stdenv.cc.cc.lib' 'nixpkgs#glibc'
           echo "LD_LIBRARY_PATH=$(nix path-info 'nixpkgs#stdenv.cc.cc.lib')/lib" >> "$GITHUB_ENV"
           ln -s "$(nix path-info 'nixpkgs#glibc' --recursive | grep glibc | grep -v bin)/lib64" /lib64
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -446,7 +446,7 @@ jobs:
 
           - container: "mcr.microsoft.com/azurelinux/base/core:3.0"
             description: "Azure Linux/3.0"
-            prereqs_command: "tdnf install -y bash-completion git iputils grep less sed util-linux"
+            prereqs_command: "tdnf install -y bash-completion ca-certificates git iputils grep less sed util-linux"
 
           - container: "debian:testing"
             description: "Debian/testing"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -484,6 +484,7 @@ jobs:
         run: |
           # Hacks to get the mounted nodejs by github actions work as its dynamically linked
           # https://github.com/actions/checkout/issues/334#issuecomment-716068696
+          set -x
           nix --extra-experimental-features nix-command --extra-experimental-features flakes build --no-link --max-jobs 2 --cores 0 'nixpkgs#stdenv.cc.cc.lib' 'nixpkgs#glibc'
           echo "LD_LIBRARY_PATH=$(nix path-info 'nixpkgs#stdenv.cc.cc.lib')/lib" >> "$GITHUB_ENV"
           ln -s "$(nix path-info 'nixpkgs#glibc' --recursive | grep glibc | grep -v bin)/lib64" /lib64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -440,21 +440,53 @@ jobs:
       matrix:
         include:
           # N.B. We don't include Ubuntu because it's already covered by the initial test job.
-          - container: "fedora:latest"
-            description: "Fedora/latest"
-            prereqs_command: "dnf install -y bash-completion iputils grep less sed util-linux"
-          - container: "debian:testing"
-            description: "Debian/testing"
-            prereqs_command: "apt-get update -y && apt-get install -y bash-completion bsdmainutils iputils-ping grep less sed"
           - container: "archlinux:latest"
             description: "Arch Linux/latest"
             prereqs_command: "pacman -Sy --noconfirm bash-completion iputils grep less sed util-linux"
+
+          - container: "mcr.microsoft.com/azurelinux/base/core:3.0"
+            description: "Azure Linux/3.0"
+            prereqs_command: "tdnf install -y bash-completion git iputils grep less sed util-linux"
+
+          - container: "debian:testing"
+            description: "Debian/testing"
+            prereqs_command: "apt-get update -y && apt-get install -y bash-completion bsdmainutils iputils-ping grep less sed"
+
+          - container: "fedora:latest"
+            description: "Fedora/latest"
+            prereqs_command: "dnf install -y bash-completion iputils grep less sed util-linux"
+
+          - container: "nixos/nix:latest"
+            description: "NixOS/latest"
+            prereqs_command: "nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install nixpkgs#hexdump nixpkgs#bash-completion"
+
+          # NOTE: We use Tumbleweed to make sure we get a recent enough version of bash.
+          - container: "opensuse/tumbleweed:latest"
+            description: "openSUSE Tumbleweed/latest"
+            prereqs_command: "zypper install -y bash-completion git"
 
     name: "OS target tests (${{ matrix.description }})"
     runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     needs: build
     steps:
+      # Install prerequisites *first*; may need some of them for checkout itself.
+      - name: Install prerequisites
+        if: ${{ matrix.prereqs_command != '' }}
+        run: ${{ matrix.prereqs_command }}
+
+      # Workaround task issues on NixOS
+      - name: "Apply workarounds: NixOS"
+        if: ${{ matrix.container == 'nixos/nix:latest' }}
+        run: |
+          # Hacks to get the mounted nodejs by github actions work as its dynamically linked
+          # https://github.com/actions/checkout/issues/334#issuecomment-716068696
+          mkdir -p ~/.config/nix
+          echo 'experimental-features = nix-command flakes' > ~/.config/nix/nix.conf
+          nix build --no-link --max-jobs 2 --cores 0 'nixpkgs#stdenv.cc.cc.lib' 'nixpkgs#glibc'
+          echo "LD_LIBRARY_PATH=$(nix path-info 'nixpkgs#stdenv.cc.cc.lib')/lib" >> "$GITHUB_ENV"
+          ln -s "$(nix path-info 'nixpkgs#glibc' --recursive | grep glibc | grep -v bin)/lib64" /lib64
+
       # Checkout sources for YAML-based test cases
       - name: Checkout
         uses: actions/checkout@v4
@@ -480,10 +512,6 @@ jobs:
           chmod +x binaries/*
           ls -l -R sources/brush-shell/tests
           ls -l binaries
-
-      - name: Install prerequisites
-        if: ${{ matrix.prereqs_command != '' }}
-        run: ${{ matrix.prereqs_command }}
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -486,8 +486,8 @@ jobs:
           # https://github.com/actions/checkout/issues/334#issuecomment-716068696
           set -x
           nix --extra-experimental-features nix-command --extra-experimental-features flakes build --no-link --max-jobs 2 --cores 0 'nixpkgs#stdenv.cc.cc.lib' 'nixpkgs#glibc'
-          echo "LD_LIBRARY_PATH=$(nix path-info 'nixpkgs#stdenv.cc.cc.lib')/lib" >> "$GITHUB_ENV"
-          ln -s "$(nix path-info 'nixpkgs#glibc' --recursive | grep glibc | grep -v bin)/lib64" /lib64
+          echo "LD_LIBRARY_PATH=$(nix --extra-experimental-features nix-command --extra-experimental-features flakes path-info 'nixpkgs#stdenv.cc.cc.lib')/lib" >> "$GITHUB_ENV"
+          ln -s "$(nix --extra-experimental-features nix-command --extra-experimental-features flakes path-info 'nixpkgs#glibc' --recursive | grep glibc | grep -v bin)/lib64" /lib64
 
       # Checkout sources for YAML-based test cases
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -456,9 +456,10 @@ jobs:
             description: "Fedora/latest"
             prereqs_command: "dnf install -y bash-completion iputils grep less sed util-linux"
 
-          - container: "nixos/nix:latest"
-            description: "NixOS/latest"
-            prereqs_command: "nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install nixpkgs#hexdump nixpkgs#bash-completion"
+          # TODO: Enable after debugging through the test failures (or marking them disabled for Nix).
+          # - container: "nixos/nix:latest"
+          #   description: "NixOS/latest"
+          #   prereqs_command: "nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install nixpkgs#hexdump nixpkgs#bash-completion"
 
           # NOTE: We use Tumbleweed to make sure we get a recent enough version of bash.
           - container: "opensuse/tumbleweed:latest"

--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -44,6 +44,7 @@ cases:
       echo hi 4>file.txt >&4
 
   - name: "Process substitution: basic"
+    ignore_stdout: true # Specific fd-based paths may vary across runs
     stdin: |
       shopt -u -o posix
       echo <(:) >(:)


### PR DESCRIPTION
* Adds openSUSE/tumbleweed + Azure Linux/3.0.
* Adds nix-based container (commented out); will need to debug through test failures on it.
* Adds logic to compat test harness to OR in additional dirs from the host system's PATH in order to resolve standard POSIX tools