### PR TITLE
fix: parse '#' as char only if inside a variable expansion

### DIFF
--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -1091,11 +1091,11 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
                 self.consume_char()?;
             }
             //
-            // N.B. We need to remember if we were recursively called, say in a command
-            // substitution; in that case we won't think a token was started but... we'd
-            // be wrong.
+            // N.B. We need to remember if we were recursively called in a variable
+            // expansion expression; in that case we won't think a token was started but...
+            // we'd be wrong.
             else if !state.token_is_operator
-                && (state.started_token() || terminating_char.is_some())
+                && (state.started_token() || matches!(terminating_char, Some('}')))
             {
                 self.consume_char()?;
                 state.append_char(c);
@@ -1115,7 +1115,6 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
                         }
                     };
                 }
-
                 // Re-start loop as if the comment never happened.
                 continue;
             //

--- a/brush-shell/tests/cases/command_substitution.yaml
+++ b/brush-shell/tests/cases/command_substitution.yaml
@@ -1,0 +1,73 @@
+name: "Command substitution"
+cases:
+  - name: "Ignore single quote in comment in command substitution"
+    stdin: |
+      var=$(
+        # I'm
+        echo "Batman"
+      )
+      echo $var
+
+  - name: "Ignore double quote in comment in command substitution"
+    stdin: |
+      var=$(
+        # This " is not being
+        echo "parsed"
+      )
+      echo $var
+
+  - name: "Ignore parantheses in comment in command substitution"
+    stdin: |
+      var=$(
+        # :(
+        echo "Sad"
+      )
+      echo $var
+
+  - name: "Ignore dollar in comment in command substitution"
+    stdin: |
+      var=$(
+        #               $
+        echo "Mr. Crabs ^"
+      )
+      echo $var
+
+  - name: "Positional parameter count not mistaken for comment"
+    stdin: |
+      echo $(echo $#)
+
+  - name: "Ignore single quote in comment in command substitution (backticks)"
+    stdin: |
+      var=`
+        # I'm
+        echo "Batman"
+      `
+      echo $var
+
+  - name: "Ignore double quote in comment in command substitution (backticks)"
+    stdin: |
+      var=`
+        # This " is not being
+        echo "parsed"
+      `
+      echo $var
+
+  - name: "Ignore parantheses in comment in command substitution (backticks)"
+    stdin: |
+      var=`
+        # :(
+        echo "Sad"
+      `
+      echo $var
+
+  - name: "Ignore dollar in comment in command substitution (backticks)"
+    stdin: |
+      var=`
+        #               $
+        echo "Mr. Crabs ^"
+      `
+      echo $var
+
+  - name: "Positional parameter count not mistaken for comment (backticks)"
+    stdin: |
+      echo `echo $#`

--- a/brush-shell/tests/cases/list.yaml
+++ b/brush-shell/tests/cases/list.yaml
@@ -1,0 +1,30 @@
+name: "List"
+cases:
+  - name: "Ignore single quote in comment in list"
+    stdin: |
+      (
+        # I'm
+        echo "Batman"
+      )
+
+  - name: "Ignore double quote in comment in list"
+    stdin: |
+      (
+        # This " is not being
+        echo "parsed"
+      )
+
+  - name: "Ignore parantheses in comment in list"
+    stdin: |
+      (
+        # :(
+        echo "Sad"
+      )
+
+  - name: "Ignore dollar in comment in list"
+    stdin: |
+      (
+        #               $
+        echo "Mr. Crabs ^"
+      )
+


### PR DESCRIPTION
Only in arithmetic expressions '#' is a valid token, in other contexts it is treated as a comment, and all following characters will be ignored by the tokenizer.

Closes: #408