### PR TITLE
test: add known failing tests for reported issues

### DIFF
--- a/brush-shell/tests/cases/arithmetic.yaml
+++ b/brush-shell/tests/cases/arithmetic.yaml
@@ -97,6 +97,12 @@ cases:
       echo "32 >> 2 == $((32>>2))"
       echo " 1 << 4 == $((1<<4))"
 
+  - name: Shift arithmetic in conditional"
+    known_failure: true
+    stdin: |
+      (( 1 >> 1 )) && echo "1. true"
+      (( 1 << 1 )) && echo "2. true"
+
   - name: "Variable references"
     stdin: |
       x=10

--- a/brush-shell/tests/cases/prompt.yaml
+++ b/brush-shell/tests/cases/prompt.yaml
@@ -90,3 +90,18 @@ cases:
       expanded=${prompt@P}
       roundtripped=$(date --date="${expanded}" +'%H:%M:%S')
       [[ ${expanded} == ${roundtripped} ]] && echo "Time matches"
+
+  - name: "Current history number"
+    known_failure: true
+    stdin: |
+      prompt='\!'
+      expanded=${prompt@P}
+      roundtripped=$(history | tail -n 1 | cut -d ' ' -f 1)
+      [[ ${expanded} == ${roundtripped} ]] && echo "History number matches"
+
+  - name: "Current command number"
+    known_failure: true # Issue #471
+    stdin: |
+      prompt='\#'
+      expanded=${prompt@P}
+      echo "${expanded}"


### PR DESCRIPTION
Adds small compat test cases to isolate and reproduce a few recently reported issues:

* `ble.sh` runs into a parse error with a `<<` arithmetic operator in a `(( ... ))` construct being treated as a here-document tag (tracked by #484)
* prompt syntax `\#` not implemented (reported in #471)
* prompt syntax '\!` not implemented (related to #469 feature work)