### PR TITLE
fix: add missing tokio feature to unblock release

### DIFF
--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.44.2", features = [
     "rt",
     "rt-multi-thread",
     "signal",
+    "sync",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,6 +11,17 @@ name = "brush-shell"
 changelog_update = true
 changelog_path = "./CHANGELOG.md"
 changelog_include = ["brush-core", "brush-interactive-shell", "brush-parser"]
+git_release_latest = true
+git_release_draft = true
 git_release_enable = true
 git_release_name = "brush v{{ version }}"
-git_release_body = ""
+git_release_body = """
+{{ changelog }}
+{% if remote.contributors %}
+### Contributors
+{% for contributor in remote.contributors %}
+* @{{ contributor.username }}
+{% endfor %}
+{% endif %}
+"""
+


### PR DESCRIPTION
`release-plz` hit a snag because it builds the crates individually vs. at the workspace level, and that found that there's a required `tokio` feature (`sync`) missing in the `brush-core` crate manifest.

This fixes that issue and updates the `release-plz` config while we're at it.