### PR TITLE
fix(backquote): correct backslash handling

### DIFF
--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -859,9 +859,10 @@ peg::parser! {
         rule backquoted_command() -> String =
             chars:(backquoted_char()*) { chars.into_iter().collect() }
 
-        rule backquoted_char() -> char =
-            "\\`" { '`' } /
-            [^'`']
+        rule backquoted_char() -> &'input str =
+            "\\`" { "`" } /
+            "\\\\" { "\\\\" } /
+            s:$([^'`']) { s }
 
         rule arithmetic_expansion() -> WordPiece =
             "$((" e:$(arithmetic_word(<"))">)) "))" { WordPiece::ArithmeticExpression(ast::UnexpandedArithmeticExpr { value: e.to_owned() } ) }

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -85,6 +85,10 @@ cases:
     stdin: |
       echo `echo \`echo hi\``
 
+  - name: "Backtick command substitution with backslashes"
+    stdin: |
+      echo `echo \\`
+
   - name: "Backtick command substitution in double quotes"
     stdin: |
       echo "`echo First line`"


### PR DESCRIPTION
Ensure that a trailing backslash in a backquoted command substitution is correctly handled.