### PR TITLE
fix(expansion): allow negative subscripts with indexed arrays + slices

### DIFF
--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -192,6 +192,10 @@ pub enum Error {
     /// System time error.
     #[error("system time error: {0}")]
     TimeError(#[from] std::time::SystemTimeError),
+
+    /// Array index out of range.
+    #[error("array index out of range")]
+    ArrayIndexOutOfRange,
 }
 
 /// Convenience function for returning an error for unimplemented functionality.

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -937,34 +937,47 @@ impl<'a> WordExpander<'a> {
                     );
                 }
 
-                let expanded_offset = offset.eval(self.shell, self.params, false).await?;
-                let expanded_offset = if expanded_offset < 0 {
-                    0
-                } else {
-                    usize::try_from(expanded_offset)?
-                };
+                #[allow(clippy::cast_possible_wrap)]
+                let expanded_parameter_len = expanded_parameter.polymorphic_len() as i64;
 
-                let expanded_parameter_len = expanded_parameter.polymorphic_len();
+                let mut expanded_offset = offset.eval(self.shell, self.params, false).await?;
+                if expanded_offset < 0 {
+                    // For arrays--and only arrays--we handle negative indexes as offsets from the end
+                    // of the array, with -1 referencing the last element of the array.
+                    if expanded_parameter.from_array {
+                        expanded_offset += expanded_parameter_len;
+
+                        // If the offset is still negative, then we need to yield an empty slice.
+                        // We force the offset to the end of the array.
+                        if expanded_offset < 0 {
+                            expanded_offset = expanded_parameter_len;
+                        }
+                    } else {
+                        // For other values, we just treat negative indexes as 0.
+                        expanded_offset = 0;
+                    }
+                }
+
+                // Make sure the offset is within the bounds of the array.
                 let expanded_offset = min(expanded_offset, expanded_parameter_len);
 
                 let end_offset = if let Some(length) = length {
                     let mut expanded_length = length.eval(self.shell, self.params, false).await?;
                     if expanded_length < 0 {
-                        let param_length: i64 = i64::try_from(expanded_parameter_len)?;
-                        expanded_length += param_length;
+                        expanded_length += expanded_parameter_len;
                     }
 
-                    let expanded_length = std::cmp::min(
-                        usize::try_from(expanded_length)?,
-                        expanded_parameter_len - expanded_offset,
-                    );
+                    let expanded_length =
+                        min(expanded_length, expanded_parameter_len - expanded_offset);
 
                     expanded_offset + expanded_length
                 } else {
                     expanded_parameter_len
                 };
 
-                Ok(expanded_parameter.polymorphic_subslice(expanded_offset, end_offset))
+                #[allow(clippy::cast_sign_loss)]
+                Ok(expanded_parameter
+                    .polymorphic_subslice(expanded_offset as usize, end_offset as usize))
             }
             brush_parser::word::ParameterExpr::Transform {
                 parameter,
@@ -1335,7 +1348,7 @@ impl<'a> WordExpander<'a> {
 
                 // Index into the array.
                 if let Some((_, var)) = self.shell.env.get(name) {
-                    if let Some(value) = var.value().get_at(index_to_use.as_str(), self.shell)? {
+                    if let Ok(Some(value)) = var.value().get_at(index_to_use.as_str(), self.shell) {
                         Ok(Expansion::from(value.to_string()))
                     } else {
                         Ok(Expansion::undefined())

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -855,8 +855,22 @@ impl ShellValue {
                 Ok(values.get(index).map(|s| Cow::Borrowed(s.as_str())))
             }
             ShellValue::IndexedArray(values) => {
-                let key = index.parse::<u64>().unwrap_or(0);
-                Ok(values.get(&key).map(|s| Cow::Borrowed(s.as_str())))
+                let mut index_value = index.parse::<i64>().unwrap_or(0);
+
+                #[allow(clippy::cast_possible_wrap)]
+                if index_value < 0 {
+                    index_value += values.len() as i64;
+                    if index_value < 0 {
+                        return Err(error::Error::ArrayIndexOutOfRange);
+                    }
+                }
+
+                // Now that we've confirmed that the index is non-negative, we can safely convert it
+                // to a u64 without any fuss.
+                #[allow(clippy::cast_sign_loss)]
+                let index_value = index_value as u64;
+
+                Ok(values.get(&index_value).map(|s| Cow::Borrowed(s.as_str())))
             }
             ShellValue::Dynamic { getter, .. } => {
                 let dynamic_value = getter(shell);

--- a/brush-shell/tests/cases/arrays.yaml
+++ b/brush-shell/tests/cases/arrays.yaml
@@ -27,6 +27,19 @@ cases:
       echo "var[*]: ${var[*]}"
       declare -p var
 
+  - name: "Negative indexed array access"
+    stdin: |
+      var=(a b c)
+      echo "var[-1]: ${var[-1]}"
+      echo "var[-2]: ${var[-2]}"
+      echo "var[-3]: ${var[-3]}"
+
+  - name: "Too large negative indexed array access"
+    ignore_stderr: true
+    stdin: |
+      var=(a b c)
+      echo "var[-4]: ${var[-4]}"
+
   - name: "Define array with expansion"
     stdin: |
       body='a b'

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -739,6 +739,16 @@ cases:
       echo "\${myarray[@]:2:2}: ${myarray[@]:2:2}"
       echo "\${myarray[@]:2}: ${myarray[@]:2}"
 
+  - name: "Substring operator on arrays with negative index"
+    stdin: |
+      set abcde fghij klmno pqrst uvwxy z
+      echo "\${@: -2:2}: ${@: -2:2}"
+      echo "\${@: -2}: ${@: -2}"
+
+      myarray=(abcde fghij klmno pqrst uvwxy z)
+      echo "\${myarray[@]: -2:2}: ${myarray[@]: -2:2}"
+      echo "\${myarray[@]: -2}: ${myarray[@]: -2}"
+
   - name: "Substring operator on single-element array"
     stdin: |
       myarray=("abcde fghij klmno pqrst uvwxy z")


### PR DESCRIPTION
Enables expansion of expressions like `${array[-1]}` and `${array:-1}`. Notably, the latter syntax doesn't yield similar behavior with strings.