### PR TITLE
chore: enable (and fix) current checks across all workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,12 @@ readme = "README.md"
 repository = "https://github.com/reubeno/brush"
 rust-version = "1.75.0"
 
+[workspace.lints.rust]
+rust_2018_idioms = { level = "deny", priority = -1 }
+unsafe_op_in_unsafe_fn = "deny"
+unused_lifetimes = "deny"
+unused_macro_rules = "deny"
+
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
 pedantic = { level = "deny", priority = -1 }

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -584,10 +584,7 @@ impl builtins::Command for CompOptCommand {
             } else {
                 let mut spec = Spec::default();
                 Self::set_options_for_spec(&mut spec, &options);
-                std::mem::swap(
-                    &mut context.shell.completion_config.default,
-                    &mut Some(spec),
-                );
+                context.shell.completion_config.default = Some(spec);
             }
         } else if self.update_empty {
             if let Some(spec) = &mut context.shell.completion_config.empty_line {
@@ -595,10 +592,7 @@ impl builtins::Command for CompOptCommand {
             } else {
                 let mut spec = Spec::default();
                 Self::set_options_for_spec(&mut spec, &options);
-                std::mem::swap(
-                    &mut context.shell.completion_config.empty_line,
-                    &mut Some(spec),
-                );
+                context.shell.completion_config.empty_line = Some(spec);
             }
         } else if self.update_initial_word {
             if let Some(spec) = &mut context.shell.completion_config.initial_word {
@@ -606,10 +600,7 @@ impl builtins::Command for CompOptCommand {
             } else {
                 let mut spec = Spec::default();
                 Self::set_options_for_spec(&mut spec, &options);
-                std::mem::swap(
-                    &mut context.shell.completion_config.initial_word,
-                    &mut Some(spec),
-                );
+                context.shell.completion_config.initial_word = Some(spec);
             }
         } else {
             // If we got here, then we need to apply to any completion actively in-flight.

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -1077,7 +1077,7 @@ async fn get_file_completions(
         .collect()
 }
 
-fn get_command_completions(shell: &Shell, context: &Context) -> IndexSet<String> {
+fn get_command_completions(shell: &Shell, context: &Context<'_>) -> IndexSet<String> {
     let mut candidates = IndexSet::new();
     let glob_pattern = std::format!("{}*", context.token_to_complete);
 

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1500,7 +1500,7 @@ impl<'a> WordExpander<'a> {
         if let Some(pattern) = pattern {
             if !pattern.is_empty() {
                 let regex = pattern.to_regex(false, false)?;
-                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures| {
+                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_>| {
                     caps[0].to_uppercase()
                 });
                 Ok(result.into_owned())
@@ -1520,7 +1520,7 @@ impl<'a> WordExpander<'a> {
         if let Some(pattern) = pattern {
             if !pattern.is_empty() {
                 let regex = pattern.to_regex(false, false)?;
-                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures| {
+                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_>| {
                     caps[0].to_lowercase()
                 });
                 Ok(result.into_owned())

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -160,7 +160,7 @@ pub trait Execute {
 trait ExecuteInPipeline {
     async fn execute_in_pipeline(
         &self,
-        context: &mut PipelineExecutionContext,
+        context: &mut PipelineExecutionContext<'_>,
         params: ExecutionParameters,
     ) -> Result<CommandSpawnResult, error::Error>;
 }
@@ -487,7 +487,7 @@ async fn wait_for_pipeline_processes_and_update_status(
 impl ExecuteInPipeline for ast::Command {
     async fn execute_in_pipeline(
         &self,
-        pipeline_context: &mut PipelineExecutionContext,
+        pipeline_context: &mut PipelineExecutionContext<'_>,
         mut params: ExecutionParameters,
     ) -> Result<CommandSpawnResult, error::Error> {
         if pipeline_context.shell.options.do_not_execute_commands {
@@ -910,7 +910,7 @@ impl ExecuteInPipeline for ast::SimpleCommand {
     #[allow(clippy::too_many_lines)] // TODO: refactor this function
     async fn execute_in_pipeline(
         &self,
-        context: &mut PipelineExecutionContext,
+        context: &mut PipelineExecutionContext<'_>,
         mut params: ExecutionParameters,
     ) -> Result<CommandSpawnResult, error::Error> {
         let default_prefix = ast::CommandPrefix::default();

--- a/brush-core/src/openfiles.rs
+++ b/brush-core/src/openfiles.rs
@@ -160,19 +160,16 @@ impl std::io::Read for OpenFile {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
             OpenFile::Stdin => std::io::stdin().read(buf),
-            OpenFile::Stdout => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                error::Error::OpenFileNotReadable("stdout"),
-            )),
-            OpenFile::Stderr => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                error::Error::OpenFileNotReadable("stderr"),
-            )),
+            OpenFile::Stdout => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
+                "stdout",
+            ))),
+            OpenFile::Stderr => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
+                "stderr",
+            ))),
             OpenFile::Null => Ok(0),
             OpenFile::File(f) => f.read(buf),
             OpenFile::PipeReader(reader) => reader.read(buf),
-            OpenFile::PipeWriter(_) => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            OpenFile::PipeWriter(_) => Err(std::io::Error::other(
                 error::Error::OpenFileNotReadable("pipe writer"),
             )),
         }
@@ -182,16 +179,14 @@ impl std::io::Read for OpenFile {
 impl std::io::Write for OpenFile {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
-            OpenFile::Stdin => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                error::Error::OpenFileNotWritable("stdin"),
-            )),
+            OpenFile::Stdin => Err(std::io::Error::other(error::Error::OpenFileNotWritable(
+                "stdin",
+            ))),
             OpenFile::Stdout => std::io::stdout().write(buf),
             OpenFile::Stderr => std::io::stderr().write(buf),
             OpenFile::Null => Ok(buf.len()),
             OpenFile::File(f) => f.write(buf),
-            OpenFile::PipeReader(_) => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            OpenFile::PipeReader(_) => Err(std::io::Error::other(
                 error::Error::OpenFileNotWritable("pipe reader"),
             )),
             OpenFile::PipeWriter(writer) => writer.write(buf),

--- a/brush-core/src/regex.rs
+++ b/brush-core/src/regex.rs
@@ -14,7 +14,7 @@ pub(crate) enum RegexPiece {
 }
 
 impl RegexPiece {
-    fn to_regex_str(&self) -> Cow<str> {
+    fn to_regex_str(&self) -> Cow<'_, str> {
         match self {
             RegexPiece::Pattern(s) => Cow::Borrowed(s.as_str()),
             RegexPiece::Literal(s) => escape_literal_regex_piece(s.as_str()),
@@ -117,7 +117,7 @@ pub(crate) fn compile_regex(
     }
 }
 
-fn add_missing_escape_chars_to_regex(s: &str) -> Cow<str> {
+fn add_missing_escape_chars_to_regex(s: &str) -> Cow<'_, str> {
     // We may see a character class with an unescaped '[' (open bracket) character. We need
     // to escape that character.
     let mut in_escape = false;
@@ -157,7 +157,7 @@ fn add_missing_escape_chars_to_regex(s: &str) -> Cow<str> {
     updated.into()
 }
 
-fn escape_literal_regex_piece(s: &str) -> Cow<str> {
+fn escape_literal_regex_piece(s: &str) -> Cow<'_, str> {
     let mut result = String::new();
 
     for c in s.chars() {

--- a/brush-interactive/src/reedline/prompt.rs
+++ b/brush-interactive/src/reedline/prompt.rs
@@ -1,7 +1,7 @@
 use crate::interactive_shell::InteractivePrompt;
 
 impl reedline::Prompt for InteractivePrompt {
-    fn render_prompt_left(&self) -> std::borrow::Cow<str> {
+    fn render_prompt_left(&self) -> std::borrow::Cow<'_, str> {
         // [Workaround: see https://github.com/nushell/reedline/issues/707]
         // If the prompt starts with a newline character, then there's a chance
         // that it won't be rendered correctly. For this specific case, insert
@@ -13,7 +13,7 @@ impl reedline::Prompt for InteractivePrompt {
         }
     }
 
-    fn render_prompt_right(&self) -> std::borrow::Cow<str> {
+    fn render_prompt_right(&self) -> std::borrow::Cow<'_, str> {
         self.alt_side_prompt.as_str().into()
     }
 
@@ -21,18 +21,18 @@ impl reedline::Prompt for InteractivePrompt {
     fn render_prompt_indicator(
         &self,
         _prompt_mode: reedline::PromptEditMode,
-    ) -> std::borrow::Cow<str> {
+    ) -> std::borrow::Cow<'_, str> {
         "".into()
     }
 
-    fn render_prompt_multiline_indicator(&self) -> std::borrow::Cow<str> {
+    fn render_prompt_multiline_indicator(&self) -> std::borrow::Cow<'_, str> {
         self.continuation_prompt.as_str().into()
     }
 
     fn render_prompt_history_search_indicator(
         &self,
         history_search: reedline::PromptHistorySearch,
-    ) -> std::borrow::Cow<str> {
+    ) -> std::borrow::Cow<'_, str> {
         match history_search.status {
             reedline::PromptHistorySearchStatus::Passing => {
                 if history_search.term.is_empty() {

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 bench = false
 

--- a/brush-parser/benches/parser.rs
+++ b/brush-parser/benches/parser.rs
@@ -42,15 +42,16 @@ done
     }
 
     pub(crate) fn criterion_benchmark(c: &mut Criterion) {
+        const POSSIBLE_BASH_COMPLETION_SCRIPT_PATH: &str =
+            "/usr/share/bash-completion/bash_completion";
+
         c.bench_function("tokenize_sample_script", |b| {
-            b.iter(|| uncached_tokenize(SAMPLE_SCRIPT))
+            b.iter(|| uncached_tokenize(SAMPLE_SCRIPT));
         });
 
         let tokens = uncached_tokenize(SAMPLE_SCRIPT);
         c.bench_function("parse_sample_script", |b| b.iter(|| parse(&tokens)));
 
-        const POSSIBLE_BASH_COMPLETION_SCRIPT_PATH: &str =
-            "/usr/share/bash-completion/bash_completion";
         let well_known_complicated_script =
             std::path::PathBuf::from(POSSIBLE_BASH_COMPLETION_SCRIPT_PATH);
 

--- a/brush-parser/src/arithmetic.rs
+++ b/brush-parser/src/arithmetic.rs
@@ -108,6 +108,9 @@ peg::parser! {
                     return Err("invalid base");
                 }
 
+                // Okay to ignore these warnings; we've already checked that the radix is valid.
+                #[allow(clippy::cast_possible_truncation)]
+                #[allow(clippy::cast_sign_loss)]
                 i64::from_str_radix(s, radix as u32).or(Err("i64"))
             } /
             // Hex literal

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -19,7 +19,7 @@ pub struct Program {
 impl Display for Program {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for complete_command in &self.complete_commands {
-            write!(f, "{}", complete_command)?;
+            write!(f, "{complete_command}")?;
         }
         Ok(())
     }
@@ -66,7 +66,7 @@ impl Display for AndOrList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.first)?;
         for item in &self.additional {
-            write!(f, "{}", item)?;
+            write!(f, "{item}")?;
         }
 
         Ok(())
@@ -90,8 +90,8 @@ pub enum AndOr {
 impl Display for AndOr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AndOr::And(pipeline) => write!(f, " && {}", pipeline),
-            AndOr::Or(pipeline) => write!(f, " || {}", pipeline),
+            AndOr::And(pipeline) => write!(f, " && {pipeline}"),
+            AndOr::Or(pipeline) => write!(f, " || {pipeline}"),
         }
     }
 }
@@ -132,7 +132,7 @@ impl Display for Pipeline {
             if i > 0 {
                 write!(f, " |")?;
             }
-            write!(f, "{}", command)?;
+            write!(f, "{command}")?;
         }
 
         Ok(())
@@ -158,17 +158,17 @@ pub enum Command {
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Command::Simple(simple_command) => write!(f, "{}", simple_command),
+            Command::Simple(simple_command) => write!(f, "{simple_command}"),
             Command::Compound(compound_command, redirect_list) => {
-                write!(f, "{}", compound_command)?;
+                write!(f, "{compound_command}")?;
                 if let Some(redirect_list) = redirect_list {
-                    write!(f, "{}", redirect_list)?;
+                    write!(f, "{redirect_list}")?;
                 }
                 Ok(())
             }
-            Command::Function(function_definition) => write!(f, "{}", function_definition),
+            Command::Function(function_definition) => write!(f, "{function_definition}"),
             Command::ExtendedTest(extended_test_expr) => {
-                write!(f, "[[ {} ]]", extended_test_expr)
+                write!(f, "[[ {extended_test_expr} ]]")
             }
         }
     }
@@ -203,24 +203,24 @@ pub enum CompoundCommand {
 impl Display for CompoundCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CompoundCommand::Arithmetic(arithmetic_command) => write!(f, "{}", arithmetic_command),
+            CompoundCommand::Arithmetic(arithmetic_command) => write!(f, "{arithmetic_command}"),
             CompoundCommand::ArithmeticForClause(arithmetic_for_clause_command) => {
-                write!(f, "{}", arithmetic_for_clause_command)
+                write!(f, "{arithmetic_for_clause_command}")
             }
             CompoundCommand::BraceGroup(brace_group_command) => {
-                write!(f, "{}", brace_group_command)
+                write!(f, "{brace_group_command}")
             }
-            CompoundCommand::Subshell(subshell_command) => write!(f, "{}", subshell_command),
-            CompoundCommand::ForClause(for_clause_command) => write!(f, "{}", for_clause_command),
+            CompoundCommand::Subshell(subshell_command) => write!(f, "{subshell_command}"),
+            CompoundCommand::ForClause(for_clause_command) => write!(f, "{for_clause_command}"),
             CompoundCommand::CaseClause(case_clause_command) => {
-                write!(f, "{}", case_clause_command)
+                write!(f, "{case_clause_command}")
             }
-            CompoundCommand::IfClause(if_clause_command) => write!(f, "{}", if_clause_command),
+            CompoundCommand::IfClause(if_clause_command) => write!(f, "{if_clause_command}"),
             CompoundCommand::WhileClause(while_or_until_clause_command) => {
-                write!(f, "while {}", while_or_until_clause_command)
+                write!(f, "while {while_or_until_clause_command}")
             }
             CompoundCommand::UntilClause(while_or_until_clause_command) => {
-                write!(f, "until {}", while_or_until_clause_command)
+                write!(f, "until {while_or_until_clause_command}")
             }
         }
     }
@@ -278,7 +278,7 @@ impl Display for ForClauseCommand {
                     write!(f, " ")?;
                 }
 
-                write!(f, "{}", value)?;
+                write!(f, "{value}")?;
             }
         }
 
@@ -308,19 +308,19 @@ impl Display for ArithmeticForClauseCommand {
         write!(f, "for ((")?;
 
         if let Some(initializer) = &self.initializer {
-            write!(f, "{}", initializer)?;
+            write!(f, "{initializer}")?;
         }
 
         write!(f, "; ")?;
 
         if let Some(condition) = &self.condition {
-            write!(f, "{}", condition)?;
+            write!(f, "{condition}")?;
         }
 
         write!(f, "; ")?;
 
         if let Some(updater) = &self.updater {
-            write!(f, "{}", updater)?;
+            write!(f, "{updater}")?;
         }
 
         writeln!(f, "))")?;
@@ -345,7 +345,7 @@ impl Display for CaseClauseCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "case {} in", self.value)?;
         for case in &self.cases {
-            write!(indenter::indented(f).with_str(DISPLAY_INDENT), "{}", case)?;
+            write!(indenter::indented(f).with_str(DISPLAY_INDENT), "{case}")?;
         }
         writeln!(f)?;
         write!(f, "esac")
@@ -417,7 +417,7 @@ impl Display for IfClauseCommand {
         )?;
         if let Some(elses) = &self.elses {
             for else_clause in elses {
-                write!(f, "{}", else_clause)?;
+                write!(f, "{else_clause}")?;
             }
         }
 
@@ -443,7 +443,7 @@ impl Display for ElseClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f)?;
         if let Some(condition) = &self.condition {
-            writeln!(f, "elif {}; then", condition)?;
+            writeln!(f, "elif {condition}; then")?;
         } else {
             writeln!(f, "else")?;
         }
@@ -476,12 +476,12 @@ impl Display for CaseItem {
             if i > 0 {
                 write!(f, "|")?;
             }
-            write!(f, "{}", pattern)?;
+            write!(f, "{pattern}")?;
         }
         writeln!(f, ")")?;
 
         if let Some(cmd) = &self.cmd {
-            write!(indenter::indented(f).with_str(DISPLAY_INDENT), "{}", cmd)?;
+            write!(indenter::indented(f).with_str(DISPLAY_INDENT), "{cmd}")?;
         }
         writeln!(f)?;
         write!(f, "{}", self.post_action)
@@ -556,7 +556,7 @@ impl Display for FunctionBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)?;
         if let Some(redirect_list) = &self.1 {
-            write!(f, "{}", redirect_list)?;
+            write!(f, "{redirect_list}")?;
         }
 
         Ok(())
@@ -617,7 +617,7 @@ impl Display for SimpleCommand {
                 write!(f, " ")?;
             }
 
-            write!(f, "{}", prefix)?;
+            write!(f, "{prefix}")?;
             wrote_something = true;
         }
 
@@ -626,7 +626,7 @@ impl Display for SimpleCommand {
                 write!(f, " ")?;
             }
 
-            write!(f, "{}", word_or_name)?;
+            write!(f, "{word_or_name}")?;
             wrote_something = true;
         }
 
@@ -635,7 +635,7 @@ impl Display for SimpleCommand {
                 write!(f, " ")?;
             }
 
-            write!(f, "{}", suffix)?;
+            write!(f, "{suffix}")?;
         }
 
         Ok(())
@@ -655,7 +655,7 @@ impl Display for CommandPrefix {
                 write!(f, " ")?;
             }
 
-            write!(f, "{}", item)?;
+            write!(f, "{item}")?;
         }
         Ok(())
     }
@@ -674,7 +674,7 @@ impl Display for CommandSuffix {
                 write!(f, " ")?;
             }
 
-            write!(f, "{}", item)?;
+            write!(f, "{item}")?;
         }
         Ok(())
     }
@@ -718,11 +718,11 @@ pub enum CommandPrefixOrSuffixItem {
 impl Display for CommandPrefixOrSuffixItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CommandPrefixOrSuffixItem::IoRedirect(io_redirect) => write!(f, "{}", io_redirect),
-            CommandPrefixOrSuffixItem::Word(word) => write!(f, "{}", word),
-            CommandPrefixOrSuffixItem::AssignmentWord(_assignment, word) => write!(f, "{}", word),
+            CommandPrefixOrSuffixItem::IoRedirect(io_redirect) => write!(f, "{io_redirect}"),
+            CommandPrefixOrSuffixItem::Word(word) => write!(f, "{word}"),
+            CommandPrefixOrSuffixItem::AssignmentWord(_assignment, word) => write!(f, "{word}"),
             CommandPrefixOrSuffixItem::ProcessSubstitution(kind, subshell_command) => {
-                write!(f, "{}({})", kind, subshell_command)
+                write!(f, "{kind}({subshell_command})")
             }
         }
     }
