### PR TITLE
fix(trap): handle '-' unregistration syntax

### DIFF
--- a/brush-core/src/builtins/trap.rs
+++ b/brush-core/src/builtins/trap.rs
@@ -36,7 +36,15 @@ impl builtins::Command for TrapCommand {
             }
             Ok(builtins::ExitCode::Success)
         } else if self.args.len() == 1 {
+            // When only a single argument is given, it is assumed to be a signal name
+            // and an indication to remove the handlers for that signal.
             let signal = self.args[0].as_str();
+            Self::remove_all_handlers(&mut context, signal.parse()?);
+            Ok(builtins::ExitCode::Success)
+        } else if self.args[0] == "-" {
+            // Alternatively, "-" as the first argument indicates that the next
+            // argument is a signal name and we need to remove the handlers for that signal.
+            let signal = self.args[1].as_str();
             Self::remove_all_handlers(&mut context, signal.parse()?);
             Ok(builtins::ExitCode::Success)
         } else {

--- a/brush-shell/tests/cases/builtins/trap.yaml
+++ b/brush-shell/tests/cases/builtins/trap.yaml
@@ -12,6 +12,18 @@ cases:
       trap "echo 4" 2
       trap -p INT
 
+  - name: "trap unregistering"
+    stdin: |
+      echo "[Case 1]"
+      trap "echo 1" SIGINT
+      trap SIGINT
+      trap -p INT
+
+      echo "[Case 2]"
+      trap "echo 2" SIGINT
+      trap - SIGINT
+      trap -p INT
+
   - name: "trap EXIT"
     known_failure: true # TODO: needs triage and debugging
     stdin: |


### PR DESCRIPTION
When `trap` is invoked with `-` as the first argument, then the next argument is treated as a signal name, and the handlers for that signal are removed.