### PR TITLE
fix(builtin): fix issues with 'builtin' invoking declaration builtins

### DIFF
--- a/brush-shell/tests/cases/builtins/builtin.yaml
+++ b/brush-shell/tests/cases/builtins/builtin.yaml
@@ -18,8 +18,11 @@ cases:
       builtin false; echo "builtin false => $?"
       builtin true; echo "builtin true => $?"
 
+  - name: "builtin with non-decl builtin"
+    stdin: |
+      builtin echo variable=value
+
   - name: "builtin with decl builtin"
-    known_failure: true # Needs investigation
     stdin: |
       builtin declare variable=value
       declare -p variable


### PR DESCRIPTION
Testing `zoxide` uncovered that the `builtin` builtin wasn't correctly wrapping inner builtins that take declarations (e.g., `declare`). This adds some tests to expose that--and a few other tests--and fixes them by adding a new helper that wraps executing `builtin`. Along the way, some of the command execution code benefited from some minimal simplification.

The logic that specially handles declaration arguments is getting increasingly... special. The next time we find ourselves updating it, we should take a hard look at whether there's a cleaner approach.