@@ -765,9 +765,9 @@ pub enum AssignmentName {
 impl Display for AssignmentName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssignmentName::VariableName(name) => write!(f, "{}", name),
+            AssignmentName::VariableName(name) => write!(f, "{name}"),
             AssignmentName::ArrayElementName(name, index) => {
-                write!(f, "{}[{}]", name, index)
+                write!(f, "{name}[{index}]")
             }
         }
     }
@@ -787,7 +787,7 @@ pub enum AssignmentValue {
 impl Display for AssignmentValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssignmentValue::Scalar(word) => write!(f, "{}", word),
+            AssignmentValue::Scalar(word) => write!(f, "{word}"),
             AssignmentValue::Array(words) => {
                 write!(f, "(")?;
                 for (i, value) in words.iter().enumerate() {
@@ -795,8 +795,8 @@ impl Display for AssignmentValue {
                         write!(f, " ")?;
                     }
                     match value {
-                        (Some(key), value) => write!(f, "[{}]={}", key, value)?,
-                        (None, value) => write!(f, "{}", value)?,
+                        (Some(key), value) => write!(f, "[{key}]={value}")?,
+                        (None, value) => write!(f, "{value}")?,
                     }
                 }
                 write!(f, ")")
@@ -814,7 +814,7 @@ pub struct RedirectList(pub Vec<IoRedirect>);
 impl Display for RedirectList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for item in &self.0 {
-            write!(f, "{}", item)?;
+            write!(f, "{item}")?;
         }
         Ok(())
     }
@@ -840,17 +840,17 @@ impl Display for IoRedirect {
         match self {
             IoRedirect::File(fd_num, kind, target) => {
                 if let Some(fd_num) = fd_num {
-                    write!(f, "{}", fd_num)?;
+                    write!(f, "{fd_num}")?;
                 }
 
-                write!(f, "{} {}", kind, target)?;
+                write!(f, "{kind} {target}")?;
             }
             IoRedirect::OutputAndError(target, append) => {
                 write!(f, "&>")?;
                 if *append {
                     write!(f, ">")?;
                 }
-                write!(f, " {}", target)?;
+                write!(f, " {target}")?;
             }
             IoRedirect::HereDocument(
                 fd_num,
@@ -862,7 +862,7 @@ impl Display for IoRedirect {
                 },
             ) => {
                 if let Some(fd_num) = fd_num {
-                    write!(f, "{}", fd_num)?;
+                    write!(f, "{fd_num}")?;
                 }
 
                 write!(f, "<<")?;
@@ -870,17 +870,17 @@ impl Display for IoRedirect {
                     write!(f, "-")?;
                 }
 
-                writeln!(f, "{}", here_end)?;
+                writeln!(f, "{here_end}")?;
 
-                write!(f, "{}", doc)?;
-                writeln!(f, "{}", here_end)?;
+                write!(f, "{doc}")?;
+                writeln!(f, "{here_end}")?;
             }
             IoRedirect::HereString(fd_num, s) => {
                 if let Some(fd_num) = fd_num {
-                    write!(f, "{}", fd_num)?;
+                    write!(f, "{fd_num}")?;
                 }
 
-                write!(f, "<<< {}", s)?;
+                write!(f, "<<< {s}")?;
             }
         }
 
@@ -940,8 +940,8 @@ pub enum IoFileRedirectTarget {
 impl Display for IoFileRedirectTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IoFileRedirectTarget::Filename(word) => write!(f, "{}", word),
-            IoFileRedirectTarget::Fd(fd) => write!(f, "{}", fd),
+            IoFileRedirectTarget::Filename(word) => write!(f, "{word}"),
+            IoFileRedirectTarget::Fd(fd) => write!(f, "{fd}"),
             IoFileRedirectTarget::ProcessSubstitution(kind, subshell_command) => {
                 write!(f, "{kind}{subshell_command}")
             }
@@ -992,7 +992,7 @@ impl Display for TestExpr {
             TestExpr::Literal(s) => write!(f, "{s}"),
             TestExpr::And(left, right) => write!(f, "{left} -a {right}"),
             TestExpr::Or(left, right) => write!(f, "{left} -o {right}"),
-            TestExpr::Not(expr) => write!(f, "! {}", expr),
+            TestExpr::Not(expr) => write!(f, "! {expr}"),
             TestExpr::Parenthesized(expr) => write!(f, "( {expr} )"),
             TestExpr::UnaryTest(pred, word) => write!(f, "{pred} {word}"),
             TestExpr::BinaryTest(left, op, right) => write!(f, "{left} {op} {right}"),
@@ -1023,22 +1023,22 @@ impl Display for ExtendedTestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ExtendedTestExpr::And(left, right) => {
-                write!(f, "{} && {}", left, right)
+                write!(f, "{left} && {right}")
             }
             ExtendedTestExpr::Or(left, right) => {
-                write!(f, "{} || {}", left, right)
+                write!(f, "{left} || {right}")
             }
             ExtendedTestExpr::Not(expr) => {
-                write!(f, "! {}", expr)
+                write!(f, "! {expr}")
             }
             ExtendedTestExpr::Parenthesized(expr) => {
-                write!(f, "( {} )", expr)
+                write!(f, "( {expr} )")
             }
             ExtendedTestExpr::UnaryTest(pred, word) => {
-                write!(f, "{} {}", pred, word)
+                write!(f, "{pred} {word}")
             }
             ExtendedTestExpr::BinaryTest(pred, left, right) => {
-                write!(f, "{} {} {}", left, pred, right)
+                write!(f, "{left} {pred} {right}")
             }
         }
     }
@@ -1502,7 +1502,7 @@ impl Display for ArithmeticTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ArithmeticTarget::Variable(name) => write!(f, "{name}"),
-            ArithmeticTarget::ArrayElement(name, index) => write!(f, "{}[{}]", name, index),
+            ArithmeticTarget::ArrayElement(name, index) => write!(f, "{name}[{index}]"),
         }
     }
 }

