### PR TITLE
fix(expansion): fix issues parsing backquoted commands nested in single/double-quoted strings

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -391,14 +391,7 @@ impl<'a> WordExpander<'a> {
 
     /// Apply tilde-expansion, parameter expansion, command substitution, and arithmetic expansion.
     pub async fn basic_expand_to_str(&mut self, word: &str) -> Result<String, error::Error> {
-        let expanded = String::from(self.basic_expand(word).await?);
-
-        tracing::debug!(
-            target: trace_categories::EXPANSION,
-            "Basic expanded: '{word}' => '{expanded}'"
-        );
-
-        Ok(expanded)
+        String::from(self.basic_expand(word).await?)
     }
 
     #[allow(clippy::ref_option)]

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -391,7 +391,7 @@ impl<'a> WordExpander<'a> {
 
     /// Apply tilde-expansion, parameter expansion, command substitution, and arithmetic expansion.
     pub async fn basic_expand_to_str(&mut self, word: &str) -> Result<String, error::Error> {
-        String::from(self.basic_expand(word).await?)
+        Ok(String::from(self.basic_expand(word).await?))
     }
 
     #[allow(clippy::ref_option)]

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -392,6 +392,12 @@ impl<'a> WordExpander<'a> {
     /// Apply tilde-expansion, parameter expansion, command substitution, and arithmetic expansion.
     pub async fn basic_expand_to_str(&mut self, word: &str) -> Result<String, error::Error> {
         let expanded = String::from(self.basic_expand(word).await?);
+
+        tracing::debug!(
+            target: trace_categories::EXPANSION,
+            "Basic expanded: '{word}' => '{expanded}'"
+        );
+
         Ok(expanded)
     }
 

--- a/brush-shell/tests/cases/prompt.yaml
+++ b/brush-shell/tests/cases/prompt.yaml
@@ -105,3 +105,21 @@ cases:
       prompt='\#'
       expanded=${prompt@P}
       echo "${expanded}"
+
+  - name: "Command substitution in prompt"
+    known_failure: true # @P expansion doesn't word-expand after prompt expanding
+    stdin: |
+      prompt='$(echo Hello)'
+      echo "Without spaces: ${prompt@P}"
+
+      prompt=' $(echo Hello) '
+      echo "With spaces: ${prompt@P}"
+
+  - name: "Backquoted command substitution in prompt"
+    known_failure: true # @P expansion doesn't word-expand after prompt expanding
+    stdin: |
+      prompt='`echo Hello`'
+      echo "Without spaces: ${prompt@P}"
+
+      prompt=' `echo Hello` '
+      echo "With spaces: ${prompt@P}"

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -80,6 +80,12 @@ cases:
     stdin: |
       echo `echo \`echo hi\``
 
+  - name: "Backtick command substitution in double quotes"
+    stdin: |
+      echo "`echo First line`"
+      echo " `echo Second line` "
+      echo "Third`echo line`here"
+
   - name: "String length"
     stdin: |
       x="abc"


### PR DESCRIPTION
The issue tracked in #488 was broader than just prompts--and found multiple bugs:

* We were missing some test coverage for a broader form of prompt-expanding.
* We only correctly parsed backquoted commands in containing double-quoted strings if the former started strictly at the start of the latter.
* Ditto for single-quoted strings.

The fixes entail correcting the "stop" conditions for the grammar rules tracking the bodies of the quoted strings.

There's still an unresolved issue of `@P`-expansion needing to word-expanding the prompt-expanded result. That will need to be resolved in a separate PR.

Resolves #488 