### PR TITLE
fix(help): better compact argument help

### DIFF
--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -233,7 +233,7 @@ pub trait Command: Parser {
         clap_command.set_bin_name(name);
 
         let s = match content_type {
-            ContentType::DetailedHelp => clap_command.render_long_help().ansi().to_string(),
+            ContentType::DetailedHelp => clap_command.render_help().ansi().to_string(),
             ContentType::ShortUsage => get_builtin_short_usage(name, &clap_command),
             ContentType::ShortDescription => get_builtin_short_description(name, &clap_command),
             ContentType::ManPage => get_builtin_man_page(name, &clap_command)?,

--- a/brush-core/src/builtins/bind.rs
+++ b/brush-core/src/builtins/bind.rs
@@ -62,19 +62,19 @@ pub(crate) struct BindCommand {
     #[arg(short = 'v')]
     list_vars_reusable: bool,
     /// Find the keys bound to the given named function.
-    #[arg(short = 'q')]
+    #[arg(short = 'q', value_name = "FUNC_NAME")]
     query_func_bindings: Option<String>,
     /// Remove all bindings for the given named function.
-    #[arg(short = 'u')]
+    #[arg(short = 'u', value_name = "FUNC_NAME")]
     remove_func_bindings: Option<String>,
     /// Remove the binding for the given key sequence.
-    #[arg(short = 'r')]
+    #[arg(short = 'r', value_name = "KEY_SEQ")]
     remove_key_seq_binding: Option<String>,
     /// Import bindings from the given file.
-    #[arg(short = 'f')]
+    #[arg(short = 'f', value_name = "PATH")]
     bindings_file: Option<String>,
     /// Bind key sequence to command.
-    #[arg(short = 'x')]
+    #[arg(short = 'x', value_name = "BINDING")]
     key_seq_bindings: Vec<String>,
     /// List key sequence bindings.
     #[arg(short = 'X')]

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -20,7 +20,7 @@ struct CommonCompleteCommandArgs {
     actions: Vec<CompleteAction>,
 
     /// File glob pattern to be expanded to generate completions.
-    #[arg(short = 'G', allow_hyphen_values = true)]
+    #[arg(short = 'G', allow_hyphen_values = true, value_name = "GLOB")]
     glob_pattern: Option<String>,
 
     /// List of words that will be considered as completions.
@@ -28,19 +28,22 @@ struct CommonCompleteCommandArgs {
     word_list: Option<String>,
 
     /// Name of a shell function to invoke to generate completions.
-    #[arg(short = 'F', allow_hyphen_values = true)]
+    #[arg(short = 'F', allow_hyphen_values = true, value_name = "FUNC_NAME")]
     function_name: Option<String>,
 
     /// Command to execute to generate completions.
     #[arg(short = 'C', allow_hyphen_values = true)]
     command: Option<String>,
 
-    #[arg(short = 'X', allow_hyphen_values = true)]
+    /// Pattern used as filter for completions.
+    #[arg(short = 'X', allow_hyphen_values = true, value_name = "PATTERN")]
     filter_pattern: Option<String>,
 
+    /// Prefix pattern used as filter for completions.
     #[arg(short = 'P', allow_hyphen_values = true)]
     prefix: Option<String>,
 
+    /// Suffix oattern used as filter for completions.
     #[arg(short = 'S', allow_hyphen_values = true)]
     suffix: Option<String>,
 
@@ -554,7 +557,7 @@ pub(crate) struct CompOptCommand {
     update_initial_word: bool,
 
     /// Enable the specified option for selected completion scenarios.
-    #[arg(short = 'o')]
+    #[arg(short = 'o', value_name = "OPT")]
     enabled_options: Vec<CompleteOption>,
     #[arg(long = concat!("+o"), hide = true)]
     disabled_options: Vec<CompleteOption>,

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -43,7 +43,7 @@ struct CommonCompleteCommandArgs {
     #[arg(short = 'P', allow_hyphen_values = true)]
     prefix: Option<String>,
 
-    /// Suffix oattern used as filter for completions.
+    /// Suffix pattern used as filter for completions.
     #[arg(short = 'S', allow_hyphen_values = true)]
     suffix: Option<String>,
 

--- a/brush-core/src/builtins/enable.rs
+++ b/brush-core/src/builtins/enable.rs
@@ -26,7 +26,7 @@ pub(crate) struct EnableCommand {
     special_only: bool,
 
     /// Path to a shared object from which built-in commands will be loaded.
-    #[arg(short = 'f')]
+    #[arg(short = 'f', value_name = "PATH")]
     shared_object_path: Option<String>,
 
     /// Remove the built-in commands loaded from the indicated object path.

--- a/brush-core/src/builtins/exec.rs
+++ b/brush-core/src/builtins/exec.rs
@@ -7,7 +7,7 @@ use crate::{builtins, commands, error};
 #[derive(Parser)]
 pub(crate) struct ExecCommand {
     /// Pass given name as zeroth argument to command.
-    #[arg(short = 'a')]
+    #[arg(short = 'a', value_name = "NAME")]
     name_for_argv0: Option<String>,
 
     /// Exec command with an empty environment.

--- a/brush-core/src/builtins/hash.rs
+++ b/brush-core/src/builtins/hash.rs
@@ -14,7 +14,7 @@ pub(crate) struct HashCommand {
     display_as_usable_input: bool,
 
     /// The path to associate with the names.
-    #[arg(short = 'p')]
+    #[arg(short = 'p', value_name = "PATH")]
     path_to_use: Option<PathBuf>,
 
     /// Remove all entries.

--- a/brush-core/src/builtins/kill.rs
+++ b/brush-core/src/builtins/kill.rs
@@ -8,11 +8,11 @@ use crate::{builtins, commands, error, sys};
 #[derive(Parser)]
 pub(crate) struct KillCommand {
     /// Name of the signal to send.
-    #[arg(short = 's')]
+    #[arg(short = 's', value_name = "SIG_NAME")]
     signal_name: Option<String>,
 
     /// Number of the signal to send.
-    #[arg(short = 'n')]
+    #[arg(short = 'n', value_name = "SIG_NUM")]
     signal_number: Option<usize>,
 
     //

--- a/brush-core/src/builtins/read.rs
+++ b/brush-core/src/builtins/read.rs
@@ -11,7 +11,7 @@ use std::io::{Read, Write};
 pub(crate) struct ReadCommand {
     /// Optionally, name of an array variable to receive read words
     /// of input.
-    #[clap(short = 'a')]
+    #[clap(short = 'a', value_name = "VAR_NAME")]
     array_variable: Option<String>,
 
     /// Optionally, a delimiter to use other than a newline character.
@@ -23,16 +23,16 @@ pub(crate) struct ReadCommand {
     use_readline: bool,
 
     /// Provide text to use as initial input for readline.
-    #[clap(short = 'i')]
+    #[clap(short = 'i', value_name = "STR")]
     initial_text: Option<String>,
 
     /// Read only the first N characters or until a specified
     /// delimiter is reached, whichever happens first.
-    #[clap(short = 'n')]
+    #[clap(short = 'n', value_name = "COUNT")]
     return_after_n_chars: Option<usize>,
 
     /// Read exactly N characters, ignoring any specified delimiter.
-    #[clap(short = 'N')]
+    #[clap(short = 'N', value_name = "COUNT")]
     return_after_n_chars_no_delimiter: Option<usize>,
 
     /// Prompt to display before reading.
@@ -49,7 +49,7 @@ pub(crate) struct ReadCommand {
 
     /// Specify timeout in seconds; fail if the timeout elapses before
     /// input is completed.
-    #[clap(short = 't')]
+    #[clap(short = 't', value_name = "SECONDS")]
     timeout_in_seconds: Option<usize>,
 
     /// File descriptor to read from instead of stdin.
@@ -98,8 +98,11 @@ impl builtins::Command for ReadCommand {
         if let Some(input_line) = input_line {
             // If -a was specified, then place the fields as elements into the array.
             if let Some(array_variable) = &self.array_variable {
-                let fields: VecDeque<_> =
-                    split_line_by_ifs(ifs.as_ref(), input_line.as_str(), None /*max_fields*/);
+                let fields: VecDeque<_> = split_line_by_ifs(
+                    ifs.as_ref(),
+                    input_line.as_str(),
+                    None, /* max_fields */
+                );
                 let literal_fields = fields.into_iter().map(|f| (None, f)).collect();
 
                 context.shell.env.update_or_add(
@@ -113,7 +116,7 @@ impl builtins::Command for ReadCommand {
                 let mut fields: VecDeque<_> = split_line_by_ifs(
                     ifs.as_ref(),
                     input_line.as_str(),
-                    /*max_fields*/ Some(self.variable_names.len()),
+                    /* max_fields */ Some(self.variable_names.len()),
                 );
 
                 for (i, name) in self.variable_names.iter().enumerate() {

--- a/brush-core/src/builtins/set.rs
+++ b/brush-core/src/builtins/set.rs
@@ -72,7 +72,7 @@ builtins::minus_or_plus_flag_arg!(
 
 #[derive(clap::Parser)]
 pub(crate) struct SetOption {
-    #[arg(short = 'o', name = "setopt_enable", num_args=0..=1)]
+    #[arg(short = 'o', name = "setopt_enable", num_args=0..=1, value_name = "OPT")]
     enable: Option<Vec<String>>,
     #[arg(long = concat!("+o"), name = "setopt_disable", hide = true, num_args=0..=1)]
     disable: Option<Vec<String>>,

--- a/brush-core/src/builtins/wait.rs
+++ b/brush-core/src/builtins/wait.rs
@@ -16,7 +16,7 @@ pub(crate) struct WaitCommand {
     wait_for_first_or_next: bool,
 
     /// Name of variable to receive the job ID of the job whose status is indicated.
-    #[arg(short = 'p')]
+    #[arg(short = 'p', value_name = "VAR_NAME")]
     variable_to_receive_id: Option<String>,
 
     /// Specs of jobs to wait for.


### PR DESCRIPTION
* Updates `name_value` for various builtin options
* Opts for more compact help output for named options