### PR TITLE
feat(builtins): implement basic `bind -x` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -283,7 +283,10 @@ dependencies = [
  "os_pipe",
  "pprof",
  "procfs",
- "rand",
+ "rand 0.9.1",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
+ "terminfo",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -380,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -397,9 +400,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "bytes"
@@ -448,9 +451,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -751,7 +754,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -979,7 +982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -1102,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1183,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1203,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -1329,7 +1332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1513,10 +1516,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.7"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1579,6 +1588,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1730,6 +1749,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,7 +1861,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -1922,12 +1979,21 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1937,8 +2003,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1971,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -1991,8 +2063,8 @@ dependencies = [
  "nu-ansi-term 0.50.1",
  "serde",
  "strip-ansi-escapes",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror 2.0.12",
  "unicode-segmentation",
  "unicode-width",
@@ -2063,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -2201,6 +2273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,6 +2327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,10 +2346,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "symbolic-common"
-version = "12.14.1"
+name = "strum_macros"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66135c8273581acaab470356f808a1c74a707fe7ec24728af019d7247e089e71"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1150bdda9314f6cfeeea801c23f5593c6e6a6c72e64f67e48d723a12b8efdb"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2275,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.14.1"
+version = "12.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bcacd080282a72e795864660b148392af7babd75691d5ae9a3b77e29c98c77"
+checksum = "9f66537def48fbc704a92e4fdaab7833bc7cb2255faca8182592fb5fa617eb82"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -2315,7 +2412,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -2325,8 +2422,20 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -2455,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2467,24 +2576,31 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tracing"
@@ -3099,11 +3215,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -3119,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -31,6 +31,8 @@ itertools = "0.14.0"
 lazy_static = "1.5.0"
 normalize-path = "0.2.1"
 rand = "0.9.1"
+strum = "0.27.1"
+strum_macros = "0.27.1"
 thiserror = "2.0.12"
 tracing = "0.1.41"
 
@@ -63,6 +65,7 @@ nix = { version = "0.30.1", features = [
     "term",
     "user",
 ] }
+terminfo = "0.9.0"
 uzers = "0.12.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -147,6 +147,10 @@ pub enum Error {
     #[error("{0}")]
     TestCommandParseError(#[from] brush_parser::TestCommandParseError),
 
+    /// Unable to parse a key binding specification.
+    #[error("{0}")]
+    BindingParseError(#[from] brush_parser::BindingParseError),
+
     /// A threading error occurred.
     #[error("threading error")]
     ThreadingError(#[from] tokio::task::JoinError),
@@ -200,6 +204,10 @@ pub enum Error {
     /// Array index out of range.
     #[error("array index out of range")]
     ArrayIndexOutOfRange,
+
+    /// Unhandled key code.
+    #[error("unhandled key code: {0:?}")]
+    UnhandledKeyCode(Vec<u8>),
 }
 
 /// Convenience function for returning an error for unimplemented functionality.

--- a/brush-core/src/interfaces.rs
+++ b/brush-core/src/interfaces.rs
@@ -1,0 +1,5 @@
+//! Exports traits for shell interfaces implemented by callers.
+
+mod keybindings;
+
+pub use keybindings::{InputFunction, Key, KeyAction, KeyBindings, KeySequence, KeyStroke};

--- a/brush-core/src/interfaces/keybindings.rs
+++ b/brush-core/src/interfaces/keybindings.rs
@@ -1,0 +1,337 @@
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+};
+
+/// Represents an action that can be taken in response to a key sequence.
+#[derive(Debug)]
+pub enum KeyAction {
+    /// Execute a shell command.
+    ShellCommand(String),
+    /// Execute an input "function".
+    DoInputFunction(InputFunction),
+}
+
+impl Display for KeyAction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            KeyAction::ShellCommand(command) => write!(f, "shell command: {command}"),
+            KeyAction::DoInputFunction(function) => function.fmt(f),
+        }
+    }
+}
+
+/// Defines all input functions.
+#[derive(Debug, strum_macros::EnumString, strum_macros::Display, strum_macros::EnumIter)]
+#[strum(serialize_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum InputFunction {
+    Abort,
+    AcceptLine,
+    AliasExpandLine,
+    ArrowKeyPrefix,
+    BackwardByte,
+    BackwardChar,
+    BackwardDeleteChar,
+    BackwardKillLine,
+    BackwardKillWord,
+    BackwardWord,
+    BeginningOfHistory,
+    BeginningOfLine,
+    BracketedPasteBegin,
+    CallLastKbdMacro,
+    CapitalizeWord,
+    CharacterSearch,
+    CharacterSearchBackward,
+    ClearDisplay,
+    ClearScreen,
+    Complete,
+    CompleteCommand,
+    CompleteFilename,
+    CompleteHostname,
+    CompleteIntoBraces,
+    CompleteUsername,
+    CompleteVariable,
+    CopyBackwardWord,
+    CopyForwardWord,
+    CopyRegionAsKill,
+    DabbrevExpand,
+    DeleteChar,
+    DeleteCharOrList,
+    DeleteHorizontalSpace,
+    DigitArgument,
+    DisplayShellVersion,
+    DoLowercaseVersion,
+    DowncaseWord,
+    DumpFunctions,
+    DumpMacros,
+    DumpVariables,
+    DynamicCompleteHistory,
+    EditAndExecuteCommand,
+    EmacsEditingMode,
+    EndKbdMacro,
+    EndOfHistory,
+    EndOfLine,
+    ExchangePointAndMark,
+    ForwardBackwardDeleteChar,
+    ForwardByte,
+    ForwardChar,
+    ForwardSearchHistory,
+    ForwardWord,
+    GlobCompleteWord,
+    GlobExpandWord,
+    GlobListExpansions,
+    HistoryAndAliasExpandLine,
+    HistoryExpandLine,
+    HistorySearchBackward,
+    HistorySearchForward,
+    HistorySubstringSearchBackward,
+    HistorySubstringSearchForward,
+    InsertComment,
+    InsertCompletions,
+    InsertLastArgument,
+    KillLine,
+    KillRegion,
+    KillWholeLine,
+    KillWord,
+    MagicSpace,
+    MenuComplete,
+    MenuCompleteBackward,
+    NextHistory,
+    NextScreenLine,
+    NonIncrementalForwardSearchHistory,
+    NonIncrementalForwardSearchHistoryAgain,
+    NonIncrementalReverseSearchHistory,
+    NonIncrementalReverseSearchHistoryAgain,
+    OldMenuComplete,
+    OperateAndGetNext,
+    OverwriteMode,
+    PossibleCommandCompletions,
+    PossibleCompletions,
+    PossibleFilenameCompletions,
+    PossibleHostnameCompletions,
+    PossibleUsernameCompletions,
+    PossibleVariableCompletions,
+    PreviousHistory,
+    PreviousScreenLine,
+    PrintLastKbdMacro,
+    QuotedInsert,
+    ReReadInitFile,
+    RedrawCurrentLine,
+    ReverseSearchHistory,
+    RevertLine,
+    SelfInsert,
+    SetMark,
+    ShellBackwardKillWord,
+    ShellBackwardWord,
+    ShellExpandLine,
+    ShellForwardWord,
+    ShellKillWord,
+    ShellTransposeWords,
+    SkipCsiSequence,
+    StartKbdMacro,
+    TabInsert,
+    TildeExpand,
+    TransposeChars,
+    TransposeWords,
+    TtyStatus,
+    Undo,
+    UniversalArgument,
+    UnixFilenameRubout,
+    UnixLineDiscard,
+    UnixWordRubout,
+    UpcaseWord,
+    ViAppendEol,
+    ViAppendMode,
+    ViArgDigit,
+    ViBWord,
+    ViBackToIndent,
+    ViBackwardBigword,
+    ViBackwardWord,
+    ViBword,
+    ViChangeCase,
+    ViChangeChar,
+    ViChangeTo,
+    ViCharSearch,
+    ViColumn,
+    ViComplete,
+    ViDelete,
+    ViDeleteTo,
+    ViEWord,
+    ViEditingMode,
+    ViEndBigword,
+    ViEndWord,
+    ViEofMaybe,
+    ViEword,
+    ViFWord,
+    ViFetchHistory,
+    ViFirstPrint,
+    ViForwardBigword,
+    ViForwardWord,
+    ViFword,
+    ViGotoMark,
+    ViInsertBeg,
+    ViInsertionMode,
+    ViMatch,
+    ViMovementMode,
+    ViNextWord,
+    ViOverstrike,
+    ViOverstrikeDelete,
+    ViPrevWord,
+    ViPut,
+    ViRedo,
+    ViReplace,
+    ViRubout,
+    ViSearch,
+    ViSearchAgain,
+    ViSetMark,
+    ViSubst,
+    ViTildeExpand,
+    ViUnixWordRubout,
+    ViYankArg,
+    ViYankPop,
+    ViYankTo,
+    Yank,
+    YankLastArg,
+    YankNthArg,
+    YankPop,
+}
+
+/// Represents a sequence of keys.
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub struct KeySequence {
+    /// The strokes in the sequence.
+    pub strokes: Vec<KeyStroke>,
+}
+
+impl Display for KeySequence {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for stroke in &self.strokes {
+            stroke.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<KeyStroke> for KeySequence {
+    /// Creates a new key sequence with a single stroke.
+    fn from(value: KeyStroke) -> Self {
+        Self {
+            strokes: vec![value],
+        }
+    }
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+/// Represents a single key press.
+pub struct KeyStroke {
+    /// Alt key was pressed.
+    pub alt: bool,
+    /// Control key was pressed.
+    pub control: bool,
+    /// Shift key was pressed.
+    pub shift: bool,
+    /// Primary key pressed.
+    pub key: Key,
+}
+
+impl Display for KeyStroke {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.alt {
+            write!(f, "\\e")?;
+        }
+        if self.control {
+            write!(f, "\\C-")?;
+        }
+        if self.shift {
+            // TODO: Figure out what to do here or if the key encodes the shift in it.
+        }
+        self.key.fmt(f)
+    }
+}
+
+impl From<Key> for KeyStroke {
+    /// Creates a new key stroke with a single key.
+    fn from(value: Key) -> Self {
+        Self {
+            alt: false,
+            control: false,
+            shift: false,
+            key: value,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// Represents a single key.
+pub enum Key {
+    /// A simple character key.
+    Character(char),
+    /// Backspace key.
+    Backspace,
+    /// Enter key.
+    Enter,
+    /// Left arrow key.
+    Left,
+    /// Right arrow key.
+    Right,
+    /// Up arrow key.
+    Up,
+    /// Down arrow key.
+    Down,
+    /// Home key.
+    Home,
+    /// End key.
+    End,
+    /// Page up key.
+    PageUp,
+    /// Page down key.
+    PageDown,
+    /// Tab key.
+    Tab,
+    /// Shift + Tab key.
+    BackTab,
+    /// Delete key.
+    Delete,
+    /// Insert key.
+    Insert,
+    /// F key.
+    F(u8),
+    /// Escape key.
+    Escape,
+}
+
+impl Display for Key {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Key::Character(c @ ('\\' | '\"' | '\'')) => write!(f, "\\{c}")?,
+            Key::Character(c) => write!(f, "{c}")?,
+            Key::Backspace => write!(f, "Backspace")?,
+            Key::Enter => write!(f, "Enter")?,
+            Key::Left => write!(f, "Left")?,
+            Key::Right => write!(f, "Right")?,
+            Key::Up => write!(f, "Up")?,
+            Key::Down => write!(f, "Down")?,
+            Key::Home => write!(f, "Home")?,
+            Key::End => write!(f, "End")?,
+            Key::PageUp => write!(f, "PageUp")?,
+            Key::PageDown => write!(f, "PageDown")?,
+            Key::Tab => write!(f, "Tab")?,
+            Key::BackTab => write!(f, "BackTab")?,
+            Key::Delete => write!(f, "Delete")?,
+            Key::Insert => write!(f, "Insert")?,
+            Key::F(n) => write!(f, "F{n}")?,
+            Key::Escape => write!(f, "Esc")?,
+        }
+
+        Ok(())
+    }
+}
+
+/// Encapsulates the shell's interaction with key bindings for input.
+pub trait KeyBindings: Send {
+    /// Retrieves current bindings.
+    fn get_current(&self) -> HashMap<KeySequence, KeyAction>;
+    /// Updates a binding.
+    fn bind(&mut self, seq: KeySequence, action: KeyAction) -> Result<(), std::io::Error>;
+}

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -14,6 +14,7 @@ mod escape;
 mod expansion;
 mod extendedtests;
 pub mod functions;
+pub mod interfaces;
 mod interp;
 mod jobs;
 mod keywords;

--- a/brush-core/src/sys.rs
+++ b/brush-core/src/sys.rs
@@ -25,6 +25,7 @@ pub(crate) mod tokio_process;
 
 pub(crate) mod fs;
 
+pub(crate) use platform::input;
 pub(crate) use platform::network;
 pub(crate) use platform::pipes;
 pub(crate) use platform::process;

--- a/brush-core/src/sys/stubs.rs
+++ b/brush-core/src/sys/stubs.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::unnecessary_wraps)]
 
 pub(crate) mod fs;
+pub(crate) mod input;
 pub(crate) mod network;
 pub(crate) mod pipes;
 pub(crate) mod process;

--- a/brush-core/src/sys/stubs/input.rs
+++ b/brush-core/src/sys/stubs/input.rs
@@ -1,0 +1,5 @@
+use crate::{error, interfaces};
+
+pub(crate) fn get_key_from_key_code(_key_code: &[u8]) -> Result<interfaces::Key, error::Error> {
+    error::unimp("get_key_from_key_code")
+}

--- a/brush-core/src/sys/unix.rs
+++ b/brush-core/src/sys/unix.rs
@@ -1,5 +1,6 @@
 pub(crate) use crate::sys::os_pipe as pipes;
 pub(crate) mod fs;
+pub(crate) mod input;
 pub(crate) mod network;
 pub(crate) use crate::sys::tokio_process as process;
 pub(crate) mod resource;

--- a/brush-core/src/sys/unix/input.rs
+++ b/brush-core/src/sys/unix/input.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+use terminfo::capability as cap;
+
+use crate::{error, interfaces};
+
+macro_rules! key {
+    ( $terminfo:expr , $our_key:expr, $terminfo_key:ty ) => {{
+        (
+            $our_key,
+            $terminfo
+                .get::<$terminfo_key>()
+                .map(|k| k.expand().to_vec()),
+        )
+    }};
+}
+
+fn build_terminfo_key_map() -> HashMap<Vec<u8>, interfaces::Key> {
+    let mut map: HashMap<Vec<u8>, interfaces::Key> = HashMap::new();
+
+    if let Ok(ti) = terminfo::Database::from_env() {
+        // Iterate over key capabilities and populate the map
+        let key_capabilities = [
+            key!(ti, interfaces::Key::F(1), cap::KeyF1<'_>),
+            key!(ti, interfaces::Key::F(2), cap::KeyF2<'_>),
+            key!(ti, interfaces::Key::F(3), cap::KeyF3<'_>),
+            key!(ti, interfaces::Key::F(4), cap::KeyF4<'_>),
+            key!(ti, interfaces::Key::F(5), cap::KeyF5<'_>),
+            key!(ti, interfaces::Key::F(6), cap::KeyF6<'_>),
+            key!(ti, interfaces::Key::F(7), cap::KeyF7<'_>),
+            key!(ti, interfaces::Key::F(8), cap::KeyF8<'_>),
+            key!(ti, interfaces::Key::F(9), cap::KeyF9<'_>),
+            key!(ti, interfaces::Key::F(10), cap::KeyF10<'_>),
+            key!(ti, interfaces::Key::F(11), cap::KeyF11<'_>),
+            key!(ti, interfaces::Key::F(12), cap::KeyF12<'_>),
+            key!(ti, interfaces::Key::Backspace, cap::KeyBackspace<'_>),
+            key!(ti, interfaces::Key::Enter, cap::KeyEnter<'_>),
+            key!(ti, interfaces::Key::Left, cap::KeyLeft<'_>),
+            key!(ti, interfaces::Key::Right, cap::KeyRight<'_>),
+            key!(ti, interfaces::Key::Up, cap::KeyUp<'_>),
+            key!(ti, interfaces::Key::Down, cap::KeyDown<'_>),
+            key!(ti, interfaces::Key::Home, cap::KeyHome<'_>),
+            key!(ti, interfaces::Key::End, cap::KeyEnd<'_>),
+            key!(ti, interfaces::Key::PageUp, cap::KeyPPage<'_>),
+            key!(ti, interfaces::Key::PageDown, cap::KeyNPage<'_>),
+            key!(ti, interfaces::Key::BackTab, cap::BackTab<'_>),
+            // It's not clear if these belong here, because they're not
+            // strictly "key" capabilities.
+            key!(ti, interfaces::Key::Up, cap::CursorUp<'_>),
+            key!(ti, interfaces::Key::Down, cap::CursorDown<'_>),
+            key!(ti, interfaces::Key::Left, cap::CursorLeft<'_>),
+            key!(ti, interfaces::Key::Right, cap::CursorRight<'_>),
+        ];
+
+        for (key, v) in key_capabilities {
+            if let Some(Ok(v)) = v {
+                map.insert(v.clone(), key.clone());
+            }
+        }
+    }
+
+    map
+}
+
+lazy_static::lazy_static! {
+    pub(crate) static ref TERMINFO_KEY_MAP: HashMap<Vec<u8>, interfaces::Key> = build_terminfo_key_map();
+}
+
+pub(crate) fn get_key_from_key_code(key_code: &[u8]) -> Result<interfaces::Key, error::Error> {
+    if let Some(key) = TERMINFO_KEY_MAP.get(key_code) {
+        Ok(key.clone())
+    } else if key_code.len() == 1 && !key_code[0].is_ascii_control() {
+        Ok(interfaces::Key::Character(key_code[0] as char))
+    } else {
+        Err(error::Error::UnhandledKeyCode(key_code.to_vec()))
+    }
+}

--- a/brush-core/src/sys/wasm.rs
+++ b/brush-core/src/sys/wasm.rs
@@ -1,4 +1,5 @@
 pub(crate) use crate::sys::stubs::fs;
+pub(crate) use crate::sys::stubs::input;
 pub(crate) use crate::sys::stubs::network;
 pub(crate) use crate::sys::stubs::pipes;
 pub(crate) use crate::sys::stubs::process;

--- a/brush-core/src/sys/windows.rs
+++ b/brush-core/src/sys/windows.rs
@@ -1,5 +1,6 @@
 pub(crate) use crate::sys::os_pipe as pipes;
 pub(crate) use crate::sys::stubs::fs;
+pub(crate) use crate::sys::stubs::input;
 pub(crate) mod network;
 pub(crate) use crate::sys::stubs::resource;
 

--- a/brush-core/src/trace_categories.rs
+++ b/brush-core/src/trace_categories.rs
@@ -1,8 +1,9 @@
 pub(crate) const COMMANDS: &str = "commands";
 pub(crate) const COMPLETION: &str = "completion";
 pub(crate) const EXPANSION: &str = "expansion";
+pub(crate) const FUNCTIONS: &str = "functions";
+pub(crate) const INPUT: &str = "input";
 pub(crate) const JOBS: &str = "jobs";
 pub(crate) const PARSE: &str = "parse";
 pub(crate) const PATTERN: &str = "pattern";
-pub(crate) const FUNCTIONS: &str = "functions";
 pub(crate) const UNIMPLEMENTED: &str = "unimplemented";

--- a/brush-interactive/src/reedline/edit_mode.rs
+++ b/brush-interactive/src/reedline/edit_mode.rs
@@ -1,0 +1,356 @@
+use brush_core::interfaces::{self, InputFunction, Key, KeyAction, KeySequence, KeyStroke};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+#[derive(thiserror::Error, Debug)]
+pub enum KeyError {
+    /// Unsupported key sequence
+    #[error("unsupported key sequence: {0}")]
+    UnsupportedKeySequence(KeySequence),
+
+    /// Unsupported key action
+    #[error("unsupported key action: {0}")]
+    UnsupportedKeyAction(KeyAction),
+}
+
+pub(crate) struct MutableEditMode {
+    inner: Arc<Mutex<UpdatableBindings>>,
+}
+
+impl MutableEditMode {
+    pub fn new(bindings: reedline::Keybindings) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(UpdatableBindings::new(bindings))),
+        }
+    }
+
+    pub fn bindings(&self) -> Arc<Mutex<UpdatableBindings>> {
+        self.inner.clone()
+    }
+}
+
+impl reedline::EditMode for MutableEditMode {
+    fn parse_event(&mut self, event: reedline::ReedlineRawEvent) -> reedline::ReedlineEvent {
+        let mut inner = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(self.inner.lock())
+        });
+
+        inner.parse_event(event)
+    }
+
+    fn edit_mode(&self) -> reedline::PromptEditMode {
+        let inner = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(self.inner.lock())
+        });
+
+        inner.edit_mode()
+    }
+}
+
+pub(crate) struct UpdatableBindings {
+    bindings: reedline::Keybindings,
+    edit_mode: Box<dyn reedline::EditMode>,
+}
+
+impl UpdatableBindings {
+    pub fn new(bindings: reedline::Keybindings) -> Self {
+        // Clone the bindings so we can keep a copy for later updates.
+        let edit_mode = Self::rebuild_edit_mode(&bindings);
+
+        Self {
+            bindings,
+            edit_mode,
+        }
+    }
+
+    pub fn update(&mut self, f: impl Fn(&mut reedline::Keybindings)) {
+        f(&mut self.bindings);
+        self.edit_mode = Self::rebuild_edit_mode(&self.bindings);
+    }
+
+    fn rebuild_edit_mode(bindings: &reedline::Keybindings) -> Box<dyn reedline::EditMode> {
+        Box::new(reedline::Emacs::new(bindings.clone()))
+    }
+}
+
+impl reedline::EditMode for UpdatableBindings {
+    fn parse_event(&mut self, event: reedline::ReedlineRawEvent) -> reedline::ReedlineEvent {
+        self.edit_mode.parse_event(event)
+    }
+
+    fn edit_mode(&self) -> reedline::PromptEditMode {
+        self.edit_mode.edit_mode()
+    }
+}
+
+impl interfaces::KeyBindings for UpdatableBindings {
+    fn get_current(&self) -> HashMap<interfaces::KeySequence, interfaces::KeyAction> {
+        let mut results = HashMap::new();
+
+        for (key_combo, event) in self.bindings.get_keybindings() {
+            let action = translate_reedline_event_to_action(event);
+            if let Some(action) = action {
+                if let Some(key) = translate_reedline_keycode(key_combo.key_code) {
+                    let mut stroke = KeyStroke::from(key);
+
+                    if key_combo.modifier.contains(reedline::KeyModifiers::CONTROL) {
+                        stroke.control = true;
+                    }
+                    if key_combo.modifier.contains(reedline::KeyModifiers::ALT) {
+                        stroke.alt = true;
+                    }
+                    if key_combo.modifier.contains(reedline::KeyModifiers::SHIFT) {
+                        stroke.shift = true;
+                    }
+                    if key_combo.modifier.contains(reedline::KeyModifiers::HYPER) {
+                        // TODO
+                    }
+                    if key_combo.modifier.contains(reedline::KeyModifiers::META) {
+                        // TODO
+                    }
+                    if key_combo.modifier.contains(reedline::KeyModifiers::SUPER) {
+                        // TODO
+                    }
+
+                    let seq = KeySequence::from(stroke);
+                    results.insert(seq, action);
+                }
+            }
+        }
+
+        results
+    }
+
+    fn bind(&mut self, seq: KeySequence, action: KeyAction) -> Result<(), std::io::Error> {
+        let Some((modifiers, key_code)) = translate_key_sequence_to_reedline(&seq) else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                KeyError::UnsupportedKeySequence(seq),
+            ));
+        };
+
+        let Some(event) = translate_action_to_reedline_event(&action) else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                KeyError::UnsupportedKeyAction(action),
+            ));
+        };
+
+        self.update(|bindings| {
+            bindings.add_binding(modifiers, key_code, event.clone());
+        });
+
+        Ok(())
+    }
+}
+
+fn translate_key_sequence_to_reedline(
+    seq: &KeySequence,
+) -> Option<(reedline::KeyModifiers, reedline::KeyCode)> {
+    if seq.strokes.len() != 1 {
+        // TODO: handle multiple strokes
+        return None;
+    }
+
+    let stroke = &seq.strokes[0];
+
+    let mut modifiers = reedline::KeyModifiers::empty();
+    modifiers.set(reedline::KeyModifiers::ALT, stroke.alt);
+    modifiers.set(reedline::KeyModifiers::CONTROL, stroke.control);
+    modifiers.set(reedline::KeyModifiers::SHIFT, stroke.shift);
+
+    let key_code = match stroke.key {
+        Key::Character(c) => reedline::KeyCode::Char(c),
+        Key::Backspace => reedline::KeyCode::Backspace,
+        Key::Enter => reedline::KeyCode::Enter,
+        Key::Left => reedline::KeyCode::Left,
+        Key::Right => reedline::KeyCode::Right,
+        Key::Up => reedline::KeyCode::Up,
+        Key::Down => reedline::KeyCode::Down,
+        Key::Home => reedline::KeyCode::Home,
+        Key::End => reedline::KeyCode::End,
+        Key::PageUp => reedline::KeyCode::PageUp,
+        Key::PageDown => reedline::KeyCode::PageDown,
+        Key::Tab => reedline::KeyCode::Tab,
+        Key::BackTab => reedline::KeyCode::BackTab,
+        Key::Delete => reedline::KeyCode::Delete,
+        Key::Insert => reedline::KeyCode::Insert,
+        Key::F(n) => reedline::KeyCode::F(n),
+        Key::Escape => reedline::KeyCode::Esc,
+    };
+
+    Some((modifiers, key_code))
+}
+
+fn translate_action_to_reedline_event(action: &KeyAction) -> Option<reedline::ReedlineEvent> {
+    match action {
+        KeyAction::ShellCommand(cmd) => {
+            Some(reedline::ReedlineEvent::ExecuteHostCommand(cmd.to_owned()))
+        }
+        KeyAction::DoInputFunction(_input_function) => None, // TODO: implement
+    }
+}
+
+fn translate_reedline_keycode(keycode: reedline::KeyCode) -> Option<Key> {
+    match keycode {
+        reedline::KeyCode::Backspace => Some(Key::Backspace),
+        reedline::KeyCode::Enter => Some(Key::Enter),
+        reedline::KeyCode::Left => Some(Key::Left),
+        reedline::KeyCode::Right => Some(Key::Right),
+        reedline::KeyCode::Up => Some(Key::Up),
+        reedline::KeyCode::Down => Some(Key::Down),
+        reedline::KeyCode::Home => Some(Key::Home),
+        reedline::KeyCode::End => Some(Key::End),
+        reedline::KeyCode::PageUp => Some(Key::PageUp),
+        reedline::KeyCode::PageDown => Some(Key::PageDown),
+        reedline::KeyCode::Tab => Some(Key::Tab),
+        reedline::KeyCode::BackTab => Some(Key::BackTab),
+        reedline::KeyCode::Delete => Some(Key::Delete),
+        reedline::KeyCode::Insert => Some(Key::Insert),
+        reedline::KeyCode::F(n) => Some(Key::F(n)),
+        reedline::KeyCode::Char(c) => Some(Key::Character(c)),
+        reedline::KeyCode::Null => None,
+        reedline::KeyCode::Esc => Some(Key::Escape),
+        reedline::KeyCode::CapsLock => None,
+        reedline::KeyCode::ScrollLock => None,
+        reedline::KeyCode::NumLock => None,
+        reedline::KeyCode::PrintScreen => None,
+        reedline::KeyCode::Pause => None,
+        reedline::KeyCode::Menu => None,
+        reedline::KeyCode::KeypadBegin => None,
+        reedline::KeyCode::Media(_media_key_code) => None,
+        reedline::KeyCode::Modifier(_modifier_key_code) => None,
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn translate_reedline_event_to_action(event: &reedline::ReedlineEvent) -> Option<KeyAction> {
+    match event {
+        reedline::ReedlineEvent::Edit(cmds) => {
+            match cmds.as_slice() {
+                [reedline::EditCommand::Backspace] => Some(KeyAction::DoInputFunction(
+                    InputFunction::BackwardDeleteChar,
+                )),
+                [reedline::EditCommand::BackspaceWord] => {
+                    // Not quite accurate, because it doesn't save the deleted text.
+                    Some(KeyAction::DoInputFunction(InputFunction::BackwardKillWord))
+                }
+                [reedline::EditCommand::CapitalizeChar] => None,
+                [reedline::EditCommand::ClearToLineEnd] => {
+                    // Not quite accurate, because it doesn't save the deleted text.
+                    Some(KeyAction::DoInputFunction(InputFunction::KillLine))
+                }
+                [reedline::EditCommand::CutFromStart] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::KillWholeLine))
+                }
+                [reedline::EditCommand::CutToLineEnd] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::KillLine))
+                }
+                [reedline::EditCommand::CutWordLeft] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::BackwardKillWord))
+                }
+                [reedline::EditCommand::CutWordRight] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::KillWord))
+                }
+                [reedline::EditCommand::Delete] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::DeleteChar))
+                }
+                [reedline::EditCommand::DeleteWord] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::KillWord))
+                }
+                [reedline::EditCommand::InsertNewline] => None,
+                [reedline::EditCommand::LowercaseWord] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::DowncaseWord))
+                }
+                [reedline::EditCommand::MoveLeft { select: false }] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::BackwardChar))
+                }
+                [reedline::EditCommand::MoveLeft { select: true }] => None,
+                [reedline::EditCommand::MoveRight { select: false }] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::ForwardChar))
+                }
+                [reedline::EditCommand::MoveRight { select: true }] => None,
+                [reedline::EditCommand::MoveToEnd { select: false }] => {
+                    // TODO: Not quite accurate, because it doesn't just go to end of line.
+                    Some(KeyAction::DoInputFunction(InputFunction::EndOfLine))
+                }
+                [reedline::EditCommand::MoveToEnd { select: true }] => None,
+                [reedline::EditCommand::MoveToLineEnd { select: false }] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::EndOfLine))
+                }
+                [reedline::EditCommand::MoveToLineEnd { select: true }] => None,
+                [reedline::EditCommand::MoveToLineStart { select: false }] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::BeginningOfLine))
+                }
+                [reedline::EditCommand::MoveToLineStart { select: true }] => None,
+                [reedline::EditCommand::MoveToStart { select: false }] => {
+                    // TODO: Not quite accurate, because it doesn't just go to beginning of line.
+                    Some(KeyAction::DoInputFunction(InputFunction::BeginningOfLine))
+                }
+                [reedline::EditCommand::MoveToStart { select: true }] => None,
+                [reedline::EditCommand::MoveWordLeft { select: false }] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::BackwardWord))
+                }
+                [reedline::EditCommand::MoveWordLeft { select: true }] => None,
+                [reedline::EditCommand::MoveWordRight { select: false }] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::ForwardWord))
+                }
+                [reedline::EditCommand::MoveWordRight { select: true }] => None,
+                [reedline::EditCommand::PasteCutBufferAfter] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::Yank))
+                }
+                [reedline::EditCommand::PasteCutBufferBefore] => None,
+                [reedline::EditCommand::Redo] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::ViRedo))
+                }
+                [reedline::EditCommand::SelectAll] => None,
+                [reedline::EditCommand::SwapGraphemes] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::TransposeChars))
+                }
+                [reedline::EditCommand::UppercaseWord] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::UpcaseWord))
+                }
+                [reedline::EditCommand::Undo] => {
+                    Some(KeyAction::DoInputFunction(InputFunction::Undo))
+                }
+                _ => {
+                    // TODO: Handle more?
+                    tracing::warn!("unhandled edit commands: {cmds:?}");
+                    None
+                }
+            }
+        }
+        reedline::ReedlineEvent::ClearScreen => {
+            Some(KeyAction::DoInputFunction(InputFunction::ClearScreen))
+        }
+        reedline::ReedlineEvent::CtrlC => None,
+        reedline::ReedlineEvent::CtrlD => None,
+        reedline::ReedlineEvent::Enter => {
+            Some(KeyAction::DoInputFunction(InputFunction::AcceptLine))
+        }
+        reedline::ReedlineEvent::Esc => None,
+        reedline::ReedlineEvent::MenuPrevious => None,
+        reedline::ReedlineEvent::OpenEditor => None,
+        reedline::ReedlineEvent::SearchHistory => Some(KeyAction::DoInputFunction(
+            InputFunction::HistorySearchBackward,
+        )),
+        reedline::ReedlineEvent::Multiple(_) => {
+            // TODO: Try to extract something from these?
+            None
+        }
+        reedline::ReedlineEvent::UntilFound(uf_events) => {
+            if let [reedline::ReedlineEvent::HistoryHintComplete
+            | reedline::ReedlineEvent::HistoryHintWordComplete, next_evt] = uf_events.as_slice()
+            {
+                translate_reedline_event_to_action(next_evt)
+            } else {
+                // TODO: Try to extract something from these?
+                None
+            }
+        }
+        _ => {
+            // TODO: Handle more?
+            None
+        }
+    }
+}

