### PR TITLE
fix(typeset): mark typeset as a declaration builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you feel so inclined, we'd love contributions toward any of the above, with b
 
 ## 🧪 Testing strategy
 
-This project is primarily tested by comparing its behavior with other existing shells, leveraging the latter as test oracles. The integration tests implemented in this repo include [600+ test cases](brush-shell/tests/cases) run on both this shell and an oracle, comparing standard output and exit codes.
+This project is primarily tested by comparing its behavior with other existing shells, leveraging the latter as test oracles. The integration tests implemented in this repo include [620+ test cases](brush-shell/tests/cases) run on both this shell and an oracle, comparing standard output and exit codes.
 
 For more details, please consult the [reference documentation on integration testing](docs/reference/integration-testing.md).
 

--- a/brush-core/src/builtins/factory.rs
+++ b/brush-core/src/builtins/factory.rs
@@ -290,7 +290,7 @@ pub(crate) fn get_default_builtins(
         m.insert("suspend".into(), builtin::<suspend::SuspendCommand>());
         m.insert("test".into(), builtin::<test::TestCommand>());
         m.insert("[".into(), builtin::<test::TestCommand>());
-        m.insert("typeset".into(), builtin::<declare::DeclareCommand>());
+        m.insert("typeset".into(), decl_builtin::<declare::DeclareCommand>());
 
         // Completion builtins
         m.insert("complete".into(), builtin::<complete::CompleteCommand>());

--- a/brush-shell/tests/cases/builtins/typeset.yaml
+++ b/brush-shell/tests/cases/builtins/typeset.yaml
@@ -1,0 +1,10 @@
+name: "Builtins: typeset"
+
+cases:
+  - name: "Display vars"
+    stdin: |
+      typeset myvar=something
+      typeset -p myvar
+
+      typeset myarr=(a b c)
+      typeset -p myarr


### PR DESCRIPTION
`typeset` is a full synonym of `declare`, but it wasn't being correctly registered as a builtin that can take complex declarations.

This fixes the registration and at least adds a "lights on" compat test for it.