### PR TITLE
fix: fix typos + add spell-checking PR check

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,0 +1,22 @@
+name: Spelling
+on: [pull_request]
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+  CLICOLOR_FORCE: 1
+
+permissions:
+  contents: read
+
+jobs:
+  spelling:
+    name: spell-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout brush
+        uses: actions/checkout@v4
+
+      - name: Spell check repo
+        uses: crate-ci/typos@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,28 @@ result_large_err = "allow"
 similar_names = "allow"
 struct_excessive_bools = "allow"
 
+[workspace.metadata.typos]
+files.extend-exclude = [
+    # Exclude the changelog because it's dynamically generated.
+    "/CHANGELOG.md",
+    # Remove this once impending mapfile updates are merged.
+    "/brush-core/src/builtins/mapfile.rs",
+]
+
+[workspace.metadata.typos.default]
+extend-ignore-re = [
+    # -ot is a valid binary operator
+    "-ot",
+    # Ignore 2-letter string literals, which show up in testing a fair bit.
+    '"[a-zA-Z]{2}"',
+]
+
+[workspace.metadata.typos.default.extend-words]
+# These show up in tests.
+"abd" = "abd"
+"hel" = "hel"
+"ba" = "ba"
+
 [profile.release]
 strip = true
 lto = "fat"

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -414,7 +414,7 @@ fn brush_help_styles() -> clap::builder::Styles {
 /// # Returns
 ///
 /// * a parsed struct T from [`clap::Parser::parse_from`]
-/// * the remain iterator `args` with `--` and the rest arguments if they present othervise None
+/// * the remain iterator `args` with `--` and the rest arguments if they present otherwise None
 ///
 /// # Examples
 /// ```

--- a/brush-core/src/builtins/dot.rs
+++ b/brush-core/src/builtins/dot.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 
 use crate::{builtins, commands};
 
-/// Evalute the provided script in the current shell environment.
+/// Evaluate the provided script in the current shell environment.
 #[derive(Parser)]
 pub(crate) struct DotCommand {
     /// Path to the script to evaluate.

--- a/brush-core/src/builtins/eval.rs
+++ b/brush-core/src/builtins/eval.rs
@@ -1,7 +1,7 @@
 use crate::{builtins, commands};
 use clap::Parser;
 
-/// Evalute the given string as script.
+/// Evaluate the given string as script.
 #[derive(Parser)]
 pub(crate) struct EvalCommand {
     /// The script to evaluate.

--- a/brush-core/src/builtins/let_.rs
+++ b/brush-core/src/builtins/let_.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use crate::{arithmetic::Evaluatable, builtins, commands};
 
-/// Evalute arithmetic expressions.
+/// Evaluate arithmetic expressions.
 #[derive(Parser)]
 pub(crate) struct LetCommand {
     /// Arithmetic expressions to evaluate.

--- a/brush-core/src/builtins/set.rs
+++ b/brush-core/src/builtins/set.rs
@@ -12,7 +12,7 @@ builtins::minus_or_plus_flag_arg!(
     "Export variables on modification"
 );
 builtins::minus_or_plus_flag_arg!(
-    NotfyJobTerminationImmediately,
+    NotifyJobTerminationImmediately,
     'b',
     "Notify job termination immediately"
 );
@@ -89,7 +89,7 @@ pub(crate) struct SetCommand {
     #[clap(flatten)]
     export_variables_on_modification: ExportVariablesOnModification,
     #[clap(flatten)]
-    notify_job_termination_immediately: NotfyJobTerminationImmediately,
+    notify_job_termination_immediately: NotifyJobTerminationImmediately,
     #[clap(flatten)]
     exit_on_nonzero_command_exit: ExitOnNonzeroCommandExit,
     #[clap(flatten)]

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -19,7 +19,7 @@ use crate::{
 pub(crate) enum CommandSpawnResult {
     /// The child process was spawned.
     SpawnedProcess(processes::ChildProcess),
-    /// The command immediatedly exited with the given numeric exit code.
+    /// The command immediately exited with the given numeric exit code.
     ImmediateExit(u8),
     /// The shell should exit after this command, yielding the given numeric exit code.
     ExitShell(u8),

--- a/brush-core/src/processes.rs
+++ b/brush-core/src/processes.rs
@@ -64,7 +64,7 @@ impl ChildProcess {
     }
 }
 
-/// Reperesents the result of waiting for an executing process.
+/// Represents the result of waiting for an executing process.
 pub(crate) enum ProcessWaitResult {
     /// The process completed.
     Completed(std::process::Output),

--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -7,7 +7,7 @@ use crate::tokenizer::{Token, TokenEndReason, Tokenizer, TokenizerOptions, Token
 pub struct ParserOptions {
     /// Whether or not to enable extended globbing (a.k.a. `extglob`).
     pub enable_extended_globbing: bool,
-    /// Whether or not to enable POSIX complaince mode.
+    /// Whether or not to enable POSIX compliance mode.
     pub posix_mode: bool,
     /// Whether or not to enable maximal compatibility with the `sh` shell.
     pub sh_mode: bool,

--- a/brush-shell/tests/cases/command_substitution.yaml
+++ b/brush-shell/tests/cases/command_substitution.yaml
@@ -16,7 +16,7 @@ cases:
       )
       echo $var
 
-  - name: "Ignore parantheses in comment in command substitution"
+  - name: "Ignore parentheses in comment in command substitution"
     stdin: |
       var=$(
         # :(
@@ -52,7 +52,7 @@ cases:
       `
       echo $var
 
-  - name: "Ignore parantheses in comment in command substitution (backticks)"
+  - name: "Ignore parentheses in comment in command substitution (backticks)"
     stdin: |
       var=`
         # :(

--- a/brush-shell/tests/cases/list.yaml
+++ b/brush-shell/tests/cases/list.yaml
@@ -14,7 +14,7 @@ cases:
         echo "parsed"
       )
 
-  - name: "Ignore parantheses in comment in list"
+  - name: "Ignore parentheses in comment in list"
     stdin: |
       (
         # :(
@@ -27,4 +27,3 @@ cases:
         #               $
         echo "Mr. Crabs ^"
       )
-

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -1390,7 +1390,7 @@ struct TestOptions {
     #[clap(long = "exact")]
     pub exact_match: bool,
 
-    /// Optionaly specify a non-default path for bash
+    /// Optionally specify a non-default path for bash
     #[clap(long = "bash-path", default_value = "bash", env = "BASH_PATH")]
     pub bash_path: PathBuf,
 
@@ -1474,7 +1474,8 @@ impl TestOptions {
     }
 
     fn test_matches_filters(&self, qualified_test_name: &String, filters: &[String]) -> bool {
-        // In exact match mode, filters must be an exact match; substring matches are not considered.
+        // In exact match mode, filters must be an exact match; substring matches are not
+        // considered.
         if self.exact_match {
             filters.contains(qualified_test_name)
         } else {


### PR DESCRIPTION
* Used [typos](https://github.com/crate-ci/typos) to find typos in code base; corrected typos.
* Added appropriate exclusions to `Cargo.toml` for files that shouldn't be checked (`CHANGELOG.md`) and string patterns to allow-list
* Added PR check to run `typos`