### PR TITLE
feat: enable cargo-binstall to work with brush

### DIFF
--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -11,6 +11,9 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/brush-{ target }{ archive-suffix }"
+
 [[bin]]
 name = "brush"
 path = "src/main.rs"


### PR DESCRIPTION
Adds metadata to `Cargo.toml` that will allow `cargo-binstall` to find the officially released binaries for `brush`.