### PR TITLE
fix(regex): enable multiline mode for extended test regexes

### DIFF
--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -199,7 +199,9 @@ async fn apply_binary_predicate(
     match op {
         ast::BinaryPredicate::StringMatchesRegex => {
             let s = expansion::basic_expand_word(shell, params, left).await?;
-            let regex = expansion::basic_expand_regex(shell, params, right).await?;
+            let regex = expansion::basic_expand_regex(shell, params, right)
+                .await?
+                .set_multiline(true);
 
             if shell.options.print_commands_and_arguments {
                 shell

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -316,12 +316,6 @@ impl Pattern {
             regex_str.push('^');
         }
 
-        if self.multiline {
-            // Set option for multiline matching + set option for allowing '.' pattern to match
-            // newline.
-            regex_str.push_str("(?ms)");
-        }
-
         let mut current_pattern = String::new();
         for piece in &self.pieces {
             match piece {
@@ -365,7 +359,7 @@ impl Pattern {
 
         tracing::debug!(target: trace_categories::PATTERN, "pattern: '{self:?}' => regex: '{regex_str}'");
 
-        let re = regex::compile_regex(regex_str, self.case_insensitive)?;
+        let re = regex::compile_regex(regex_str, self.case_insensitive, self.multiline)?;
         Ok(re)
     }
 

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -299,3 +299,7 @@ cases:
       [[ z =~ ^z{2,6}$ ]] && echo "1. Matches"
       [[ zzzz =~ ^z{2,6}$ ]] && echo "2. Matches"
       [[ zzzzzzzzz =~ ^z{2,6}$ ]] && echo "3. Matches"
+
+  - name: "Regex with newline"
+    stdin: |
+      [[ $'\n' =~ . ]] && echo "1. Matches"


### PR DESCRIPTION
Fixes extended test regex matching to always enable multiline mode. This ensures that `.` matches `$'\n'`.