### PR TITLE
ci: run cd workflow in dry-run mode on PR

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,8 +7,14 @@ name: CD # Continuous Deployment
 on:
   release:
     types: [published]
+
   # Manual triggers don't actually publish but dry-run the builds.
   workflow_dispatch: null
+
+  # Run on PR in dry-run mode to make sure this workflow is still generally
+  # working.
+  pull_request:
+    branches: ["main"]
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Run through the CD release workflow in "dry run" mode as part of PR validation. It increases the likelihood we'd catch release issues earlier in the flow.