### PR TITLE
fix: suppress warning when building with --no-default-features

### DIFF
--- a/brush-interactive/src/completion.rs
+++ b/brush-interactive/src/completion.rs
@@ -4,6 +4,7 @@ use indexmap::IndexSet;
 
 use crate::trace_categories;
 
+#[allow(dead_code)]
 pub(crate) async fn complete_async(
     shell: &mut brush_core::Shell,
     line: &str,
@@ -50,6 +51,7 @@ pub(crate) async fn complete_async(
     completions
 }
 
+#[allow(dead_code)]
 fn postprocess_completion_candidate(
     mut candidate: String,
     options: &brush_core::completion::ProcessingOptions,


### PR DESCRIPTION
For now, we need to suppress the warnings. When building with `--no-default-features`, `brush-interactive` hits a few warnings because completion-related code isn't required (and thus unused/dead).

Once we're past the impending release, we need to look back at this and appropriate tag the code as being conditional on the features that actually require it.