### PR TITLE
test(parser): start using insta crate for snapshot-testing parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "pprof",
  "pretty_assertions",
  "serde",
+ "serde_yaml",
  "thiserror 2.0.12",
  "tracing",
  "utf8-chars",
@@ -1376,10 +1377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
+ "globset",
  "once_cell",
  "ron",
  "serde",
  "similar",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,12 +178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,7 +332,6 @@ version = "0.2.16"
 dependencies = [
  "anyhow",
  "arbitrary",
- "assert_matches",
  "cached",
  "criterion",
  "indenter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +342,7 @@ dependencies = [
  "cached",
  "criterion",
  "indenter",
+ "insta",
  "peg",
  "pprof",
  "pretty_assertions",
@@ -609,6 +616,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72b06487a0d4683349ad74d62e87ad639b09667082b3c495c5b6bab7d84b3da"
 dependencies = [
  "windows 0.44.0",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -912,6 +931,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equator"
@@ -1342,6 +1367,19 @@ dependencies = [
  "quick-xml 0.26.0",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "ron",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -2115,6 +2153,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64",
+ "bitflags 1.3.2",
+ "serde",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2320,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -32,7 +32,6 @@ utf8-chars = "3.0.5"
 
 [dev-dependencies]
 anyhow = "1.0.98"
-assert_matches = "1.5.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 insta = { version = "1.43.1", features = ["glob", "ron", "yaml"] }
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -34,9 +34,10 @@ utf8-chars = "3.0.5"
 anyhow = "1.0.98"
 assert_matches = "1.5.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }
-insta = { version = "1.43.1", features = ["ron"] }
+insta = { version = "1.43.1", features = ["glob", "ron", "yaml"] }
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 serde = { version = "1.0.219", features = ["derive"] }
+serde_yaml = "0.9.34"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.15.0", features = ["criterion", "flamegraph"] }

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -34,6 +34,7 @@ utf8-chars = "3.0.5"
 anyhow = "1.0.98"
 assert_matches = "1.5.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+insta = { version = "1.43.1", features = ["ron"] }
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 serde = { version = "1.0.219", features = ["derive"] }
 

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -13,6 +13,7 @@ const DISPLAY_INDENT: &str = "    ";
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
 pub struct Program {
     /// A sequence of complete shell commands.
+    #[cfg_attr(test, serde(rename = "cmds"))]
     pub complete_commands: Vec<CompleteCommand>,
 }
 
@@ -55,10 +56,12 @@ impl Display for SeparatorOperator {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "AndOr"))]
 pub struct AndOrList {
     /// The first command pipeline.
     pub first: Pipeline,
     /// Any additional command pipelines, in sequence order.
+    #[cfg_attr(test, serde(skip_serializing_if = "Vec::is_empty"))]
     pub additional: Vec<AndOr>,
 }
 
@@ -193,9 +196,11 @@ pub enum PipelineTimed {
 pub struct Pipeline {
     /// Indicates whether the pipeline's execution should be timed with reported
     /// timings in output.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub timed: Option<PipelineTimed>,
     /// Indicates whether the result of the overall pipeline should be the logical
     /// negation of the result of the pipeline.
+    #[cfg_attr(test, serde(skip_serializing_if = "<&bool as std::ops::Not>::not"))]
     pub bang: bool,
     /// The sequence of commands in the pipeline.
     pub seq: Vec<Command>,
@@ -434,6 +439,7 @@ impl Display for CaseClauseCommand {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "List"))]
 pub struct CompoundList(pub Vec<CompoundListItem>);
 
 impl Display for CompoundList {
@@ -462,6 +468,7 @@ impl Display for CompoundList {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "Item"))]
 pub struct CompoundListItem(pub AndOrList, pub SeparatorOperator);
 
 impl Display for CompoundListItem {
@@ -482,6 +489,7 @@ pub struct IfClauseCommand {
     /// The command to execute if the condition is true.
     pub then: CompoundList,
     /// Optionally, `else` clauses that will be evaluated if the condition is false.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub elses: Option<Vec<ElseClause>>,
 }
 
@@ -512,6 +520,7 @@ impl Display for IfClauseCommand {
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
 pub struct ElseClause {
     /// If present, the condition that must be met for this `else` clause to be executed.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub condition: Option<CompoundList>,
     /// The commands to execute if this `else` clause is selected.
     pub body: CompoundList,
@@ -677,12 +686,17 @@ impl Display for DoGroupCommand {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "Simple"))]
 pub struct SimpleCommand {
     /// Optionally, a prefix to the command.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub prefix: Option<CommandPrefix>,
     /// The name of the command to execute.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(test, serde(rename = "w"))]
     pub word_or_name: Option<Word>,
     /// Optionally, a suffix to the command.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub suffix: Option<CommandSuffix>,
 }
 
@@ -724,6 +738,7 @@ impl Display for SimpleCommand {
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "Prefix"))]
 pub struct CommandPrefix(pub Vec<CommandPrefixOrSuffixItem>);
 
 impl Display for CommandPrefix {
@@ -743,6 +758,7 @@ impl Display for CommandPrefix {
 #[derive(Clone, Default, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "Suffix"))]
 pub struct CommandSuffix(pub Vec<CommandPrefixOrSuffixItem>);
 
 impl Display for CommandSuffix {
@@ -788,6 +804,7 @@ pub enum CommandPrefixOrSuffixItem {
     /// A word.
     Word(Word),
     /// An assignment/declaration word.
+    #[cfg_attr(test, serde(rename = "Assign"))]
     AssignmentWord(Assignment, Word),
     /// A process substitution.
     ProcessSubstitution(ProcessSubstitutionKind, SubshellCommand),
@@ -810,12 +827,14 @@ impl Display for CommandPrefixOrSuffixItem {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "Assign"))]
 pub struct Assignment {
     /// Name being assigned to.
     pub name: AssignmentName,
     /// Value being assigned.
     pub value: AssignmentValue,
     /// Whether or not to append to the preexisting value associated with the named variable.
+    #[cfg_attr(test, serde(skip_serializing_if = "<&bool as std::ops::Not>::not"))]
     pub append: bool,
 }
 
@@ -835,6 +854,7 @@ impl Display for Assignment {
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
 pub enum AssignmentName {
     /// A named variable.
+    #[cfg_attr(test, serde(rename = "Var"))]
     VariableName(String),
     /// An element in a named array.
     ArrayElementName(String, String),
@@ -1033,8 +1053,10 @@ impl Display for IoFileRedirectTarget {
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
 pub struct IoHereDocument {
     /// Whether to remove leading tabs from the here document.
+    #[cfg_attr(test, serde(skip_serializing_if = "<&bool as std::ops::Not>::not"))]
     pub remove_tabs: bool,
     /// Whether to basic-expand the contents of the here document.
+    #[cfg_attr(test, serde(skip_serializing_if = "<&bool as std::ops::Not>::not"))]
     pub requires_expansion: bool,
     /// The delimiter marking the end of the here document.
     pub here_end: Word,
@@ -1281,8 +1303,10 @@ impl Display for BinaryPredicate {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, derive(PartialEq, Eq, serde::Serialize))]
+#[cfg_attr(test, serde(rename = "W"))]
 pub struct Word {
     /// Raw text of the word.
+    #[cfg_attr(test, serde(rename = "v"))]
     pub value: String,
 }
 

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -14,6 +14,9 @@ mod error;
 mod parser;
 mod tokenizer;
 
+#[cfg(test)]
+mod snapshot_tests;
+
 pub use error::{BindingParseError, ParseError, TestCommandParseError, WordParseError};
 pub use parser::{parse_tokens, Parser, ParserOptions, SourceInfo};
 pub use tokenizer::{

--- a/brush-parser/src/snapshot_tests.rs
+++ b/brush-parser/src/snapshot_tests.rs
@@ -1,0 +1,128 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct TestCaseSet {
+    /// Name of the test case set
+    pub name: Option<String>,
+    /// Set of test cases
+    pub cases: Vec<TestCase>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct TestCase {
+    /// Name of the test case
+    pub name: Option<String>,
+    #[serde(default)]
+    pub stdin: Option<String>,
+}
+
+#[test]
+#[ignore = "not yet ready for default-enablement"]
+fn test_parser_using_yaml_test_cases() {
+    insta::glob!("../../brush-shell", "tests/cases/**/*.yaml", |path| {
+        test_parser_using_yaml(path).unwrap();
+    });
+}
+
+fn test_parser_using_yaml(path: &Path) -> Result<()> {
+    let yaml_file = std::fs::File::open(path)?;
+    let test_case_set: TestCaseSet = serde_yaml::from_reader(yaml_file)
+        .context(format!("parsing {}", path.to_string_lossy()))?;
+
+    test_parser_using_test_case_set(&test_case_set);
+
+    Ok(())
+}
+
+fn test_parser_using_test_case_set(test_case_set: &TestCaseSet) {
+    let name = test_case_set.name.as_deref().unwrap_or_default();
+
+    for test_case in &test_case_set.cases {
+        parse(name, test_case);
+    }
+}
+
+// NOTE: The name of this function affects the name of the snapshot generated.
+fn parse(test_case_set_name: &str, test_case: &TestCase) {
+    #[derive(serde::Serialize)]
+    struct TestCaseInfo {
+        test_case_set: String,
+        test_case: String,
+    }
+
+    let name = test_case.name.as_deref().unwrap_or_default();
+    let script_content = test_case.stdin.as_deref().unwrap_or_default();
+
+    if script_content.is_empty() {
+        return;
+    }
+
+    let summary = parse_script_content(script_content);
+
+    let info = TestCaseInfo {
+        test_case_set: test_case_set_name.to_string(),
+        test_case: name.to_string(),
+    };
+
+    // Generate a cleaned-up name.
+    let snapshot_suffix = std::format!("{test_case_set_name}-{name}")
+        .to_lowercase()
+        .replace(' ', "_")
+        .replace(|c: char| !c.is_ascii_alphanumeric(), "_");
+
+    insta::with_settings!({
+        info => &info,
+        prepend_module_to_snapshot => false,
+        omit_expression => true,
+        snapshot_suffix => snapshot_suffix,
+    }, {
+        insta::assert_ron_snapshot!(summary);
+    });
+}
+
+#[cfg_attr(test, derive(serde::Serialize))]
+struct ParseSummary<'a> {
+    input: Vec<&'a str>,
+    result: ParseResult,
+}
+
+#[cfg_attr(test, derive(serde::Serialize))]
+enum ParseResult {
+    Success(crate::ast::Program),
+    Failure(String),
+}
+
+fn parse_script_content(s: &str) -> ParseSummary<'_> {
+    let input_lines: Vec<_> = s.lines().collect();
+
+    let tokens = match crate::tokenize_str_with_options(s, &crate::TokenizerOptions::default()) {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            return ParseSummary {
+                input: input_lines,
+                result: ParseResult::Failure(err.to_string()),
+            }
+        }
+    };
+
+    let parsed_program = match crate::parse_tokens(
+        &tokens,
+        &crate::ParserOptions::default(),
+        &crate::SourceInfo::default(),
+    ) {
+        Ok(parsed_program) => parsed_program,
+        Err(err) => {
+            return ParseSummary {
+                input: input_lines,
+                result: ParseResult::Failure(err.to_string()),
+            }
+        }
+    };
+
+    ParseSummary {
+        input: input_lines,
+        result: ParseResult::Success(parsed_program),
+    }
+}

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case.snap
@@ -1,0 +1,44 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &command }"
+---
+ParseResult(
+  input: "\\\ncase x in\nx)\n    echo y;;\nesac\\\n",
+  result: CaseClauseCommand(
+    value: Word(
+      value: "x",
+    ),
+    cases: [
+      CaseItem(
+        patterns: [
+          Word(
+            value: "x",
+          ),
+        ],
+        cmd: Some(CompoundList([
+          CompoundListItem(AndOrList(
+            first: Pipeline(
+              timed: None,
+              bang: false,
+              seq: [
+                Simple(SimpleCommand(
+                  prefix: None,
+                  word_or_name: Some(Word(
+                    value: "echo",
+                  )),
+                  suffix: Some(CommandSuffix([
+                    Word(Word(
+                      value: "y",
+                    )),
+                  ])),
+                )),
+              ],
+            ),
+            additional: [],
+          ), Sequence),
+        ])),
+        post_action: ExitCase,
+      ),
+    ],
+  ),
+)

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case.snap
@@ -5,36 +5,32 @@ expression: "ParseResult { input, result: &command }"
 ParseResult(
   input: "\\\ncase x in\nx)\n    echo y;;\nesac\\\n",
   result: CaseClauseCommand(
-    value: Word(
-      value: "x",
+    value: W(
+      v: "x",
     ),
     cases: [
       CaseItem(
         patterns: [
-          Word(
-            value: "x",
+          W(
+            v: "x",
           ),
         ],
-        cmd: Some(CompoundList([
-          CompoundListItem(AndOrList(
+        cmd: Some(List([
+          Item(AndOr(
             first: Pipeline(
-              timed: None,
-              bang: false,
               seq: [
-                Simple(SimpleCommand(
-                  prefix: None,
-                  word_or_name: Some(Word(
-                    value: "echo",
+                Simple(Simple(
+                  w: Some(W(
+                    v: "echo",
                   )),
-                  suffix: Some(CommandSuffix([
-                    Word(Word(
-                      value: "y",
+                  suffix: Some(Suffix([
+                    Word(W(
+                      v: "y",
                     )),
                   ])),
                 )),
               ],
             ),
-            additional: [],
           ), Sequence),
         ])),
         post_action: ExitCase,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case_ns.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case_ns.snap
@@ -5,36 +5,32 @@ expression: "ParseResult { input, result: &command }"
 ParseResult(
   input: "\\\ncase x in\nx)\n    echo y\nesac\\\n",
   result: CaseClauseCommand(
-    value: Word(
-      value: "x",
+    value: W(
+      v: "x",
     ),
     cases: [
       CaseItem(
         patterns: [
-          Word(
-            value: "x",
+          W(
+            v: "x",
           ),
         ],
-        cmd: Some(CompoundList([
-          CompoundListItem(AndOrList(
+        cmd: Some(List([
+          Item(AndOr(
             first: Pipeline(
-              timed: None,
-              bang: false,
               seq: [
-                Simple(SimpleCommand(
-                  prefix: None,
-                  word_or_name: Some(Word(
-                    value: "echo",
+                Simple(Simple(
+                  w: Some(W(
+                    v: "echo",
                   )),
-                  suffix: Some(CommandSuffix([
-                    Word(Word(
-                      value: "y",
+                  suffix: Some(Suffix([
+                    Word(W(
+                      v: "y",
                     )),
                   ])),
                 )),
               ],
             ),
-            additional: [],
           ), Sequence),
         ])),
         post_action: ExitCase,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case_ns.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case_ns.snap
@@ -1,0 +1,44 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &command }"
+---
+ParseResult(
+  input: "\\\ncase x in\nx)\n    echo y\nesac\\\n",
+  result: CaseClauseCommand(
+    value: Word(
+      value: "x",
+    ),
+    cases: [
+      CaseItem(
+        patterns: [
+          Word(
+            value: "x",
+          ),
+        ],
+        cmd: Some(CompoundList([
+          CompoundListItem(AndOrList(
+            first: Pipeline(
+              timed: None,
+              bang: false,
+              seq: [
+                Simple(SimpleCommand(
+                  prefix: None,
+                  word_or_name: Some(Word(
+                    value: "echo",
+                  )),
+                  suffix: Some(CommandSuffix([
+                    Word(Word(
+                      value: "y",
+                    )),
+                  ])),
+                )),
+              ],
+            ),
+            additional: [],
+          ), Sequence),
+        ])),
+        post_action: ExitCase,
+      ),
+    ],
+  ),
+)

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection-2.snap
@@ -7,38 +7,32 @@ ParseResult(
   result: [
     Function(FunctionDefinition(
       fname: "foo",
-      body: FunctionBody(BraceGroup(BraceGroupCommand(CompoundList([
-        CompoundListItem(AndOrList(
+      body: FunctionBody(BraceGroup(BraceGroupCommand(List([
+        Item(AndOr(
           first: Pipeline(
-            timed: None,
-            bang: false,
             seq: [
-              Simple(SimpleCommand(
-                prefix: None,
-                word_or_name: Some(Word(
-                  value: "echo",
+              Simple(Simple(
+                w: Some(W(
+                  v: "echo",
                 )),
-                suffix: Some(CommandSuffix([
-                  Word(Word(
-                    value: "1",
+                suffix: Some(Suffix([
+                  Word(W(
+                    v: "1",
                   )),
                 ])),
               )),
             ],
           ),
-          additional: [],
         ), Sequence),
       ]))), Some(RedirectList([
         File(Some(2), DuplicateOutput, Fd(1)),
       ]))),
       source: "",
     )),
-    Simple(SimpleCommand(
-      prefix: None,
-      word_or_name: Some(Word(
-        value: "cat",
+    Simple(Simple(
+      w: Some(W(
+        v: "cat",
       )),
-      suffix: None,
     )),
   ],
 )

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection-2.snap
@@ -1,0 +1,44 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &seq }"
+---
+ParseResult(
+  input: "foo() { echo 1; } |& cat",
+  result: [
+    Function(FunctionDefinition(
+      fname: "foo",
+      body: FunctionBody(BraceGroup(BraceGroupCommand(CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            timed: None,
+            bang: false,
+            seq: [
+              Simple(SimpleCommand(
+                prefix: None,
+                word_or_name: Some(Word(
+                  value: "echo",
+                )),
+                suffix: Some(CommandSuffix([
+                  Word(Word(
+                    value: "1",
+                  )),
+                ])),
+              )),
+            ],
+          ),
+          additional: [],
+        ), Sequence),
+      ]))), Some(RedirectList([
+        File(Some(2), DuplicateOutput, Fd(1)),
+      ]))),
+      source: "",
+    )),
+    Simple(SimpleCommand(
+      prefix: None,
+      word_or_name: Some(Word(
+        value: "cat",
+      )),
+      suffix: None,
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
@@ -7,38 +7,32 @@ ParseResult(
   result: [
     Function(FunctionDefinition(
       fname: "foo",
-      body: FunctionBody(BraceGroup(BraceGroupCommand(CompoundList([
-        CompoundListItem(AndOrList(
+      body: FunctionBody(BraceGroup(BraceGroupCommand(List([
+        Item(AndOr(
           first: Pipeline(
-            timed: None,
-            bang: false,
             seq: [
-              Simple(SimpleCommand(
-                prefix: None,
-                word_or_name: Some(Word(
-                  value: "echo",
+              Simple(Simple(
+                w: Some(W(
+                  v: "echo",
                 )),
-                suffix: Some(CommandSuffix([
-                  Word(Word(
-                    value: "1",
+                suffix: Some(Suffix([
+                  Word(W(
+                    v: "1",
                   )),
                 ])),
               )),
             ],
           ),
-          additional: [],
         ), Sequence),
       ]))), Some(RedirectList([
         File(Some(2), DuplicateOutput, Fd(1)),
       ]))),
       source: "",
     )),
-    Simple(SimpleCommand(
-      prefix: None,
-      word_or_name: Some(Word(
-        value: "cat",
+    Simple(Simple(
+      w: Some(W(
+        v: "cat",
       )),
-      suffix: None,
     )),
   ],
 )

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
@@ -1,0 +1,44 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &seq }"
+---
+ParseResult(
+  input: "foo() { echo 1; } 2>&1 | cat",
+  result: [
+    Function(FunctionDefinition(
+      fname: "foo",
+      body: FunctionBody(BraceGroup(BraceGroupCommand(CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            timed: None,
+            bang: false,
+            seq: [
+              Simple(SimpleCommand(
+                prefix: None,
+                word_or_name: Some(Word(
+                  value: "echo",
+                )),
+                suffix: Some(CommandSuffix([
+                  Word(Word(
+                    value: "1",
+                  )),
+                ])),
+              )),
+            ],
+          ),
+          additional: [],
+        ), Sequence),
+      ]))), Some(RedirectList([
+        File(Some(2), DuplicateOutput, Fd(1)),
+      ]))),
+      source: "",
+    )),
+    Simple(SimpleCommand(
+      prefix: None,
+      word_or_name: Some(Word(
+        value: "cat",
+      )),
+      suffix: None,
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
@@ -5,53 +5,46 @@ expression: "ParseResult { input, result: &result }"
 ParseResult(
   input: "\n\n#!/usr/bin/env bash\n\nfor f in A B C; do\n\n    # sdfsdf\n    echo \"${f@L}\" >&2\n\n   done\n\n",
   result: Program(
-    complete_commands: [
-      CompoundList([
-        CompoundListItem(AndOrList(
+    cmds: [
+      List([
+        Item(AndOr(
           first: Pipeline(
-            timed: None,
-            bang: false,
             seq: [
               Compound(ForClause(ForClauseCommand(
                 variable_name: "f",
                 values: Some([
-                  Word(
-                    value: "A",
+                  W(
+                    v: "A",
                   ),
-                  Word(
-                    value: "B",
+                  W(
+                    v: "B",
                   ),
-                  Word(
-                    value: "C",
+                  W(
+                    v: "C",
                   ),
                 ]),
-                body: DoGroupCommand(CompoundList([
-                  CompoundListItem(AndOrList(
+                body: DoGroupCommand(List([
+                  Item(AndOr(
                     first: Pipeline(
-                      timed: None,
-                      bang: false,
                       seq: [
-                        Simple(SimpleCommand(
-                          prefix: None,
-                          word_or_name: Some(Word(
-                            value: "echo",
+                        Simple(Simple(
+                          w: Some(W(
+                            v: "echo",
                           )),
-                          suffix: Some(CommandSuffix([
-                            Word(Word(
-                              value: "\"${f@L}\"",
+                          suffix: Some(Suffix([
+                            Word(W(
+                              v: "\"${f@L}\"",
                             )),
                             IoRedirect(File(None, DuplicateOutput, Fd(2))),
                           ])),
                         )),
                       ],
                     ),
-                    additional: [],
                   ), Sequence),
                 ])),
               )), None),
             ],
           ),
-          additional: [],
         ), Sequence),
       ]),
     ],

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
@@ -1,0 +1,59 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "\n\n#!/usr/bin/env bash\n\nfor f in A B C; do\n\n    # sdfsdf\n    echo \"${f@L}\" >&2\n\n   done\n\n",
+  result: Program(
+    complete_commands: [
+      CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            timed: None,
+            bang: false,
+            seq: [
+              Compound(ForClause(ForClauseCommand(
+                variable_name: "f",
+                values: Some([
+                  Word(
+                    value: "A",
+                  ),
+                  Word(
+                    value: "B",
+                  ),
+                  Word(
+                    value: "C",
+                  ),
+                ]),
+                body: DoGroupCommand(CompoundList([
+                  CompoundListItem(AndOrList(
+                    first: Pipeline(
+                      timed: None,
+                      bang: false,
+                      seq: [
+                        Simple(SimpleCommand(
+                          prefix: None,
+                          word_or_name: Some(Word(
+                            value: "echo",
+                          )),
+                          suffix: Some(CommandSuffix([
+                            Word(Word(
+                              value: "\"${f@L}\"",
+                            )),
+                            IoRedirect(File(None, DuplicateOutput, Fd(2))),
+                          ])),
+                        )),
+                      ],
+                    ),
+                    additional: [],
+                  ), Sequence),
+                ])),
+              )), None),
+            ],
+          ),
+          additional: [],
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_redirection.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_redirection.snap
@@ -5,21 +5,18 @@ expression: "ParseResult { input, result: &seq }"
 ParseResult(
   input: "echo |& wc",
   result: [
-    Simple(SimpleCommand(
-      prefix: None,
-      word_or_name: Some(Word(
-        value: "echo",
+    Simple(Simple(
+      w: Some(W(
+        v: "echo",
       )),
-      suffix: Some(CommandSuffix([
+      suffix: Some(Suffix([
         IoRedirect(File(Some(2), DuplicateOutput, Fd(1))),
       ])),
     )),
-    Simple(SimpleCommand(
-      prefix: None,
-      word_or_name: Some(Word(
-        value: "wc",
+    Simple(Simple(
+      w: Some(W(
+        v: "wc",
       )),
-      suffix: None,
     )),
   ],
 )

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_redirection.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_redirection.snap
@@ -1,0 +1,25 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &seq }"
+---
+ParseResult(
+  input: "echo |& wc",
+  result: [
+    Simple(SimpleCommand(
+      prefix: None,
+      word_or_name: Some(Word(
+        value: "echo",
+      )),
+      suffix: Some(CommandSuffix([
+        IoRedirect(File(Some(2), DuplicateOutput, Fd(1))),
+      ])),
+    )),
+    Simple(SimpleCommand(
+      prefix: None,
+      word_or_name: Some(Word(
+        value: "wc",
+      )),
+      suffix: None,
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_arithmetic_expansion.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_arithmetic_expansion.snap
@@ -1,0 +1,16 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"$((0))\")?"
+---
+ParseTestResults(
+  input: "$((0))",
+  result: [
+    WordPieceWithSource(
+      piece: ArithmeticExpression(UnexpandedArithmeticExpr(
+        value: "0",
+      )),
+      start_index: 0,
+      end_index: 6,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_arithmetic_expansion_with_parens.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_arithmetic_expansion_with_parens.snap
@@ -1,0 +1,16 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"$((((1+2)*3)))\")?"
+---
+ParseTestResults(
+  input: "$((((1+2)*3)))",
+  result: [
+    WordPieceWithSource(
+      piece: ArithmeticExpression(UnexpandedArithmeticExpr(
+        value: "((1+2)*3)",
+      )),
+      start_index: 0,
+      end_index: 14,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_backquoted_command.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_backquoted_command.snap
@@ -1,0 +1,14 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"`echo hi`\")?"
+---
+ParseTestResults(
+  input: "`echo hi`",
+  result: [
+    WordPieceWithSource(
+      piece: BackquotedCommandSubstitution("echo hi"),
+      start_index: 0,
+      end_index: 9,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_backquoted_command_in_double_quotes.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_backquoted_command_in_double_quotes.snap
@@ -1,0 +1,20 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(r#\"\"`echo hi`\"\"#)?"
+---
+ParseTestResults(
+  input: "\"`echo hi`\"",
+  result: [
+    WordPieceWithSource(
+      piece: DoubleQuotedSequence([
+        WordPieceWithSource(
+          piece: BackquotedCommandSubstitution("echo hi"),
+          start_index: 1,
+          end_index: 10,
+        ),
+      ]),
+      start_index: 0,
+      end_index: 11,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_substitution.snap
@@ -1,0 +1,14 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"$(echo hi)\")?"
+---
+ParseTestResults(
+  input: "$(echo hi)",
+  result: [
+    WordPieceWithSource(
+      piece: CommandSubstitution("echo hi"),
+      start_index: 0,
+      end_index: 10,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_substitution_with_embedded_extglob.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_substitution_with_embedded_extglob.snap
@@ -1,0 +1,14 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"$(echo !(x))\")?"
+---
+ParseTestResults(
+  input: "$(echo !(x))",
+  result: [
+    WordPieceWithSource(
+      piece: CommandSubstitution("echo !(x)"),
+      start_index: 0,
+      end_index: 12,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_substitution_with_embedded_quotes.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_substitution_with_embedded_quotes.snap
@@ -1,0 +1,14 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(r#\"$(echo \"hi\")\"#)?"
+---
+ParseTestResults(
+  input: "$(echo \"hi\")",
+  result: [
+    WordPieceWithSource(
+      piece: CommandSubstitution("echo \"hi\""),
+      start_index: 0,
+      end_index: 12,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_extglob_with_embedded_parameter.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_extglob_with_embedded_parameter.snap
@@ -1,0 +1,27 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"+([$var])\")?"
+---
+ParseTestResults(
+  input: "+([$var])",
+  result: [
+    WordPieceWithSource(
+      piece: Text("+(["),
+      start_index: 0,
+      end_index: 3,
+    ),
+    WordPieceWithSource(
+      piece: ParameterExpansion(Parameter(
+        parameter: Named("var"),
+        indirect: false,
+      )),
+      start_index: 3,
+      end_index: 7,
+    ),
+    WordPieceWithSource(
+      piece: Text("])"),
+      start_index: 7,
+      end_index: 9,
+    ),
+  ],
+)

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -1275,7 +1275,6 @@ mod tests {
 
     use super::*;
     use anyhow::Result;
-    // use assert_matches::assert_matches;
     use pretty_assertions::{assert_eq, assert_matches};
 
     #[test]

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -1402,8 +1402,6 @@ struct TestOptions {
     #[clap(long = "test-cases-path", env = "BRUSH_COMPAT_TEST_CASES")]
     pub test_cases_path: Option<PathBuf>,
 
-    //
-    // Compat-only options
     /// Show output from test cases (for compatibility only, has no effect)
     #[clap(long = "show-output")]
     pub show_output: bool,
@@ -1411,6 +1409,10 @@ struct TestOptions {
     /// Capture output? (for compatibility only, has no effect)
     #[clap(long = "nocapture")]
     pub no_capture: bool,
+
+    /// Colorize output? (for compatibility only, has no effect)
+    #[clap(long = "color", default_value_t = clap::ColorChoice::Auto)]
+    pub color: clap::ColorChoice,
 
     #[clap(long = "ignored")]
     pub skipped_tests_only: bool,


### PR DESCRIPTION
Switches parser tests to use `insta` crate for snapshot-based testing using RON serialization (for now). The best way to update/review snapshot changes is the `cargo insta` tool.

Also adds not-yet-enabled test code that can do snapshot testing of the parser using the scriptlets in all the YAML test cases.

_Credit to @39555 for path-finding via #265._

Resolves #254