### PR TITLE
test(extended-tests): explicitly set modified date on test files

### DIFF
--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -127,18 +127,20 @@ cases:
 
   - name: "File is newer"
     stdin: |
-      touch bar
+      touch -d "2 hours ago" bar
       touch foo
-      [[ foo -nt bar ]] && echo "-nt correctly identified newer file"
 
+      [[ foo -nt bar ]] && echo "-nt correctly identified newer file"
+      [[ foo -nt foo ]] && echo "-nt incorrectly identified file as newer than itself"
       [[ foo -nt file_no_exists ]] && echo "-nt correctly identified when file2 does not exist"
 
   - name: "File is older"
     stdin: |
-      touch foo
+      touch -d "2 hours ago" foo
       touch bar
-      [[ foo -ot bar ]] && echo "-ot correctly identified older file"
 
+      [[ foo -ot bar ]] && echo "-ot correctly identified older file"
+      [[ foo -ot foo ]] && echo "-ot incorrectly identified file as older than itself"
       [[ file_no_exists -ot foo ]] && echo "-ot correctly identified when file1 does not exist"
 
   - name: "Unary string extended tests"


### PR DESCRIPTION
I've noticed some of the new extended test tests inconsistently failing on local runs. My suspicion is that two sequential invocations of `touch` *could* leave behind files with identical timestamps.

This change explicitly sets a "2 hours ago" modified date on the file that should appear older--to ensure ordering. The local test failures appeared to be resolved with the change. While I was modifying the tests, I added a test case to ensure correct behavior when `-nt` or `-ot` is provided path operands to files that are guaranteed to have identical timestamps (because it's the same file).