### PR TITLE
fix(interactive): fix behavior of cmds piped to stdin

### DIFF
--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -1,5 +1,5 @@
 use crate::ShellError;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 
 /// Result of a read operation.
 pub enum ReadResult {
@@ -71,8 +71,10 @@ pub trait InteractiveShell: Send {
         &mut self,
     ) -> impl std::future::Future<Output = Result<(), ShellError>> + Send {
         async {
-            // TODO: Consider finding a better place for this.
-            let _ = brush_core::TerminalControl::acquire()?;
+            // Acquire terminal control if stdin is a terminal.
+            if std::io::stdin().is_terminal() {
+                brush_core::TerminalControl::acquire()?;
+            }
 
             let mut announce_exit = self.shell().as_ref().options.interactive;
 

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -21,7 +21,7 @@ const VERSION: &str = const_format::concatcp!(
 );
 
 /// Identifies the input backend to use for the shell.
-#[derive(Clone, clap::ValueEnum)]
+#[derive(Clone, Copy, clap::ValueEnum)]
 pub enum InputBackend {
     /// Richest input backend, based on reedline.
     Reedline,
@@ -159,18 +159,23 @@ pub struct CommandLineArgs {
 impl CommandLineArgs {
     /// Returns whether or not the arguments indicate that the shell should run in interactive mode.
     pub fn is_interactive(&self) -> bool {
+        // If -i is provided, then that overrides any further consideration; it forces
+        // interactive mode.
         if self.interactive {
             return true;
         }
 
+        // If -c or non-option arguments are provided, then we're not in interactive mode.
         if self.command.is_some() || self.script_path.is_some() {
             return false;
         }
 
+        // If *either* stdin or stderr is not a terminal, then we're not in interactive mode.
         if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
             return false;
         }
 
+        // In all other cases, we assume interactive mode.
         true
     }
 }

--- a/brush-shell/tests/cases/basic.yaml
+++ b/brush-shell/tests/cases/basic.yaml
@@ -13,6 +13,29 @@ cases:
     stdin: |
       echo 'hi'; echo 'there'
 
+  - name: "Basic -s usage with -c"
+    args: ["-s", "-c", "echo hi1 hi2"]
+    stdin: |
+      [[ $(type -P $0) == $(type -P $BASH) ]] && echo '$0 matches $BASH'
+      echo "\$1: $1"
+      echo "\$2: $2"
+      echo "\$3: $3"
+
+  - name: "Basic -s usage with positional args"
+    args: ["-s", "arg1", "arg2", "arg3"]
+    stdin: |
+      [[ $(type -P $0) == $(type -P $BASH) ]] && echo '$0 matches $BASH'
+      echo "\$1: $1"
+      echo "\$2: $2"
+      echo "\$3: $3"
+
+  - name: "Basic -i usage with commands via stdin"
+    skip: true # Needs investigation
+    args: ["-i"]
+    stdin: |
+      echo hi
+      echo there
+
   - name: "Basic script execution"
     test_files:
       - path: "script.sh"


### PR DESCRIPTION
This addresses the issues we're seeing when commands are piped into `brush`'s `stdin`. 

Note: this is incremental progress. There are still some issues with how `-i` interacts and we need to ensure we find a reasonable approach to getting back some of the coverage of the reedline impl of `InteractiveShell` that will be lost with this change. We also need to add variants of some of the "basic" tests running with `stdin` being a terminal (say, via pty). We'll sort those out in subsequent PRs.

Resolves #538 