--- a/brush-interactive/src/reedline/mod.rs
+++ b/brush-interactive/src/reedline/mod.rs
@@ -1,4 +1,5 @@
 mod completer;
+mod edit_mode;
 mod highlighter;
 mod prompt;
 mod reedline_shell;

--- a/brush-interactive/src/reedline/reedline_shell.rs
+++ b/brush-interactive/src/reedline/reedline_shell.rs
@@ -3,7 +3,7 @@ use reedline::MenuBuilder;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use super::{completer, highlighter, refs, validator};
+use super::{completer, edit_mode, highlighter, refs, validator};
 use crate::{interactive_shell::InteractivePrompt, InteractiveShell, ReadResult, ShellError};
 
 /// Represents an interactive shell capable of taking commands from standard input
@@ -24,9 +24,19 @@ impl ReedlineShell {
     pub async fn new(options: &crate::Options) -> Result<ReedlineShell, ShellError> {
         // Set up shell first. Its initialization may influence how the
         // editor needs to operate.
-        let shell = brush_core::Shell::new(&options.shell).await?;
+        let mut shell = brush_core::Shell::new(&options.shell).await?;
         let history_file_path = shell.get_history_file_path();
 
+        // Set up key bindings.
+        let key_bindings = compose_key_bindings(COMPLETION_MENU_NAME);
+
+        // Set up mutable edit mode.
+        let mutable_edit_mode = edit_mode::MutableEditMode::new(key_bindings);
+        let updatable_bindings = mutable_edit_mode.bindings();
+        shell.key_bindings = Some(updatable_bindings.clone());
+
+        // Wrap the shell in an Arc<Mutex> so we can share it with the helper
+        // objects we'll need to set up for reedline.
         let shell_ref = Arc::new(Mutex::new(shell));
 
         // Create helper objects that implement reedline traits; each will
@@ -57,9 +67,6 @@ impl ReedlineShell {
                 .with_selected_match_text_style(Color::Blue.bold().reverse()),
         );
 
-        // Set up key bindings.
-        let key_bindings = compose_key_bindings(COMPLETION_MENU_NAME);
-
         // Set up default history-based hinter.
         let mut hinter = reedline::DefaultHinter::default();
         if !options.disable_color {
@@ -76,7 +83,7 @@ impl ReedlineShell {
             .with_validator(Box::new(validator))
             .with_hinter(Box::new(hinter))
             .with_menu(reedline::ReedlineMenu::EngineCompleter(completion_menu))
-            .with_edit_mode(Box::new(reedline::Emacs::new(key_bindings)));
+            .with_edit_mode(Box::new(mutable_edit_mode));
 
         // If requested, apply some additional niceties.
         if !options.disable_highlighting && !options.disable_color {
@@ -146,6 +153,29 @@ impl InteractiveShell for ReedlineShell {
             }
         } else {
             Ok(ReadResult::Eof)
+        }
+    }
+
+    fn get_read_buffer(&self) -> Option<(String, usize)> {
+        self.reedline.as_ref().map(|r| {
+            (
+                r.current_buffer_contents().to_owned(),
+                r.current_insertion_point(),
+            )
+        })
+    }
+
+    fn set_read_buffer(&mut self, buffer: String, cursor: usize) {
+        if let Some(reedline) = &mut self.reedline {
+            reedline.run_edit_commands(&[
+                reedline::EditCommand::MoveToStart { select: false },
+                reedline::EditCommand::ClearToLineEnd,
+                reedline::EditCommand::InsertString(buffer),
+                reedline::EditCommand::MoveToPosition {
+                    position: cursor,
+                    select: false,
+                },
+            ]);
         }
     }
 

--- a/brush-parser/src/error.rs
+++ b/brush-parser/src/error.rs
@@ -58,6 +58,18 @@ pub enum TestCommandParseError {
     TestCommand(peg::error::ParseError<usize>),
 }
 
+/// Represents an error that occurred while parsing a key-binding specification.
+#[derive(Debug, thiserror::Error)]
+pub enum BindingParseError {
+    /// An unknown error occurred while parsing a key-binding specification.
+    #[error("unknown error while parsing key-binding: '{0}'")]
+    Unknown(String),
+
+    /// A key code was missing from the key-binding specification.
+    #[error("missing key code in key-binding")]
+    MissingKeyCode,
+}
+
 pub(crate) fn convert_peg_parse_error(
     err: &peg::error::ParseError<usize>,
     tokens: &[Token],

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -6,6 +6,7 @@ pub mod arithmetic;
 pub mod ast;
 pub mod pattern;
 pub mod prompt;
+pub mod readline_binding;
 pub mod test_command;
 pub mod word;
 
@@ -13,7 +14,7 @@ mod error;
 mod parser;
 mod tokenizer;
 
-pub use error::{ParseError, TestCommandParseError, WordParseError};
+pub use error::{BindingParseError, ParseError, TestCommandParseError, WordParseError};
 pub use parser::{parse_tokens, Parser, ParserOptions, SourceInfo};
 pub use tokenizer::{
     tokenize_str, tokenize_str_with_options, uncached_tokenize_str, unquote_str, SourcePosition,

--- a/brush-parser/src/readline_binding.rs
+++ b/brush-parser/src/readline_binding.rs
@@ -1,0 +1,147 @@
+//! Implements a parser for readline binding syntax.
+
+use crate::error;
+
+/// Represents a readline key-sequence binding.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeySequenceBinding {
+    /// Key sequence to bind
+    pub seq: KeySequence,
+    /// Command to bind to the sequence
+    pub command: String,
+}
+
+/// Represents a key sequence.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeySequence(pub Vec<KeySequenceItem>);
+
+/// Represents an element of a key sequence.
+#[derive(Debug, Clone, PartialEq)]
+pub enum KeySequenceItem {
+    /// Control
+    Control,
+    /// Meta
+    Meta,
+    /// Regular character
+    Byte(u8),
+}
+
+/// Represents a single key stroke.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct KeyStroke {
+    /// Meta key is held down
+    pub meta: bool,
+    /// Control key is held down
+    pub control: bool,
+    /// Primary key code
+    pub key_code: Vec<u8>,
+}
+
+/// Parses a key-sequence binding specification.
+///
+/// # Arguments
+///
+/// * `input` - The input string to parse
+pub fn parse_key_sequence_binding(
+    input: &str,
+) -> Result<KeySequenceBinding, error::BindingParseError> {
+    readline_binding::key_sequence_binding(input)
+        .map_err(|_err| error::BindingParseError::Unknown(input.to_owned()))
+}
+
+/// Converts a `KeySequence` to a vector of `KeyStroke`.
+///
+/// # Arguments
+///
+/// * `seq` - The key sequence to convert
+pub fn key_sequence_to_strokes(
+    seq: &KeySequence,
+) -> Result<Vec<KeyStroke>, error::BindingParseError> {
+    let mut strokes = vec![];
+    let mut current_stroke = KeyStroke::default();
+
+    for item in &seq.0 {
+        if matches!(item, KeySequenceItem::Control | KeySequenceItem::Meta)
+            && !current_stroke.key_code.is_empty()
+        {
+            strokes.push(current_stroke);
+            current_stroke = KeyStroke::default();
+        }
+
+        match item {
+            KeySequenceItem::Control => current_stroke.control = true,
+            KeySequenceItem::Meta => current_stroke.meta = true,
+            KeySequenceItem::Byte(b) => current_stroke.key_code.push(*b),
+        }
+    }
+
+    if current_stroke.key_code.is_empty() {
+        if current_stroke.control || current_stroke.meta {
+            return Err(error::BindingParseError::MissingKeyCode);
+        }
+    } else {
+        strokes.push(current_stroke);
+    }
+
+    Ok(strokes)
+}
+
+peg::parser! {
+    grammar readline_binding() for str {
+        rule _() = [' ' | '\t' | '\n']*
+
+        pub rule key_sequence_binding() -> KeySequenceBinding =
+            _ "\"" seq:key_sequence() "\"" _ ":" _ command:cmd() _ { KeySequenceBinding { seq, command } }
+
+        rule cmd() -> String = s:$([_]*) { s.to_string() }
+
+        // Main rule for parsing a key sequence
+        rule key_sequence() -> KeySequence =
+            items:key_sequence_item()* { KeySequence(items) }
+
+        rule key_sequence_item() -> KeySequenceItem =
+            "\\C-" { KeySequenceItem::Control } /
+            "\\M-" { KeySequenceItem::Meta } /
+            "\\e" { KeySequenceItem::Byte(b'\x1b') } /
+            "\\\\" { KeySequenceItem::Byte(b'\\') } /
+            "\\\"" { KeySequenceItem::Byte(b'"') } /
+            "\\'" { KeySequenceItem::Byte(b'\'') } /
+            "\\a" { KeySequenceItem::Byte(b'\x07') } /
+            "\\b" { KeySequenceItem::Byte(b'\x08') } /
+            "\\d" { KeySequenceItem::Byte(b'\x7f') } /
+            "\\f" { KeySequenceItem::Byte(b'\x0c') } /
+            "\\n" { KeySequenceItem::Byte(b'\n') } /
+            "\\r" { KeySequenceItem::Byte(b'\r') } /
+            "\\t" { KeySequenceItem::Byte(b'\t') } /
+            "\\v" { KeySequenceItem::Byte(b'\x0b') } /
+            "\\" n:octal_number() { KeySequenceItem::Byte(n) } /
+            "\\" n:hex_number() { KeySequenceItem::Byte(n) } /
+            [c if c != '"'] { KeySequenceItem::Byte(c as u8) }
+
+        rule octal_number() -> u8 =
+            s:$(['0'..='7']*<1,3>) {? u8::from_str_radix(s, 8).or(Err("invalid octal number")) }
+
+        rule hex_number() -> u8 =
+            s:$(['0'..='9' | 'a'..='f' | 'A'..='F']*<1,2>) {? u8::from_str_radix(s, 16).or(Err("invalid hex number")) }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unnecessary_wraps)]
+#[allow(clippy::panic_in_result_fn)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn test_basic_parse() -> Result<()> {
+        let binding = parse_key_sequence_binding(r#""\C-k": xyz"#)?;
+        assert_eq!(
+            binding.seq.0,
+            [KeySequenceItem::Control, KeySequenceItem::Byte(b'k')]
+        );
+        assert_eq!(binding.command, "xyz");
+
+        Ok(())
+    }
+}

--- a/brush-shell/src/events.rs
+++ b/brush-shell/src/events.rs
@@ -23,6 +23,9 @@ pub enum TraceEvent {
     /// Traces functions.
     #[clap(name = "functions")]
     Functions,
+    /// Traces input controls.
+    #[clap(name = "input")]
+    Input,
     /// Traces job management.
     #[clap(name = "jobs")]
     Jobs,
@@ -48,6 +51,7 @@ impl Display for TraceEvent {
             TraceEvent::Complete => write!(f, "complete"),
             TraceEvent::Expand => write!(f, "expand"),
             TraceEvent::Functions => write!(f, "functions"),
+            TraceEvent::Input => write!(f, "input"),
             TraceEvent::Jobs => write!(f, "jobs"),
             TraceEvent::Parse => write!(f, "parse"),
             TraceEvent::Pattern => write!(f, "pattern"),
@@ -136,6 +140,7 @@ impl TraceEventConfig {
             TraceEvent::Complete => vec!["completion"],
             TraceEvent::Expand => vec!["expansion"],
             TraceEvent::Functions => vec!["functions"],
+            TraceEvent::Input => vec!["input"],
             TraceEvent::Jobs => vec!["jobs"],
             TraceEvent::Parse => vec!["parse"],
             TraceEvent::Pattern => vec!["pattern"],

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,7 @@ allow = [
     "MIT",
     "NCSA",
     "Unicode-3.0",
+    "WTFPL",
     "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.
@@ -92,7 +93,11 @@ skip = [
     { crate = "itertools" },
     { crate = "linux-raw-sys" },
     { crate = "nu-ansi-term" },
+    { crate = "rand" },
+    { crate = "rand_core" },
     { crate = "rustix" },
+    { crate = "strum" },
+    { crate = "strum_macros" },
     { crate = "wasi" },
     { crate = "zerocopy" },
 ]


### PR DESCRIPTION
There's a lot here. Supporting even the most minimal functionality in `bind` required:

* Some `reedline`-specific integration code in `brush-interactive` that lets us add an indirection between `reedline` and the key bindings. This was needed to let us mutate the key bindings at runtime.
* A pattern and interface for us to let the `bind` builtin in `brush-core` "upcall" back to the interactive shell layer for querying and mutating bindings.
* Implementation of this new trait for the `reedline` input backend.
* Parsing the `readline` binding syntax supported by `bind`.
* Translating the key codes referenced in the `readline` binding syntax into the abstract keys that `reedline` allows configuring.
* Implementing `READLINE_LINE` and `READLINE_POINT` handling in the shell.

With this support in place, projects like [atuin](https://atuin.sh/) are *starting* to work. (There's still gaps, but this is a big step.)

_Relates to: #380_