### PR TITLE
test: enable testing on nixos/nix container image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -478,16 +478,23 @@ jobs:
         if: ${{ matrix.prereqs_command != '' }}
         run: ${{ matrix.prereqs_command }}
 
-      # Workaround task issues on NixOS
+      # Workaround path issues on NixOS
       - name: "Apply workarounds: NixOS"
         if: ${{ matrix.container == 'nixos/nix:latest' }}
         run: |
-          # Hacks to get the mounted nodejs by github actions work as its dynamically linked
-          # https://github.com/actions/checkout/issues/334#issuecomment-716068696
           set -x
-          nix --extra-experimental-features nix-command --extra-experimental-features flakes build --no-link --max-jobs 2 --cores 0 'nixpkgs#stdenv.cc.cc.lib' 'nixpkgs#glibc'
-          echo "LD_LIBRARY_PATH=$(nix --extra-experimental-features nix-command --extra-experimental-features flakes path-info 'nixpkgs#stdenv.cc.cc.lib')/lib" >> "$GITHUB_ENV"
-          ln -s "$(nix --extra-experimental-features nix-command --extra-experimental-features flakes path-info 'nixpkgs#glibc' --recursive | grep glibc | grep -v bin)/lib64" /lib64
+
+          # Allow use of experimental features to avoid nix from complaining.
+          export NIX_CONFIG="extra-experimental-features = nix-command flakes"
+
+          # Hacks to get the mounted nodejs by github actions work as it's dynamically linked
+          # https://github.com/actions/checkout/issues/334#issuecomment-716068696
+          nix build --no-link --max-jobs 2 --cores 0 'nixpkgs#stdenv.cc.cc.lib' 'nixpkgs#glibc'
+          echo "LD_LIBRARY_PATH=$(nix path-info 'nixpkgs#stdenv.cc.cc.lib')/lib" >> "$GITHUB_ENV"
+          ln -s "$(nix path-info 'nixpkgs#glibc' --recursive | grep glibc | grep -v bin)/lib64" /lib64
+
+          # Provide alternate path for bash-completion
+          echo "BASH_COMPLETION_PATH=$(nix path-info 'nixpkgs#bash-completion')/share/bash-completion/bash_completion">>"$GITHUB_ENV"
 
       # Checkout sources for YAML-based test cases
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -456,10 +456,9 @@ jobs:
             description: "Fedora/latest"
             prereqs_command: "dnf install -y bash-completion iputils grep less sed util-linux"
 
-          # TODO: Enable after debugging through the test failures (or marking them disabled for Nix).
-          # - container: "nixos/nix:latest"
-          #   description: "NixOS/latest"
-          #   prereqs_command: "nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install nixpkgs#hexdump nixpkgs#bash-completion"
+          - container: "nixos/nix:latest"
+            description: "NixOS/latest"
+            prereqs_command: "nix --extra-experimental-features nix-command --extra-experimental-features flakes profile install nixpkgs#hexdump nixpkgs#bash-completion"
 
           # NOTE: We use Tumbleweed to make sure we get a recent enough version of bash.
           - container: "opensuse/tumbleweed:latest"

--- a/brush-core/src/builtins/command.rs
+++ b/brush-core/src/builtins/command.rs
@@ -97,11 +97,7 @@ impl CommandCommand {
             let candidate_path = shell.get_absolute_path(Path::new(command_name));
             if candidate_path.executable() {
                 Some(FoundCommand::External(
-                    candidate_path
-                        .canonicalize()
-                        .unwrap()
-                        .to_string_lossy()
-                        .to_string(),
+                    candidate_path.to_string_lossy().to_string(),
                 ))
             } else {
                 None

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -75,7 +75,15 @@ impl PrintfCommand {
     ) -> Result<String, crate::error::Error> {
         // TODO: Don't call external printf command.
         let mut cmd = std::process::Command::new("printf");
+
+        // Clear all environment variables except the PATH we had on launch.
+        // This latter variable is preserved in case the default fallback
+        // PATH isn't sufficient to find printf.
         cmd.env_clear();
+        if let Ok(orig_path) = std::env::var("PATH") {
+            cmd.env("PATH", orig_path);
+        }
+
         cmd.args(&self.format_and_args);
 
         let output = cmd.output()?;

--- a/brush-shell/tests/cases/builtins/command.yaml
+++ b/brush-shell/tests/cases/builtins/command.yaml
@@ -69,6 +69,7 @@ cases:
       command ls --help
 
   - name: "command with -p"
+    ignore_stderr: true # In case it fails on the oracle as well, ignore the specific error message.
     stdin: |
       unset PATH
 


### PR DESCRIPTION
Also includes targeted changes to get tests passing:

* Preserves original `PATH` when invoking `printf` as an external process.
* Ignores `stderr` on a test that may fail on some OSes.