### PR TITLE
fix(tokenizer): correctly treat $( (...) ) as a cmd substitution

### DIFF
--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -61,6 +61,11 @@ cases:
       x=$(echo foo | (wc -l; echo hi))
       echo "\$x: $x"
 
+  - name: "Command substitution with subshell"
+    stdin: |
+      x=$( (echo hi) )
+      echo "\$x: $x"
+
   - name: "Command substitution exit code"
     stdin: |
       x=$(false) && echo "1. Made it past false"


### PR DESCRIPTION
While running the `bash` test suite, we identified that `brush`'s tokenization process was causing `$( (...) )` to be treated as an arithmetic expression (incorrect) instead of a command substitution with a nested subshell (correct).

This change adds a targeted fix that lets parsing of a command substitution preserve the whitespace in its body during tokenization.