### PR TITLE
fix: handle complete builtin run without options

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -y && \
         build-essential \
         curl \
         git \
+        iputils-ping \
         language-pack-en \
         neovim \
         sed \

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -265,7 +265,8 @@ impl CompleteCommand {
             None
         };
 
-        if self.print {
+        // Treat 'complete' with no options the same as 'complete -p'.
+        if self.print || (!self.remove && target_spec.is_none()) {
             if let Some(target_spec) = target_spec {
                 if let Some(existing_spec) = target_spec {
                     let existing_spec = existing_spec.clone();

--- a/brush-shell/tests/cases/builtins/complete.yaml
+++ b/brush-shell/tests/cases/builtins/complete.yaml
@@ -1,5 +1,10 @@
 name: "Builtins: complete"
 cases:
+  - name: "complete with no options"
+    stdin: |
+      complete -W foo mycmd
+      complete
+
   - name: "Roundtrip: complete -W"
     stdin: |
       complete -W foo mycmd


### PR DESCRIPTION
Fix for `complete` built-in being run with no options, and adds a basic compat test for that usage.

Resolves #434 