### PR TITLE
fix(trace): send trace output to correct stderr

### DIFF
--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -91,7 +91,7 @@ pub(crate) async fn expand_and_eval(
     // Trace if applicable.
     if trace_if_needed && shell.options.print_commands_and_arguments {
         shell
-            .trace_command(std::format!("(( {expr} ))"))
+            .trace_command(params, std::format!("(( {expr} ))"))
             .await
             .map_err(|_err| EvalError::TraceError)?;
     }

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -55,10 +55,13 @@ async fn apply_unary_predicate(
 
     if shell.options.print_commands_and_arguments {
         shell
-            .trace_command(std::format!(
-                "[[ {op} {} ]]",
-                escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
-            ))
+            .trace_command(
+                params,
+                std::format!(
+                    "[[ {op} {} ]]",
+                    escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
+                ),
+            )
             .await?;
     }
 
@@ -206,7 +209,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {s} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {s} {op} {right} ]]"))
                     .await?;
             }
 
@@ -245,7 +248,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -257,7 +260,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -269,7 +272,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {s} {op} {substring} ]]"))
+                    .trace_command(params, std::format!("[[ {s} {op} {substring} ]]"))
                     .await?;
             }
 
@@ -281,7 +284,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -302,7 +305,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -323,7 +326,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -344,7 +347,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -357,7 +360,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -372,7 +375,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -386,7 +389,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -400,7 +403,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -414,7 +417,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -428,7 +431,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -442,7 +445,7 @@ async fn apply_binary_predicate(
 
             if shell.options.print_commands_and_arguments {
                 shell
-                    .trace_command(std::format!("[[ {left} {op} {right} ]]"))
+                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
             }
 
@@ -466,7 +469,7 @@ async fn apply_binary_predicate(
                     escape::QuoteMode::BackslashEscape,
                 );
                 shell
-                    .trace_command(std::format!("[[ {s} {op} {escaped_right} ]]"))
+                    .trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
                     .await?;
             }
 
@@ -486,7 +489,7 @@ async fn apply_binary_predicate(
                     escape::QuoteMode::BackslashEscape,
                 );
                 shell
-                    .trace_command(std::format!("[[ {s} {op} {escaped_right} ]]"))
+                    .trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
                     .await?;
             }
 

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -624,15 +624,18 @@ impl Execute for ast::ForClauseCommand {
             if shell.options.print_commands_and_arguments {
                 if let Some(unexpanded_values) = &self.values {
                     shell
-                        .trace_command(std::format!(
-                            "for {} in {}",
-                            self.variable_name,
-                            unexpanded_values.iter().join(" ")
-                        ))
+                        .trace_command(
+                            params,
+                            std::format!(
+                                "for {} in {}",
+                                self.variable_name,
+                                unexpanded_values.iter().join(" ")
+                            ),
+                        )
                         .await?;
                 } else {
                     shell
-                        .trace_command(std::format!("for {}", self.variable_name,))
+                        .trace_command(params, std::format!("for {}", self.variable_name,))
                         .await?;
                 }
             }
@@ -685,7 +688,7 @@ impl Execute for ast::CaseClauseCommand {
         // on, but that's not it.
         if shell.options.print_commands_and_arguments {
             shell
-                .trace_command(std::format!("case {} in", &self.value))
+                .trace_command(params, std::format!("case {} in", &self.value))
                 .await?;
         }
 
@@ -1010,8 +1013,9 @@ impl ExecuteInPipeline for ast::SimpleCommand {
                             if let Some(alias_value) = context.shell.aliases.get(cmd_name.as_str())
                             {
                                 //
-                                // TODO(#57): This is a total hack; aliases are supposed to be handled
-                                // much earlier in the process.
+                                // TODO(#57): This is a total hack; aliases are supposed to be
+                                // handled much earlier in the
+                                // process.
                                 //
                                 let mut alias_pieces: Vec<_> = alias_value
                                     .split_ascii_whitespace()
@@ -1101,7 +1105,10 @@ async fn execute_command(
     if context.shell.options.print_commands_and_arguments {
         context
             .shell
-            .trace_command(args.iter().map(|arg| arg.quote_for_tracing()).join(" "))
+            .trace_command(
+                &params,
+                args.iter().map(|arg| arg.quote_for_tracing()).join(" "),
+            )
             .await?;
     }
 
@@ -1299,7 +1306,7 @@ async fn apply_assignment(
     if shell.options.print_commands_and_arguments {
         let op = if assignment.append { "+=" } else { "=" };
         shell
-            .trace_command(std::format!("{}{op}{new_value}", assignment.name))
+            .trace_command(params, std::format!("{}{op}{new_value}", assignment.name))
             .await?;
     }
 

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1612,9 +1612,11 @@ impl Shell {
     ///
     /// # Arguments
     ///
+    /// * `params` - Execution parameters.
     /// * `command` - The command to trace.
     pub(crate) async fn trace_command<S: AsRef<str>>(
         &mut self,
+        params: &ExecutionParameters,
         command: S,
     ) -> Result<(), error::Error> {
         let ps4 = self.as_mut().expand_prompt_var("PS4", "").await?;
@@ -1628,7 +1630,7 @@ impl Shell {
             }
         }
 
-        writeln!(self.stderr(), "{prefix}{}", command.as_ref())?;
+        writeln!(params.stderr(), "{prefix}{}", command.as_ref())?;
         Ok(())
     }
 

--- a/brush-shell/tests/cases/options.yaml
+++ b/brush-shell/tests/cases/options.yaml
@@ -104,3 +104,20 @@ cases:
       ((x = 3)) || ((x = 4))
 
       override=value echo some_output
+
+  - name: "set -x with redirection"
+    stdin: |
+      set -x
+
+      echo "This is a test" >output.txt 2>&1
+
+      exec >output2.txt 2>&1
+
+      echo "This is another test"
+
+  - name: "set -x with sourced script"
+    stdin: |
+      set -x
+
+      echo 'echo hi' >script.sh
+      source script.sh >output.txt 2>&1


### PR DESCRIPTION
In some redirection cases, the open files in `ExecutionParameters` may not match those in `Shell`; tracing should be sent through `ExecutionParameters::stderr()` and not `Shell::stderr()`.