### PR TITLE
fix: allow "bind" usage in .bashrc

### DIFF
--- a/brush-core/src/builtins/bind.rs
+++ b/brush-core/src/builtins/bind.rs
@@ -95,8 +95,9 @@ impl builtins::Command for BindCommand {
         } else {
             writeln!(
                 context.stderr(),
-                "bind: key bindings not supported in this configuration"
+                "bind: key bindings not supported in this config"
             )?;
+
             Ok(builtins::ExitCode::Unimplemented)
         }
     }

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -28,6 +28,9 @@ const BASH_BUILD: u32 = 1;
 const BASH_RELEASE: &str = "release";
 const BASH_MACHINE: &str = "unknown";
 
+/// Type for storing a key bindings helper.
+pub type KeyBindingsHelper = Arc<Mutex<dyn interfaces::KeyBindings>>;
+
 /// Represents an instance of a shell.
 pub struct Shell {
     //
@@ -97,7 +100,7 @@ pub struct Shell {
     last_stopwatch_offset: u32,
 
     /// Key bindings for the shell, optionally implemented by an interactive shell.
-    pub key_bindings: Option<Arc<Mutex<dyn interfaces::KeyBindings>>>,
+    pub key_bindings: Option<KeyBindingsHelper>,
 }
 
 impl Clone for Shell {
@@ -144,7 +147,7 @@ impl AsMut<Shell> for Shell {
 }
 
 /// Options for creating a new shell.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct CreateOptions {
     /// Disabled shopt options.
     pub disabled_shopt_options: Vec<String>,
@@ -184,6 +187,8 @@ pub struct CreateOptions {
     pub verbose: bool,
     /// Maximum function call depth.
     pub max_function_call_depth: Option<usize>,
+    /// Key bindings helper for the shell to use.
+    pub key_bindings: Option<KeyBindingsHelper>,
 }
 
 /// Represents an executing script.
@@ -235,7 +240,7 @@ impl Shell {
             program_location_cache: pathcache::PathCache::default(),
             last_stopwatch_time: std::time::SystemTime::now(),
             last_stopwatch_offset: 0,
-            key_bindings: None,
+            key_bindings: options.key_bindings.clone(),
             depth: 0,
         };
 

--- a/brush-interactive/src/reedline/reedline_shell.rs
+++ b/brush-interactive/src/reedline/reedline_shell.rs
@@ -21,19 +21,19 @@ impl ReedlineShell {
     /// # Arguments
     ///
     /// * `options` - Options for creating the interactive shell.
-    pub async fn new(options: &crate::Options) -> Result<ReedlineShell, ShellError> {
-        // Set up shell first. Its initialization may influence how the
-        // editor needs to operate.
-        let mut shell = brush_core::Shell::new(&options.shell).await?;
-        let history_file_path = shell.get_history_file_path();
-
+    pub async fn new(mut options: crate::Options) -> Result<ReedlineShell, ShellError> {
         // Set up key bindings.
         let key_bindings = compose_key_bindings(COMPLETION_MENU_NAME);
 
         // Set up mutable edit mode.
         let mutable_edit_mode = edit_mode::MutableEditMode::new(key_bindings);
         let updatable_bindings = mutable_edit_mode.bindings();
-        shell.key_bindings = Some(updatable_bindings.clone());
+        options.shell.key_bindings = Some(updatable_bindings);
+
+        // Set up shell first. Its initialization may influence how the
+        // editor needs to operate.
+        let shell = brush_core::Shell::new(&options.shell).await?;
+        let history_file_path = shell.get_history_file_path();
 
         // Wrap the shell in an Arc<Mutex> so we can share it with the helper
         // objects we'll need to set up for reedline.

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -261,6 +261,7 @@ async fn instantiate_shell(
             sh_mode: args.sh_mode,
             verbose: args.verbose,
             max_function_call_depth: None,
+            key_bindings: None,
         },
         disable_bracketed_paste: args.disable_bracketed_paste,
         disable_color: args.disable_color,
@@ -268,7 +269,7 @@ async fn instantiate_shell(
     };
 
     // Create the shell.
-    let mut shell = factory.create(&options).await?;
+    let mut shell = factory.create(options).await?;
 
     // Register our own built-in(s) with the shell.
     brushctl::register(shell.shell_mut().as_mut());

--- a/brush-shell/src/shell_factory.rs
+++ b/brush-shell/src/shell_factory.rs
@@ -3,7 +3,7 @@ pub(crate) trait ShellFactory {
 
     async fn create(
         &self,
-        options: &brush_interactive::Options,
+        options: brush_interactive::Options,
     ) -> Result<Self::ShellType, brush_interactive::ShellError>;
 }
 
@@ -61,7 +61,7 @@ impl ShellFactory for ReedlineShellFactory {
     #[allow(unused)]
     async fn create(
         &self,
-        options: &brush_interactive::Options,
+        options: brush_interactive::Options,
     ) -> Result<Self::ShellType, brush_interactive::ShellError> {
         #[cfg(any(windows, unix))]
         {
@@ -85,11 +85,11 @@ impl ShellFactory for BasicShellFactory {
     #[allow(unused)]
     async fn create(
         &self,
-        options: &brush_interactive::Options,
+        options: brush_interactive::Options,
     ) -> Result<Self::ShellType, brush_interactive::ShellError> {
         #[cfg(feature = "basic")]
         {
-            brush_interactive::BasicShell::new(options).await
+            brush_interactive::BasicShell::new(&options).await
         }
         #[cfg(not(feature = "basic"))]
         {
@@ -109,11 +109,11 @@ impl ShellFactory for MinimalShellFactory {
     #[allow(unused)]
     async fn create(
         &self,
-        options: &brush_interactive::Options,
+        options: brush_interactive::Options,
     ) -> Result<Self::ShellType, brush_interactive::ShellError> {
         #[cfg(feature = "minimal")]
         {
-            brush_interactive::MinimalShell::new(options).await
+            brush_interactive::MinimalShell::new(&options).await
         }
         #[cfg(not(feature = "minimal"))]
         {


### PR DESCRIPTION
Without this change, the `reedline` input backend was registering a key bindings implementation *after* `.bashrc` et al. were processed.