### PR TITLE
fix(break,continue): use `default_value_t` for flag values

### DIFF
--- a/brush-core/src/builtins/break_.rs
+++ b/brush-core/src/builtins/break_.rs
@@ -6,7 +6,7 @@ use crate::{builtins, commands};
 #[derive(Parser)]
 pub(crate) struct BreakCommand {
     /// If specified, indicates which nested loop to break out of.
-    #[clap(default_value = "1")]
+    #[clap(default_value_t = 1)]
     which_loop: i8,
 }
 

--- a/brush-core/src/builtins/continue_.rs
+++ b/brush-core/src/builtins/continue_.rs
@@ -6,7 +6,7 @@ use crate::{builtins, commands};
 #[derive(Parser)]
 pub(crate) struct ContinueCommand {
     /// If specified, indicates which nested loop to continue to the next iteration of.
-    #[clap(default_value = "1")]
+    #[clap(default_value_t = 1)]
     which_loop: i8,
 }
 


### PR DESCRIPTION
`default_value` is for types that can be converted into a `String`, which can be expensive, but `default_value_t` is for stack-allocated types and should be a less expensive to use.

At the level that you use `default_value`, it won't get us that much more performance, but it's still worth it.

#490 does the ones for `mapfile`.