### PR TITLE
test(tokenizer): adopt insta for tokenizer tests

### DIFF
--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"a$((1+2))b c\")?"
+---
+TokenizerResult(
+  input: "a$((1+2))b c",
+  result: [
+    W("a$((1+2))b", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+    )),
+    W("c", Loc(
+      start: Pos(
+        idx: 11,
+        line: 1,
+        col: 12,
+      ),
+      end: Pos(
+        idx: 12,
+        line: 1,
+        col: 13,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_parens.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_parens.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$(( (0) ))\")?"
+---
+TokenizerResult(
+  input: "$(( (0) ))",
+  result: [
+    W("$(( (0) ))", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_space.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_space.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$(( 1 ))\")?"
+---
+TokenizerResult(
+  input: "$(( 1 ))",
+  result: [
+    W("$(( 1 ))", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 8,
+        line: 1,
+        col: 9,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_backquote_with_escape.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_backquote_with_escape.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"echo `echo\\`hi`\")?"
+---
+TokenizerResult(
+  input: "echo `echo\\`hi`",
+  result: [
+    W("echo", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("`echo\\`hi`", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 15,
+        line: 1,
+        col: 16,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion-2.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"a${x}b\")?"
+---
+TokenizerResult(
+  input: "a${x}b",
+  result: [
+    W("a${x}b", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"${x}\")?"
+---
+TokenizerResult(
+  input: "${x}",
+  result: [
+    W("${x}", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion_with_escaping.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion_with_escaping.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"a${x\\}}b\")?"
+---
+TokenizerResult(
+  input: "a${x\\}}b",
+  result: [
+    W("a${x\\}}b", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 8,
+        line: 1,
+        col: 9,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"a$(echo hi)b c\")?"
+---
+TokenizerResult(
+  input: "a$(echo hi)b c",
+  result: [
+    W("a$(echo hi)b", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 12,
+        line: 1,
+        col: 13,
+      ),
+    )),
+    W("c", Loc(
+      start: Pos(
+        idx: 13,
+        line: 1,
+        col: 14,
+      ),
+      end: Pos(
+        idx: 14,
+        line: 1,
+        col: 15,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_containing_extglob.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_containing_extglob.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"echo $(echo !(x))\")?"
+---
+TokenizerResult(
+  input: "echo $(echo !(x))",
+  result: [
+    W("echo", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("$(echo !(x))", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 17,
+        line: 1,
+        col: 18,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_with_subshell.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_with_subshell.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$( (:) )\")?"
+---
+TokenizerResult(
+  input: "$( (:) )",
+  result: [
+    W("$( (:) )", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 8,
+        line: 1,
+        col: 9,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"a #comment\n\")?"
+---
+TokenizerResult(
+  input: "a #comment\n",
+  result: [
+    W("a", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 1,
+        line: 1,
+        col: 2,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment_at_eof.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment_at_eof.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"a #comment\")?"
+---
+TokenizerResult(
+  input: "a #comment",
+  result: [
+    W("a", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 1,
+        line: 1,
+        col: 2,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_complex_here_docs_in_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_complex_here_docs_in_command_substitution.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"echo $(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\nOTHER\nHERE2\n)\")?"
+---
+TokenizerResult(
+  input: "echo $(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\nOTHER\nHERE2\n)",
+  result: [
+    W("echo", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("$(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\nOTHER\nHERE2\n)", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 59,
+        line: 6,
+        col: 2,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quote.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r#\"x\"a b\"y\"#)?"
+---
+TokenizerResult(
+  input: "x\"a b\"y",
+  result: [
+    W("x\"a b\"y", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 7,
+        line: 1,
+        col: 8,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_arithmetic_expression.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_arithmetic_expression.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r#\"x\"$((1+2))\"y\"#)?"
+---
+TokenizerResult(
+  input: "x\"$((1+2))\"y",
+  result: [
+    W("x\"$((1+2))\"y", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 12,
+        line: 1,
+        col: 13,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_command_substitution.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r#\"x\"$(echo hi)\"y\"#)?"
+---
+TokenizerResult(
+  input: "x\"$(echo hi)\"y",
+  result: [
+    W("x\"$(echo hi)\"y", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 14,
+        line: 1,
+        col: 15,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_empty_here_doc.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_empty_here_doc.snap
@@ -1,0 +1,81 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<HERE\nHERE\n\")?"
+---
+TokenizerResult(
+  input: "cat <<HERE\nHERE\n",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+      end: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+    )),
+    W("", Loc(
+      start: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 16,
+        line: 3,
+        col: 1,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 16,
+        line: 3,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 16,
+        line: 3,
+        col: 1,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_escaped_whitespace.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_escaped_whitespace.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"1\\ 2 3\")?"
+---
+TokenizerResult(
+  input: "1\\ 2 3",
+  result: [
+    W("1\\ 2", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("3", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc.snap
@@ -1,0 +1,117 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\necho after\n\")?"
+---
+TokenizerResult(
+  input: "cat <<HERE\nSOMETHING\nHERE\necho after\n",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+      end: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+    )),
+    W("SOMETHING\n", Loc(
+      start: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+    )),
+    W("echo", Loc(
+      start: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 30,
+        line: 4,
+        col: 5,
+      ),
+    )),
+    W("after", Loc(
+      start: Pos(
+        idx: 31,
+        line: 4,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 36,
+        line: 4,
+        col: 11,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 36,
+        line: 4,
+        col: 11,
+      ),
+      end: Pos(
+        idx: 37,
+        line: 5,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_command_substitution.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"echo $(cat <<HERE\nTEXT\nHERE\n)\")?"
+---
+TokenizerResult(
+  input: "echo $(cat <<HERE\nTEXT\nHERE\n)",
+  result: [
+    W("echo", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("$(cat <<HERE\nTEXT\nHERE\n)", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 29,
+        line: 4,
+        col: 2,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_other_tokens.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_other_tokens.snap
@@ -1,0 +1,117 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<EOF | wc -l\nA B C\n1 2 3\nD E F\nEOF\n\")?"
+---
+TokenizerResult(
+  input: "cat <<EOF | wc -l\nA B C\n1 2 3\nD E F\nEOF\n",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+    W("EOF", Loc(
+      start: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+      end: Pos(
+        idx: 9,
+        line: 1,
+        col: 10,
+      ),
+    )),
+    W("A B C\n1 2 3\nD E F\n", Loc(
+      start: Pos(
+        idx: 18,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 40,
+        line: 6,
+        col: 1,
+      ),
+    )),
+    W("EOF", Loc(
+      start: Pos(
+        idx: 40,
+        line: 6,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 40,
+        line: 6,
+        col: 1,
+      ),
+    )),
+    Op("|", Loc(
+      start: Pos(
+        idx: 9,
+        line: 1,
+        col: 10,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 1,
+        col: 12,
+      ),
+    )),
+    W("wc", Loc(
+      start: Pos(
+        idx: 12,
+        line: 1,
+        col: 13,
+      ),
+      end: Pos(
+        idx: 14,
+        line: 1,
+        col: 15,
+      ),
+    )),
+    W("-l", Loc(
+      start: Pos(
+        idx: 14,
+        line: 1,
+        col: 15,
+      ),
+      end: Pos(
+        idx: 17,
+        line: 1,
+        col: 18,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 17,
+        line: 1,
+        col: 18,
+      ),
+      end: Pos(
+        idx: 18,
+        line: 2,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_tab_removal.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_tab_removal.snap
@@ -1,0 +1,81 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<-HERE\n\tSOMETHING\n\tHERE\n\")?"
+---
+TokenizerResult(
+  input: "cat <<-HERE\n\tSOMETHING\n\tHERE\n",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<-", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 7,
+        line: 1,
+        col: 8,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 7,
+        line: 1,
+        col: 8,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 1,
+        col: 12,
+      ),
+    )),
+    W("SOMETHING\n", Loc(
+      start: Pos(
+        idx: 12,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 29,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 29,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 29,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 11,
+        line: 1,
+        col: 12,
+      ),
+      end: Pos(
+        idx: 12,
+        line: 2,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_line_continuation.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_line_continuation.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"a\\\nbc\")?"
+---
+TokenizerResult(
+  input: "a\\\nbc",
+  result: [
+    W("abc", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 5,
+        line: 2,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_multiple_here_docs.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_multiple_here_docs.snap
@@ -1,0 +1,165 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<HERE1 <<HERE2\nSOMETHING\nHERE1\nOTHER\nHERE2\necho after\n\")?"
+---
+TokenizerResult(
+  input: "cat <<HERE1 <<HERE2\nSOMETHING\nHERE1\nOTHER\nHERE2\necho after\n",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+    W("HERE1", Loc(
+      start: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 1,
+        col: 12,
+      ),
+    )),
+    W("SOMETHING\n", Loc(
+      start: Pos(
+        idx: 20,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 36,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    W("HERE1", Loc(
+      start: Pos(
+        idx: 36,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 36,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 11,
+        line: 1,
+        col: 12,
+      ),
+      end: Pos(
+        idx: 14,
+        line: 1,
+        col: 15,
+      ),
+    )),
+    W("HERE2", Loc(
+      start: Pos(
+        idx: 14,
+        line: 1,
+        col: 15,
+      ),
+      end: Pos(
+        idx: 19,
+        line: 1,
+        col: 20,
+      ),
+    )),
+    W("OTHER\n", Loc(
+      start: Pos(
+        idx: 36,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 48,
+        line: 6,
+        col: 1,
+      ),
+    )),
+    W("HERE2", Loc(
+      start: Pos(
+        idx: 48,
+        line: 6,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 48,
+        line: 6,
+        col: 1,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 19,
+        line: 1,
+        col: 20,
+      ),
+      end: Pos(
+        idx: 20,
+        line: 2,
+        col: 1,
+      ),
+    )),
+    W("echo", Loc(
+      start: Pos(
+        idx: 48,
+        line: 6,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 52,
+        line: 6,
+        col: 5,
+      ),
+    )),
+    W("after", Loc(
+      start: Pos(
+        idx: 53,
+        line: 6,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 58,
+        line: 6,
+        col: 11,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 58,
+        line: 6,
+        col: 11,
+      ),
+      end: Pos(
+        idx: 59,
+        line: 7,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_operators.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_operators.snap
@@ -1,0 +1,45 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"a>>b\")?"
+---
+TokenizerResult(
+  input: "a>>b",
+  result: [
+    W("a", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 1,
+        line: 1,
+        col: 2,
+      ),
+    )),
+    Op(">>", Loc(
+      start: Pos(
+        idx: 1,
+        line: 1,
+        col: 2,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    W("b", Loc(
+      start: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_simple_backquote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_simple_backquote.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"echo `echo hi`\")?"
+---
+TokenizerResult(
+  input: "echo `echo hi`",
+  result: [
+    W("echo", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("`echo hi`", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 14,
+        line: 1,
+        col: 15,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_single_quote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_single_quote.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"x'a b'y\")?"
+---
+TokenizerResult(
+  input: "x\'a b\'y",
+  result: [
+    W("x\'a b\'y", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 7,
+        line: 1,
+        col: 8,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-2.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$@\")?"
+---
+TokenizerResult(
+  input: "$@",
+  result: [
+    W("$@", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-3.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-3.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$!\")?"
+---
+TokenizerResult(
+  input: "$!",
+  result: [
+    W("$!", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-4.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-4.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$?\")?"
+---
+TokenizerResult(
+  input: "$?",
+  result: [
+    W("$?", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-5.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-5.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$*\")?"
+---
+TokenizerResult(
+  input: "$*",
+  result: [
+    W("$*", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$$\")?"
+---
+TokenizerResult(
+  input: "$$",
+  result: [
+    W("$$", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion-2.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"a$x\")?"
+---
+TokenizerResult(
+  input: "a$x",
+  result: [
+    W("a$x", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion.snap
@@ -1,0 +1,21 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"$x\")?"
+---
+TokenizerResult(
+  input: "$x",
+  result: [
+    W("$x", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_whitespace.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_whitespace.snap
@@ -1,0 +1,45 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(\"1 2 3\")?"
+---
+TokenizerResult(
+  input: "1 2 3",
+  result: [
+    W("1", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 1,
+        line: 1,
+        col: 2,
+      ),
+    )),
+    W("2", Loc(
+      start: Pos(
+        idx: 2,
+        line: 1,
+        col: 3,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    W("3", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+    )),
+  ],
+)


### PR DESCRIPTION
Follows the pattern of #545 -- starts using `insta` for tokenizer tests. This brings stronger strictness, since full source position information will now be captured too.