### PR TITLE
fix(declare): turn down volume on non-existent functions

### DIFF
--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -199,7 +199,7 @@ impl DeclareCommand {
                 }
                 Ok(true)
             } else {
-                writeln!(context.stderr(), "declare: {name}: not found")?;
+                // For some reason, bash does not print an error message in this case.
                 Ok(false)
             }
         } else if let Some(variable) = context.shell.env.get_using_policy(name, lookup) {

--- a/brush-shell/tests/cases/builtins/declare.yaml
+++ b/brush-shell/tests/cases/builtins/declare.yaml
@@ -198,6 +198,14 @@ cases:
       declare -f test
       declare -p -f test
 
+  - name: "Displaying non-existent functions"
+    stdin: |
+      declare -f not_a_function
+      echo "Result (-f): $?"
+
+      declare -F not_a_function
+      echo "Result (-F): $?"
+
   - name: "Valid conversions"
     stdin: |
       declare -a arr1=(a b c)


### PR DESCRIPTION
In testing with `fzf`, we found that `brush` complains more noisily when `declare -F` (or `-f`) is asked to find a non-existent function. Apparently this is counted on by some scripts (without suppressing `stderr`) to check for function existence.