### PR TITLE
chore: remove `uzers` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "uzers",
  "whoami",
 ]
 
@@ -2578,16 +2577,6 @@ dependencies = [
  "getrandom 0.3.2",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "uzers"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -62,7 +62,6 @@ nix = { version = "0.29.0", features = [
     "term",
     "user",
 ] }
-uzers = "0.12.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.17.0"

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -428,10 +428,9 @@ impl Shell {
         // EUID
         #[cfg(unix)]
         {
-            let mut euid_var = ShellVariable::new(ShellValue::String(format!(
-                "{}",
-                uzers::get_effective_uid()
-            )));
+            use nix::unistd::Uid;
+            let mut euid_var =
+                ShellVariable::new(ShellValue::String(format!("{}", Uid::effective().as_raw())));
             euid_var.treat_as_integer().set_readonly();
             self.env.set_global("EUID", euid_var)?;
         }
@@ -661,8 +660,9 @@ impl Shell {
         // UID
         #[cfg(unix)]
         {
+            use nix::unistd::Uid;
             let mut uid_var =
-                ShellVariable::new(ShellValue::String(format!("{}", uzers::get_current_uid())));
+                ShellVariable::new(ShellValue::String(format!("{}", Uid::current().as_raw())));
             uid_var.treat_as_integer().set_readonly();
             self.env.set_global("UID", uid_var)?;
         }

--- a/brush-core/src/sys/unix/users.rs
+++ b/brush-core/src/sys/unix/users.rs
@@ -1,50 +1,54 @@
 use crate::error;
-use std::path::PathBuf;
+use std::{ffi::CString, path::PathBuf};
 
-use uzers::os::unix::UserExt;
+use nix::{
+    errno::Errno,
+    unistd::{getgrouplist, Gid, Group, Uid, User},
+};
 
 pub(crate) fn is_root() -> bool {
-    uzers::get_current_uid() == 0
+    Uid::current().is_root()
 }
 
 pub(crate) fn get_user_home_dir(username: &str) -> Option<PathBuf> {
-    if let Some(user_info) = uzers::get_user_by_name(username) {
-        return Some(user_info.home_dir().to_path_buf());
-    }
-
-    None
+    User::from_name(username)
+        .unwrap_or(None)
+        .map(|user| user.dir)
 }
 
 pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
-    if let Some(username) = uzers::get_current_username() {
-        if let Some(user_info) = uzers::get_user_by_name(&username) {
-            return Some(user_info.home_dir().to_path_buf());
-        }
-    }
-
-    None
+    User::from_uid(Uid::effective())
+        .unwrap_or(None)
+        .map(|user| user.dir)
 }
 
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn get_effective_uid() -> Result<u32, error::Error> {
-    Ok(uzers::get_effective_uid())
+    Ok(Uid::effective().as_raw())
 }
 
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn get_effective_gid() -> Result<u32, error::Error> {
-    Ok(uzers::get_effective_gid())
+    Ok(Gid::effective().as_raw())
 }
 
 pub(crate) fn get_current_username() -> Result<String, error::Error> {
-    let username = uzers::get_current_username().ok_or_else(|| error::Error::NoCurrentUser)?;
-    Ok(username.to_string_lossy().to_string())
+    User::from_uid(Uid::effective())
+        .map_err(error::Error::ErrnoError)?
+        .map(|user| user.name)
+        .ok_or(error::Error::NoCurrentUser)
 }
 
 pub(crate) fn get_user_group_ids() -> Result<Vec<u32>, error::Error> {
-    let username = uzers::get_current_username().ok_or_else(|| error::Error::NoCurrentUser)?;
-    let gid = uzers::get_current_gid();
-    let groups = uzers::get_user_groups(&username, gid).unwrap_or_default();
-    Ok(groups.into_iter().map(|g| g.gid()).collect())
+    // If this string somehow returned something with a null byte in it, the system shouldn't be
+    // relied on anymore, it'd be completely messed up.
+    #[allow(clippy::expect_used)]
+    let username = CString::new(get_current_username()?).expect("Unexpected early null byte");
+    let group_gid = get_effective_gid()?;
+    Ok(getgrouplist(&username, group_gid.into())?
+        .iter()
+        .map(|gid| gid.as_raw())
+        .collect())
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -56,7 +60,12 @@ pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
 
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_groups() -> Result<Vec<String>, error::Error> {
-    // TODO: uzers::all_groups() is available but unsafe
-    tracing::debug!("UNIMPLEMENTED: get_all_groups");
-    Ok(vec![])
+    let mut res = vec![];
+    for group in nix::unistd::getgroups()? {
+        res.push(match Group::from_gid(group)? {
+            Some(real_group) => real_group.name,
+            None => return Err(error::Error::ErrnoError(Errno::EINVAL)),
+        });
+    }
+    Ok(res)
 }


### PR DESCRIPTION
You can take this PR or not, it depends on how important `uzers` is for possible future development, but I noticed that most of the functions that `uzers` provide just wrap over `nix`, which we already have.

If you want the simplicity of the `uzers` API though, I'll just close this PR :)