### PR TITLE
Allow reading a script from bytes

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -995,7 +995,10 @@ impl Shell {
         &self,
         reader: R,
     ) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
-        parse_impl(reader, self.parser_options())
+        let mut parser = create_parser(reader, &self.parser_options());
+
+        tracing::debug!(target: trace_categories::PARSE, "Parsing reader as program...");
+        parser.parse_program()
     }
 
     /// Parses the given string as a shell program, returning the resulting Abstract Syntax Tree
@@ -1730,16 +1733,6 @@ impl Shell {
             Ok(None)
         }
     }
-}
-
-fn parse_impl<R: Read>(
-    r: R,
-    parser_options: brush_parser::ParserOptions,
-) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
-    let mut parser = create_parser(r, &parser_options);
-
-    tracing::debug!(target: trace_categories::PARSE, "Parsing reader as program...");
-    parser.parse_program()
 }
 
 #[cached::proc_macro::cached(size = 64, result = true)]

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -990,19 +990,6 @@ impl Shell {
         parse_impl(reader, self.parser_options())
     }
 
-    /// Parses the given bytes as a shell program, returning the resulting Abstract Syntax Tree
-    /// for the program.
-    ///
-    /// # Arguments
-    ///
-    /// * `b` - The bytes to parse as a program.
-    pub fn parse_bytes<B: AsRef<[u8]>>(
-        &self,
-        b: B,
-    ) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
-        parse_bytes_impl(b.as_ref(), self.parser_options())
-    }
-
     /// Parses the given string as a shell program, returning the resulting Abstract Syntax Tree
     /// for the program.
     ///
@@ -1744,16 +1731,6 @@ fn parse_impl<R: Read>(
     let mut parser = create_parser(r, &parser_options);
 
     tracing::debug!(target: trace_categories::PARSE, "Parsing reader as program...");
-    parser.parse_program()
-}
-
-fn parse_bytes_impl(
-    b: &[u8],
-    parser_options: brush_parser::ParserOptions,
-) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
-    let mut parser = create_parser(b, &parser_options);
-
-    tracing::debug!(target: trace_categories::PARSE, "Parsing bytes as program...");
     parser.parse_program()
 }
 


### PR DESCRIPTION
This allows reading input scripts from bytes, in addition to the existing string functionality.