### PR TITLE
chore: separate release and bench profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,11 @@ similar_names = "allow"
 struct_excessive_bools = "allow"
 
 [profile.release]
-strip = "debuginfo"
+strip = true
 lto = "fat"
 codegen-units = 1
 panic = "abort"
+
+[profile.bench]
+inherits = "release"
+strip = "debuginfo"


### PR DESCRIPTION
This should allow us to more aggressively strip information from release binaries, with the cost of losing more symbolic info.