--- a/brush-parser/src/error.rs
+++ b/brush-parser/src/error.rs
@@ -59,7 +59,7 @@ pub enum TestCommandParseError {
 }
 
 pub(crate) fn convert_peg_parse_error(
-    err: peg::error::ParseError<usize>,
+    err: &peg::error::ParseError<usize>,
     tokens: &[Token],
 ) -> ParseError {
     let approx_token_index = err.location;

--- a/brush-parser/src/pattern.rs
+++ b/brush-parser/src/pattern.rs
@@ -104,7 +104,7 @@ peg::parser! {
                         s.push_str(&branches.join("|"));
                         s.push_str(").+?|)");
                     } else {
-                        s.push_str("(?:.+)")
+                        s.push_str("(?:.+)");
                     }
                 } else {
                     s.push('(');
@@ -161,6 +161,7 @@ fn escape_char_class_char_list(s: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic_in_result_fn)]
 mod tests {
     use super::*;
     use anyhow::Result;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,9 @@ rust-version.workspace = true
 [package.metadata]
 cargo-fuzz = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.98"
 assert_cmd = "2.0.17"

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -16,7 +16,9 @@ lazy_static::lazy_static! {
     };
 }
 
-fn eval_arithmetic(mut shell: brush_core::Shell, input: ast::ArithmeticExpr) -> Result<()> {
+fn eval_arithmetic(mut shell: brush_core::Shell, input: &ast::ArithmeticExpr) -> Result<()> {
+    const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
+
     //
     // Turn it back into a string so we can pass it in on the command-line.
     //
@@ -45,7 +47,6 @@ fn eval_arithmetic(mut shell: brush_core::Shell, input: ast::ArithmeticExpr) -> 
 
     let mut oracle_cmd = assert_cmd::Command::from_std(oracle_cmd);
 
-    const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
     oracle_cmd.timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_IN_SECONDS));
 
     let input = std::format!("echo \"$(( {input_str} ))\"\n");
@@ -86,5 +87,5 @@ fuzz_target!(|input: ast::ArithmeticExpr| {
     }
 
     let shell = SHELL_TEMPLATE.clone();
-    eval_arithmetic(shell, input).unwrap();
+    eval_arithmetic(shell, &input).unwrap();
 });

--- a/fuzz/fuzz_targets/fuzz_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_parse.rs
@@ -15,7 +15,10 @@ lazy_static::lazy_static! {
     };
 }
 
+#[allow(clippy::unused_async)]
 async fn parse_async(shell: brush_core::Shell, input: String) -> Result<()> {
+    const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
+
     //
     // Instantiate a brush shell with defaults, then try to parse the input.
     //
@@ -35,7 +38,6 @@ async fn parse_async(shell: brush_core::Shell, input: String) -> Result<()> {
 
     let mut oracle_cmd = assert_cmd::Command::from_std(oracle_cmd);
 
-    const DEFAULT_TIMEOUT_IN_SECONDS: u64 = 15;
     oracle_cmd.timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_IN_SECONDS));
 
     let mut input = input;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.98"
 brush-shell = { version = "^0.2.17", path = "../brush-shell" }


### PR DESCRIPTION
This is a stepping stone toward enabling more checks, and specifically checks around type exporting.