### PR TITLE
feat(Shell): add `get_env_var` method for more generic variable returns

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1259,6 +1259,15 @@ impl Shell {
         self.env.get_str(name, self)
     }
 
+    /// Tries to retrieve a variable from the shell's environment.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the variable to retrieve.
+    pub fn get_env_var(&self, name: &str) -> Option<ShellVariable> {
+        self.env.get(name).map(|(_, var)| var.clone())
+    }
+
     /// Returns the current value of the IFS variable, or the default value if it is not set.
     pub(crate) fn get_ifs(&self) -> Cow<'_, str> {
         self.get_env_str("IFS").unwrap_or_else(|| " \t\n".into())

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1264,8 +1264,8 @@ impl Shell {
     /// # Arguments
     ///
     /// * `name` - The name of the variable to retrieve.
-    pub fn get_env_var(&self, name: &str) -> Option<ShellVariable> {
-        self.env.get(name).map(|(_, var)| var.clone())
+    pub fn get_env_var(&self, name: &str) -> Option<&ShellVariable> {
+        self.env.get(name).map(|(_, var)| var)
     }
 
     /// Returns the current value of the IFS variable, or the default value if it is not set.


### PR DESCRIPTION
### Considerations
* ~~I do use a `.clone()` here, which is probably not ideal, so I am open to suggestions on figuring out how to remove it.~~
* We should consider if we should deprecate `get_env_str` or keep it around as a convenience method.

Closes #436.