### PR TITLE
chore(traps): convert to public interface

### DIFF
--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -31,7 +31,7 @@ mod terminal;
 mod tests;
 mod timing;
 mod trace_categories;
-mod traps;
+pub mod traps;
 mod variables;
 
 pub use commands::ExecutionContext;

--- a/brush-core/src/traps.rs
+++ b/brush-core/src/traps.rs
@@ -1,3 +1,5 @@
+//! Implements various trapping capabilties.
+
 use std::str::FromStr;
 use std::{collections::HashMap, fmt::Display};
 
@@ -131,6 +133,7 @@ impl TryFrom<&str> for TrapSignal {
     }
 }
 
+/// Error type for [`TrapSignal`] conversions.
 #[derive(Debug, Clone, Copy)]
 pub struct DoesntHaveANumber;
 


### PR DESCRIPTION
I expect that there will be some more discussions as to what else needs/not to be public, but I am making it now to get the ball rolling.

---

Closes #454.