### PR TITLE
fix(tokenizer): correctly handle here docs terminated by EOF

### DIFF
--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -1044,6 +1044,29 @@ esac\
     }
 
     #[test]
+    fn parse_here_doc_with_no_trailing_newline() -> Result<()> {
+        let input = r"cat <<EOF
+Something
+EOF";
+
+        let tokens = tokenize_str(input)?;
+        let result = super::token_parser::program(
+            &Tokens {
+                tokens: tokens.as_slice(),
+            },
+            &ParserOptions::default(),
+            &SourceInfo::default(),
+        )?;
+
+        assert_ron_snapshot!(ParseResult {
+            input,
+            result: &result
+        });
+
+        Ok(())
+    }
+
+    #[test]
     fn parse_function_with_pipe_redirection() -> Result<()> {
         let inputs = [r"foo() { echo 1; } 2>&1 | cat", r"foo() { echo 1; } |& cat"];
 

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_here.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_here.snap
@@ -1,0 +1,35 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "cat <<EOF\nSomething\nEOF\n",
+  result: Program(
+    cmds: [
+      List([
+        Item(AndOr(
+          first: Pipeline(
+            seq: [
+              Simple(Simple(
+                w: Some(W(
+                  v: "cat",
+                )),
+                suffix: Some(Suffix([
+                  IoRedirect(HereDocument(None, IoHereDocument(
+                    requires_expansion: true,
+                    here_end: W(
+                      v: "EOF",
+                    ),
+                    doc: W(
+                      v: "Something\n",
+                    ),
+                  ))),
+                ])),
+              )),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_here_doc_with_no_trailing_newline.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_here_doc_with_no_trailing_newline.snap
@@ -1,0 +1,35 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "cat <<EOF\nSomething\nEOF",
+  result: Program(
+    cmds: [
+      List([
+        Item(AndOr(
+          first: Pipeline(
+            seq: [
+              Simple(Simple(
+                w: Some(W(
+                  v: "cat",
+                )),
+                suffix: Some(Suffix([
+                  IoRedirect(HereDocument(None, IoHereDocument(
+                    requires_expansion: true,
+                    here_end: W(
+                      v: "EOF",
+                    ),
+                    doc: W(
+                      v: "Something\n",
+                    ),
+                  ))),
+                ])),
+              )),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-2.snap
@@ -1,0 +1,81 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\n\")?"
+---
+TokenizerResult(
+  input: "cat <<HERE\nSOMETHING\nHERE\n",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+      end: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+    )),
+    W("SOMETHING\n", Loc(
+      start: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-3.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-3.snap
@@ -1,0 +1,93 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\n\n\")?"
+---
+TokenizerResult(
+  input: "cat <<HERE\nSOMETHING\nHERE\n\n",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+      end: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+    )),
+    W("SOMETHING\n", Loc(
+      start: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 26,
+        line: 4,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 27,
+        line: 5,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-4.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-4.snap
@@ -1,0 +1,81 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\")?"
+---
+TokenizerResult(
+  input: "cat <<HERE\nSOMETHING\nHERE",
+  result: [
+    W("cat", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 3,
+        line: 1,
+        col: 4,
+      ),
+    )),
+    Op("<<", Loc(
+      start: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 6,
+        line: 1,
+        col: 7,
+      ),
+      end: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+    )),
+    W("SOMETHING\n", Loc(
+      start: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 25,
+        line: 3,
+        col: 5,
+      ),
+    )),
+    W("HERE", Loc(
+      start: Pos(
+        idx: 25,
+        line: 3,
+        col: 5,
+      ),
+      end: Pos(
+        idx: 25,
+        line: 3,
+        col: 5,
+      ),
+    )),
+    Op("\n", Loc(
+      start: Pos(
+        idx: 10,
+        line: 1,
+        col: 11,
+      ),
+      end: Pos(
+        idx: 11,
+        line: 2,
+        col: 1,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -1353,6 +1353,24 @@ HERE
 echo after
 "
         )?);
+        assert_ron_snapshot!(test_tokenizer(
+            r"cat <<HERE
+SOMETHING
+HERE
+"
+        )?);
+        assert_ron_snapshot!(test_tokenizer(
+            r"cat <<HERE
+SOMETHING
+HERE
+
+"
+        )?);
+        assert_ron_snapshot!(test_tokenizer(
+            r"cat <<HERE
+SOMETHING
+HERE"
+        )?);
         Ok(())
     }
 

--- a/brush-shell/tests/cases/here.yaml
+++ b/brush-shell/tests/cases/here.yaml
@@ -53,6 +53,9 @@ cases:
       wc -l <<EOF
       EOF
 
+  - name: "Basic here doc"
+    stdin: "wc -l <<EOF\nSomething\nEOF"
+
   - name: "Here doc with other tokens after tag"
     stdin: |
       wc -l <<EOF | wc -l


### PR DESCRIPTION
This fixes the tokenizer to handle a here document being terminated by the final tag, immediately followed by an EOF (rather than a newline).

_Huge credit to @mati865 for finding the issue, identifying a targeted fix, and sharing it out._

Resolves #547 