### PR TITLE
chore: enable more lints + fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,26 +22,38 @@ rust-version = "1.85.0"
 
 [workspace.lints.rust]
 warnings = { level = "deny" }
+future_incompatible = { level = "deny" }
+missing_docs = { level = "deny" }
+nonstandard_style = { level = "deny" }
 rust_2018_idioms = { level = "deny", priority = -1 }
 unnameable_types = "deny"
 unsafe_op_in_unsafe_fn = "deny"
+unused_attributes = "deny"
 unused_lifetimes = "deny"
 unused_macro_rules = "deny"
 # For now we allow unknown lints so we can opt into warnings that don't exist on the
 # oldest toolchain we need to support.
 unknown_lints = { level = "allow", priority = -100 }
 
+[workspace.lints.rustdoc]
+all = { level = "deny", priority = -1 }
+
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
 pedantic = { level = "deny", priority = -1 }
 cargo = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
 perf = { level = "deny", priority = -1 }
+
+# Denied rules
 expect_used = "deny"
 format_push_string = "deny"
 panic = "deny"
 panic_in_result_fn = "deny"
 todo = "deny"
 unwrap_in_result = "deny"
+
+# Allowed rules
 bool_to_int_with_if = "allow"
 collapsible_else_if = "allow"
 collapsible_if = "allow"
@@ -52,8 +64,10 @@ missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 multiple_crate_versions = "allow"
 must_use_candidate = "allow"
+option_if_let_else = "allow"
 redundant_closure_for_method_calls = "allow"
 redundant_else = "allow"
+redundant_pub_crate = "allow"
 result_large_err = "allow"
 similar_names = "allow"
 struct_excessive_bools = "allow"

--- a/brush-core/benches/shell.rs
+++ b/brush-core/benches/shell.rs
@@ -1,3 +1,7 @@
+//! Benchmarks for the brush-core crate.
+
+#![allow(missing_docs)]
+
 #[cfg(unix)]
 mod unix {
     use criterion::{Criterion, black_box};
@@ -151,6 +155,7 @@ criterion::criterion_group! {
                 .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
     targets = unix::criterion_benchmark
 }
+
 #[cfg(unix)]
 criterion::criterion_main!(benches);
 

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -96,11 +96,11 @@ macro_rules! minus_or_plus_flag_arg {
 
         impl $struct_name {
             #[allow(dead_code)]
-            pub fn is_some(&self) -> bool {
+            pub const fn is_some(&self) -> bool {
                 self._enable || self._disable
             }
 
-            pub fn to_bool(&self) -> Option<bool> {
+            pub const fn to_bool(&self) -> Option<bool> {
                 match (self._enable, self._disable) {
                     (true, false) => Some(true),
                     (false, true) => Some(false),
@@ -144,17 +144,17 @@ pub enum ExitCode {
 impl From<ExecutionResult> for ExitCode {
     fn from(result: ExecutionResult) -> Self {
         if let Some(count) = result.continue_loop {
-            ExitCode::ContinueLoop(count)
+            Self::ContinueLoop(count)
         } else if let Some(count) = result.break_loop {
-            ExitCode::BreakLoop(count)
+            Self::BreakLoop(count)
         } else if result.return_from_function_or_script {
-            ExitCode::ReturnFromFunctionOrScript(result.exit_code)
+            Self::ReturnFromFunctionOrScript(result.exit_code)
         } else if result.exit_shell {
-            ExitCode::ExitShell(result.exit_code)
+            Self::ExitShell(result.exit_code)
         } else if result.exit_code == 0 {
-            ExitCode::Success
+            Self::Success
         } else {
-            ExitCode::Custom(result.exit_code)
+            Self::Custom(result.exit_code)
         }
     }
 }
@@ -291,7 +291,7 @@ pub struct Registration {
 impl Registration {
     /// Updates the given registration to mark it for a special builtin.
     #[must_use]
-    pub fn special(self) -> Self {
+    pub const fn special(self) -> Self {
         Self {
             special_builtin: true,
             ..self
@@ -299,7 +299,10 @@ impl Registration {
     }
 }
 
-fn get_builtin_man_page(_name: &str, _command: &clap::Command) -> Result<String, error::Error> {
+const fn get_builtin_man_page(
+    _name: &str,
+    _command: &clap::Command,
+) -> Result<String, error::Error> {
     error::unimp("man page rendering is not yet implemented")
 }
 

--- a/brush-core/src/builtins/bind.rs
+++ b/brush-core/src/builtins/bind.rs
@@ -21,12 +21,12 @@ enum BindKeyMap {
 }
 
 impl BindKeyMap {
-    fn is_vi(&self) -> bool {
+    const fn is_vi(&self) -> bool {
         matches!(self, Self::ViCommand | Self::ViInsert)
     }
 
     #[allow(dead_code)]
-    fn is_emacs(&self) -> bool {
+    const fn is_emacs(&self) -> bool {
         matches!(
             self,
             Self::EmacsStandard | Self::EmacsMeta | Self::EmacsCtlx
@@ -178,6 +178,9 @@ impl BindCommand {
                 bind_key_sequence(&mut *bindings, key_seq, command)?;
             }
         }
+
+        // We might as well drop the bindings lock here since we don't need it anymore.
+        drop(bindings);
 
         if let Some(key_sequence) = &self.key_sequence {
             if self.keymap.as_ref().is_some_and(|k| k.is_vi()) {

--- a/brush-core/src/builtins/brushinfo.rs
+++ b/brush-core/src/builtins/brushinfo.rs
@@ -67,8 +67,8 @@ impl CommandGroup {
         context: &mut commands::ExecutionContext<'_>,
     ) -> Result<crate::builtins::ExitCode, crate::error::Error> {
         match self {
-            CommandGroup::Process(process) => process.execute(context),
-            CommandGroup::Complete(complete) => complete.execute(context).await,
+            Self::Process(process) => process.execute(context),
+            Self::Complete(complete) => complete.execute(context).await,
         }
     }
 }
@@ -79,11 +79,11 @@ impl ProcessCommand {
         context: &commands::ExecutionContext<'_>,
     ) -> Result<crate::builtins::ExitCode, crate::error::Error> {
         match self {
-            ProcessCommand::ShowProcessId => {
+            Self::ShowProcessId => {
                 writeln!(context.stdout(), "{}", std::process::id())?;
                 Ok(builtins::ExitCode::Success)
             }
-            ProcessCommand::ShowProcessGroupId => {
+            Self::ShowProcessGroupId => {
                 if let Some(pgid) = sys::terminal::get_process_group_id() {
                     writeln!(context.stdout(), "{pgid}")?;
                     Ok(builtins::ExitCode::Success)
@@ -92,7 +92,7 @@ impl ProcessCommand {
                     Ok(builtins::ExitCode::Custom(1))
                 }
             }
-            ProcessCommand::ShowForegroundProcessId => {
+            Self::ShowForegroundProcessId => {
                 if let Some(pid) = sys::terminal::get_foreground_pid() {
                     writeln!(context.stdout(), "{pid}")?;
                     Ok(builtins::ExitCode::Success)
@@ -101,7 +101,7 @@ impl ProcessCommand {
                     Ok(builtins::ExitCode::Custom(1))
                 }
             }
-            ProcessCommand::ShowParentProcessId => {
+            Self::ShowParentProcessId => {
                 if let Some(pid) = sys::terminal::get_parent_process_id() {
                     writeln!(context.stdout(), "{pid}")?;
                     Ok(builtins::ExitCode::Success)
@@ -120,7 +120,7 @@ impl CompleteCommand {
         context: &mut commands::ExecutionContext<'_>,
     ) -> Result<crate::builtins::ExitCode, crate::error::Error> {
         match self {
-            CompleteCommand::Line { cursor_index, line } => {
+            Self::Line { cursor_index, line } => {
                 let completions = context
                     .shell
                     .get_completions(line, cursor_index.unwrap_or(line.len()))

--- a/brush-core/src/builtins/command.rs
+++ b/brush-core/src/builtins/command.rs
@@ -79,8 +79,8 @@ enum FoundCommand {
 impl Display for FoundCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FoundCommand::Builtin(name) => write!(f, "{name}"),
-            FoundCommand::External(path) => write!(f, "{path}"),
+            Self::Builtin(name) => write!(f, "{name}"),
+            Self::External(path) => write!(f, "{path}"),
         }
     }
 }

--- a/brush-core/src/builtins/complete.rs
+++ b/brush-core/src/builtins/complete.rs
@@ -305,7 +305,7 @@ impl CompleteCommand {
     }
 
     fn try_display_spec_for_command(
-        context: &mut commands::ExecutionContext<'_>,
+        context: &commands::ExecutionContext<'_>,
         name: &str,
     ) -> Result<bool, error::Error> {
         if let Some(spec) = context.shell.completion_config.get(name) {

--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -140,7 +140,7 @@ impl builtins::Command for DeclareCommand {
         if !self.declarations.is_empty() {
             for declaration in &self.declarations {
                 if self.print && !matches!(verb, DeclareVerb::Readonly) {
-                    if !self.try_display_declaration(&mut context, declaration, verb)? {
+                    if !self.try_display_declaration(&context, declaration, verb)? {
                         result = builtins::ExitCode::Custom(1);
                     }
                 } else {
@@ -152,14 +152,14 @@ impl builtins::Command for DeclareCommand {
         } else {
             // Display matching declarations from the variable environment.
             if !self.function_names_only && !self.function_names_or_defs_only {
-                self.display_matching_env_declarations(&mut context, verb)?;
+                self.display_matching_env_declarations(&context, verb)?;
             }
 
             // Do the same for functions.
             if !matches!(verb, DeclareVerb::Local | DeclareVerb::Readonly)
                 && (!self.print || self.function_names_only || self.function_names_or_defs_only)
             {
-                self.display_matching_functions(&mut context)?;
+                self.display_matching_functions(&context)?;
             }
         }
 
@@ -170,7 +170,7 @@ impl builtins::Command for DeclareCommand {
 impl DeclareCommand {
     fn try_display_declaration(
         &self,
-        context: &mut crate::commands::ExecutionContext<'_>,
+        context: &commands::ExecutionContext<'_>,
         declaration: &commands::CommandArg,
         verb: DeclareVerb,
     ) -> Result<bool, error::Error> {
@@ -390,7 +390,7 @@ impl DeclareCommand {
 
     fn display_matching_env_declarations(
         &self,
-        context: &mut crate::commands::ExecutionContext<'_>,
+        context: &commands::ExecutionContext<'_>,
         verb: DeclareVerb,
     ) -> Result<(), error::Error> {
         //
@@ -508,7 +508,7 @@ impl DeclareCommand {
 
     fn display_matching_functions(
         &self,
-        context: &mut crate::commands::ExecutionContext<'_>,
+        context: &commands::ExecutionContext<'_>,
     ) -> Result<(), error::Error> {
         for (name, registration) in context.shell.funcs.iter().sorted_by_key(|v| v.0) {
             if self.function_names_only {
@@ -522,7 +522,10 @@ impl DeclareCommand {
     }
 
     #[allow(clippy::unnecessary_wraps)]
-    fn apply_attributes_before_update(&self, var: &mut ShellVariable) -> Result<(), error::Error> {
+    const fn apply_attributes_before_update(
+        &self,
+        var: &mut ShellVariable,
+    ) -> Result<(), error::Error> {
         if let Some(value) = self.make_integer.to_bool() {
             if value {
                 var.treat_as_integer();

--- a/brush-core/src/builtins/echo.rs
+++ b/brush-core/src/builtins/echo.rs
@@ -32,7 +32,7 @@ impl builtins::Command for EchoCommand {
     where
         I: IntoIterator<Item = String>,
     {
-        let (mut this, rest_args) = crate::builtins::try_parse_known::<EchoCommand>(args)?;
+        let (mut this, rest_args) = crate::builtins::try_parse_known::<Self>(args)?;
         if let Some(args) = rest_args {
             this.args.extend(args);
         }

--- a/brush-core/src/builtins/getopts.rs
+++ b/brush-core/src/builtins/getopts.rs
@@ -28,7 +28,7 @@ impl builtins::Command for GetOptsCommand {
     where
         I: IntoIterator<Item = String>,
     {
-        let (mut this, rest_args) = crate::builtins::try_parse_known::<GetOptsCommand>(args)?;
+        let (mut this, rest_args) = crate::builtins::try_parse_known::<Self>(args)?;
         if let Some(args) = rest_args {
             this.args.extend(args);
         }

--- a/brush-core/src/builtins/printf.rs
+++ b/brush-core/src/builtins/printf.rs
@@ -105,7 +105,7 @@ fn format_via_uucore(
                     error::Error::PrintfInvalidUsage(format!("printf formatting error: {e}"))
                 })?;
 
-            if let ControlFlow::Break(()) = control_flow {
+            if control_flow == ControlFlow::Break(()) {
                 break;
             }
         }
@@ -154,8 +154,8 @@ mod tests {
 
     #[test]
     fn test_basic_sprintf() -> Result<()> {
-        assert_eq!(sprintf_via_uucore("%s", ["xyz"].iter())?, "xyz");
-        assert_eq!(sprintf_via_uucore(r"%d\n", ["1"].iter())?, "1\n");
+        assert_eq!(sprintf_via_uucore("%s", std::iter::once(&"xyz"))?, "xyz");
+        assert_eq!(sprintf_via_uucore(r"%d\n", std::iter::once(&"1"))?, "1\n");
 
         Ok(())
     }

--- a/brush-core/src/builtins/set.rs
+++ b/brush-core/src/builtins/set.rs
@@ -178,7 +178,7 @@ impl builtins::Command for SetCommand {
             }
         }
 
-        let (mut this, rest_args) = crate::builtins::try_parse_known::<SetCommand>(updated_args)?;
+        let (mut this, rest_args) = crate::builtins::try_parse_known::<Self>(updated_args)?;
         if let Some(args) = rest_args {
             this.positional_args.extend(args);
         }

--- a/brush-core/src/builtins/ulimit.rs
+++ b/brush-core/src/builtins/ulimit.rs
@@ -21,10 +21,10 @@ enum Unit {
 }
 
 impl Unit {
-    fn scale(self) -> u64 {
+    const fn scale(self) -> u64 {
         match self {
-            Unit::Block | Unit::HalfKBytes => 512,
-            Unit::KBytes => 1024,
+            Self::Block | Self::HalfKBytes => 512,
+            Self::KBytes => 1024,
             _ => 1,
         }
     }
@@ -39,27 +39,27 @@ enum Virtual {
 impl Virtual {
     fn get(self) -> std::io::Result<(u64, u64)> {
         match self {
-            Virtual::Pipe => {
+            Self::Pipe => {
                 let lim = nix::unistd::PathconfVar::PIPE_BUF as u64 * 512;
                 Ok((lim, lim))
             }
-            Virtual::VMem => rlimit::Resource::AS
+            Self::VMem => rlimit::Resource::AS
                 .get()
                 .or_else(|_| rlimit::Resource::VMEM.get()),
         }
     }
     fn set(self, soft: u64, hard: u64) -> std::io::Result<()> {
         match self {
-            Virtual::Pipe => Err(std::io::Error::from(ErrorKind::Unsupported)),
-            Virtual::VMem => rlimit::Resource::AS
+            Self::Pipe => Err(std::io::Error::from(ErrorKind::Unsupported)),
+            Self::VMem => rlimit::Resource::AS
                 .set(soft, hard)
                 .or_else(|_| rlimit::Resource::VMEM.set(soft, hard)),
         }
     }
-    fn is_supported(self) -> bool {
+    const fn is_supported(self) -> bool {
         match self {
-            Virtual::Pipe => true,
-            Virtual::VMem => {
+            Self::Pipe => true,
+            Self::VMem => {
                 rlimit::Resource::AS.is_supported() || rlimit::Resource::VMEM.is_supported()
             }
         }
@@ -75,20 +75,20 @@ enum Resource {
 impl Resource {
     fn get(self) -> std::io::Result<(u64, u64)> {
         match self {
-            Resource::Phy(res) => res.get(),
-            Resource::Virt(res) => res.get(),
+            Self::Phy(res) => res.get(),
+            Self::Virt(res) => res.get(),
         }
     }
     fn set(self, soft: u64, hard: u64) -> std::io::Result<()> {
         match self {
-            Resource::Phy(res) => res.set(soft, hard),
-            Resource::Virt(res) => res.set(soft, hard),
+            Self::Phy(res) => res.set(soft, hard),
+            Self::Virt(res) => res.set(soft, hard),
         }
     }
-    fn is_supported(self) -> bool {
+    const fn is_supported(self) -> bool {
         match self {
-            Resource::Phy(res) => res.is_supported(),
-            Resource::Virt(res) => res.is_supported(),
+            Self::Phy(res) => res.is_supported(),
+            Self::Virt(res) => res.is_supported(),
         }
     }
 }
@@ -103,147 +103,147 @@ struct ResourceDescription {
 }
 
 impl ResourceDescription {
-    const SBSIZE: ResourceDescription = ResourceDescription {
+    const SBSIZE: Self = Self {
         resource: Resource::Phy(rlimit::Resource::SBSIZE),
         help: "the socket buffer size",
         description: "socket buffer size",
         short: 'b',
         unit: Unit::Bytes,
     };
-    const CORE: ResourceDescription = ResourceDescription {
+    const CORE: Self = Self {
         resource: Resource::Phy(rlimit::Resource::CORE),
         help: "the maximum size of core files created",
         description: "core file size",
         short: 'c',
         unit: Unit::Block,
     };
-    const DATA: ResourceDescription = ResourceDescription {
+    const DATA: Self = Self {
         resource: Resource::Phy(rlimit::Resource::DATA),
         help: "the maximum size of a process's data segment",
         description: "data seg size",
         short: 'd',
         unit: Unit::KBytes,
     };
-    const NICE: ResourceDescription = ResourceDescription {
+    const NICE: Self = Self {
         resource: Resource::Phy(rlimit::Resource::NICE),
         help: "the maximum scheduling priority (`nice`)",
         description: "scheduling priority",
         short: 'e',
         unit: Unit::Number,
     };
-    const FSIZE: ResourceDescription = ResourceDescription {
+    const FSIZE: Self = Self {
         resource: Resource::Phy(rlimit::Resource::FSIZE),
         help: "the maximum size of files written by the shell and its children",
         description: "file size",
         short: 'f',
         unit: Unit::Block,
     };
-    const SIGPENDING: ResourceDescription = ResourceDescription {
+    const SIGPENDING: Self = Self {
         resource: Resource::Phy(rlimit::Resource::SIGPENDING),
         help: "the maximum number of pending signals",
         description: "pending signals",
         short: 'i',
         unit: Unit::Number,
     };
-    const MEMLOCK: ResourceDescription = ResourceDescription {
+    const MEMLOCK: Self = Self {
         resource: Resource::Phy(rlimit::Resource::MEMLOCK),
         help: "the maximum size a process may lock into memory",
         description: "max locked memory",
         short: 'l',
         unit: Unit::KBytes,
     };
-    const KQUEUES: ResourceDescription = ResourceDescription {
+    const KQUEUES: Self = Self {
         resource: Resource::Phy(rlimit::Resource::KQUEUES),
         help: "the maximum number of kqueues allocated for this process",
         description: "max kqueues",
         short: 'k',
         unit: Unit::Number,
     };
-    const RSS: ResourceDescription = ResourceDescription {
+    const RSS: Self = Self {
         resource: Resource::Phy(rlimit::Resource::RSS),
         help: "the maximum resident set size",
         description: "max memory size",
         short: 'm',
         unit: Unit::KBytes,
     };
-    const LOCKS: ResourceDescription = ResourceDescription {
+    const LOCKS: Self = Self {
         resource: Resource::Phy(rlimit::Resource::LOCKS),
         help: "the maximum number of file locks",
         description: "file locks",
         short: 'x',
         unit: Unit::Number,
     };
-    const NOFILE: ResourceDescription = ResourceDescription {
+    const NOFILE: Self = Self {
         resource: Resource::Phy(rlimit::Resource::NOFILE),
         help: "the maximum number of open file descriptors",
         description: "open files",
         short: 'n',
         unit: Unit::Number,
     };
-    const MSGQUEUE: ResourceDescription = ResourceDescription {
+    const MSGQUEUE: Self = Self {
         resource: Resource::Phy(rlimit::Resource::MSGQUEUE),
         help: "the maximum number of bytes in POSIX message queues",
         description: "POSIX message queues",
         short: 'q',
         unit: Unit::Bytes,
     };
-    const PIPE: ResourceDescription = ResourceDescription {
+    const PIPE: Self = Self {
         resource: Resource::Virt(Virtual::Pipe),
         help: "the pipe buffer size",
         description: "pipe size",
         short: 'p',
         unit: Unit::HalfKBytes,
     };
-    const RTPRIO: ResourceDescription = ResourceDescription {
+    const RTPRIO: Self = Self {
         resource: Resource::Phy(rlimit::Resource::RTPRIO),
         help: "the maximum real-time scheduling priority",
         description: "real-time priority",
         short: 'r',
         unit: Unit::Number,
     };
-    const RTTIME: ResourceDescription = ResourceDescription {
+    const RTTIME: Self = Self {
         resource: Resource::Phy(rlimit::Resource::RTTIME),
         help: "the maximum real-time scheduling priority",
         description: "real-time non-blocking time",
         short: 'R',
         unit: Unit::Micros,
     };
-    const STACK: ResourceDescription = ResourceDescription {
+    const STACK: Self = Self {
         resource: Resource::Phy(rlimit::Resource::STACK),
         help: "the maximum stack size",
         description: "stack size",
         short: 's',
         unit: Unit::KBytes,
     };
-    const CPU: ResourceDescription = ResourceDescription {
+    const CPU: Self = Self {
         resource: Resource::Phy(rlimit::Resource::CPU),
         help: "the maximum amount of cpu time in seconds",
         description: "cpu time",
         short: 't',
         unit: Unit::Seconds,
     };
-    const NPROC: ResourceDescription = ResourceDescription {
+    const NPROC: Self = Self {
         resource: Resource::Phy(rlimit::Resource::NPROC),
         help: "the maximum number of user processes",
         description: "max user processes",
         short: 'u',
         unit: Unit::Number,
     };
-    const VMEM: ResourceDescription = ResourceDescription {
+    const VMEM: Self = Self {
         resource: Resource::Virt(Virtual::VMem),
         help: "the size of virtual memory",
         description: "virtual memory",
         short: 'v',
         unit: Unit::KBytes,
     };
-    const THREADS: ResourceDescription = ResourceDescription {
+    const THREADS: Self = Self {
         resource: Resource::Phy(rlimit::Resource::THREADS),
         help: "the maximum number of threads",
         description: "number of threads",
         short: 'T',
         unit: Unit::Number,
     };
-    const NPTS: ResourceDescription = ResourceDescription {
+    const NPTS: Self = Self {
         resource: Resource::Phy(rlimit::Resource::NPTS),
         help: "the maximum number of pseudoterminals",
         description: "number of pseudoterminals",
@@ -336,11 +336,11 @@ impl FromStr for LimitValue {
     type Err = <u64 as FromStr>::Err;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let v = match s {
-            "" => LimitValue::Unset,
-            "unlimited" => LimitValue::Unlimited,
-            "soft" => LimitValue::Soft,
-            "hard" => LimitValue::Hard,
-            _ => LimitValue::Value(s.parse()?),
+            "" => Self::Unset,
+            "unlimited" => Self::Unlimited,
+            "soft" => Self::Soft,
+            "hard" => Self::Hard,
+            _ => Self::Value(s.parse()?),
         };
         Ok(v)
     }

--- a/brush-core/src/builtins/unset.rs
+++ b/brush-core/src/builtins/unset.rs
@@ -29,7 +29,7 @@ pub(crate) struct UnsetNameInterpretation {
 }
 
 impl UnsetNameInterpretation {
-    pub fn unspecified(&self) -> bool {
+    pub const fn unspecified(&self) -> bool {
         !self.shell_functions && !self.shell_variables && !self.name_references
     }
 }

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -383,7 +383,7 @@ impl Spec {
     #[allow(clippy::too_many_lines)]
     async fn generate_action_completions(
         &self,
-        shell: &mut Shell,
+        shell: &Shell,
         context: &Context<'_>,
     ) -> Result<IndexSet<String>, error::Error> {
         let mut candidates = IndexSet::new();
@@ -561,7 +561,7 @@ impl Spec {
 
     async fn call_completion_command(
         &self,
-        shell: &mut Shell,
+        shell: &Shell,
         command_name: &str,
         context: &Context<'_>,
     ) -> Result<IndexSet<String>, error::Error> {
@@ -996,12 +996,12 @@ impl Config {
         }
     }
 
-    fn tokenize_input_for_completion(shell: &mut Shell, input: &str) -> Vec<brush_parser::Token> {
+    fn tokenize_input_for_completion(shell: &Shell, input: &str) -> Vec<brush_parser::Token> {
         const FALLBACK: &str = " \t\n\"\'@><=;|&(:";
 
         let delimiter_str = shell
             .get_env_str("COMP_WORDBREAKS")
-            .unwrap_or(FALLBACK.into());
+            .unwrap_or_else(|| FALLBACK.into());
 
         let delimiters: Vec<_> = delimiter_str.chars().collect();
 
@@ -1204,7 +1204,7 @@ fn completion_filter_pattern_matches(
     pattern: &str,
     candidate: &str,
     token_being_completed: &str,
-    shell: &mut Shell,
+    shell: &Shell,
 ) -> Result<bool, error::Error> {
     let pattern = replace_unescaped_ampersands(pattern, token_being_completed);
 

--- a/brush-core/src/env.rs
+++ b/brush-core/src/env.rs
@@ -22,7 +22,7 @@ pub enum EnvironmentLookup {
 }
 
 /// Represents a shell environment scope.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EnvironmentScope {
     /// Scope local to a function instance
     Local,

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -224,7 +224,7 @@ pub enum Error {
 /// # Arguments
 ///
 /// * `msg` - The message to include in the error
-pub(crate) fn unimp<T>(msg: &'static str) -> Result<T, Error> {
+pub(crate) const fn unimp<T>(msg: &'static str) -> Result<T, Error> {
     Err(Error::Unimplemented(msg))
 }
 
@@ -233,6 +233,9 @@ pub(crate) fn unimp<T>(msg: &'static str) -> Result<T, Error> {
 /// # Arguments
 ///
 /// * `msg` - The message to include in the error
-pub(crate) fn unimp_with_issue<T>(msg: &'static str, project_issue_id: u32) -> Result<T, Error> {
+pub(crate) const fn unimp_with_issue<T>(
+    msg: &'static str,
+    project_issue_id: u32,
+) -> Result<T, Error> {
     Err(Error::UnimplementedAndTracked(msg, project_issue_id))
 }

--- a/brush-core/src/escape.rs
+++ b/brush-core/src/escape.rs
@@ -329,7 +329,7 @@ fn ansi_c_quote(s: &str) -> String {
 
 // Returns whether or not the given character needs to be escaped (or quoted) if outside
 // quotes.
-fn needs_escaping(c: char) -> bool {
+const fn needs_escaping(c: char) -> bool {
     matches!(
         c,
         '(' | ')'
@@ -356,7 +356,7 @@ fn needs_escaping(c: char) -> bool {
     )
 }
 
-fn needs_ansi_c_quoting(c: char) -> bool {
+const fn needs_ansi_c_quoting(c: char) -> bool {
     c.is_ascii_control()
 }
 

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -44,7 +44,7 @@ impl Default for Expansion {
 impl From<Expansion> for String {
     fn from(value: Expansion) -> Self {
         // TODO: Use IFS instead for separator?
-        value.fields.into_iter().map(String::from).join(" ")
+        value.fields.into_iter().map(Self::from).join(" ")
     }
 }
 
@@ -52,7 +52,7 @@ impl From<String> for Expansion {
     fn from(value: String) -> Self {
         Self {
             fields: vec![WordField::from(value)],
-            ..Expansion::default()
+            ..Self::default()
         }
     }
 }
@@ -61,7 +61,7 @@ impl From<ExpansionPiece> for Expansion {
     fn from(piece: ExpansionPiece) -> Self {
         Self {
             fields: vec![WordField::from(piece)],
-            ..Expansion::default()
+            ..Self::default()
         }
     }
 }
@@ -108,7 +108,7 @@ impl Expansion {
             let actual_len = min(len, self.fields.len() - index);
             let fields = self.fields[index..(index + actual_len)].to_vec();
 
-            Expansion {
+            Self {
                 fields,
                 concatenate: self.concatenate,
                 undefined: self.undefined,
@@ -178,7 +178,7 @@ impl Expansion {
                 }
             }
 
-            Expansion {
+            Self {
                 fields,
                 concatenate: self.concatenate,
                 undefined: self.undefined,
@@ -192,7 +192,7 @@ impl Expansion {
 struct WordField(Vec<ExpansionPiece>);
 
 impl WordField {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(vec![])
     }
 
@@ -203,7 +203,7 @@ impl WordField {
 
 impl From<WordField> for String {
     fn from(field: WordField) -> Self {
-        field.0.into_iter().map(String::from).collect()
+        field.0.into_iter().map(Self::from).collect()
     }
 }
 
@@ -215,7 +215,7 @@ impl From<WordField> for patterns::Pattern {
             .map(patterns::PatternPiece::from)
             .collect();
 
-        patterns::Pattern::from(pieces)
+        Self::from(pieces)
     }
 }
 
@@ -249,8 +249,8 @@ impl From<ExpansionPiece> for String {
 impl From<ExpansionPiece> for patterns::PatternPiece {
     fn from(piece: ExpansionPiece) -> Self {
         match piece {
-            ExpansionPiece::Unsplittable(s) => patterns::PatternPiece::Literal(s),
-            ExpansionPiece::Splittable(s) => patterns::PatternPiece::Pattern(s),
+            ExpansionPiece::Unsplittable(s) => Self::Literal(s),
+            ExpansionPiece::Splittable(s) => Self::Pattern(s),
         }
     }
 }
@@ -258,8 +258,8 @@ impl From<ExpansionPiece> for patterns::PatternPiece {
 impl From<ExpansionPiece> for crate::regex::RegexPiece {
     fn from(piece: ExpansionPiece) -> Self {
         match piece {
-            ExpansionPiece::Unsplittable(s) => crate::regex::RegexPiece::Literal(s),
-            ExpansionPiece::Splittable(s) => crate::regex::RegexPiece::Pattern(s),
+            ExpansionPiece::Unsplittable(s) => Self::Literal(s),
+            ExpansionPiece::Splittable(s) => Self::Pattern(s),
         }
     }
 }
@@ -267,22 +267,22 @@ impl From<ExpansionPiece> for crate::regex::RegexPiece {
 impl ExpansionPiece {
     fn as_str(&self) -> &str {
         match self {
-            ExpansionPiece::Unsplittable(s) => s.as_str(),
-            ExpansionPiece::Splittable(s) => s.as_str(),
+            Self::Unsplittable(s) => s.as_str(),
+            Self::Splittable(s) => s.as_str(),
         }
     }
 
     fn len(&self) -> usize {
         match self {
-            ExpansionPiece::Unsplittable(s) => s.len(),
-            ExpansionPiece::Splittable(s) => s.len(),
+            Self::Unsplittable(s) => s.len(),
+            Self::Splittable(s) => s.len(),
         }
     }
 
-    fn make_unsplittable(self) -> ExpansionPiece {
+    fn make_unsplittable(self) -> Self {
         match self {
-            ExpansionPiece::Unsplittable(_) => self,
-            ExpansionPiece::Splittable(s) => ExpansionPiece::Unsplittable(s),
+            Self::Unsplittable(_) => self,
+            Self::Splittable(s) => Self::Unsplittable(s),
         }
     }
 }
@@ -380,7 +380,7 @@ struct WordExpander<'a> {
 }
 
 impl<'a> WordExpander<'a> {
-    pub fn new(shell: &'a mut Shell, params: &'a ExecutionParameters) -> Self {
+    pub const fn new(shell: &'a mut Shell, params: &'a ExecutionParameters) -> Self {
         let parser_options = shell.parser_options();
         Self {
             shell,
@@ -1401,7 +1401,7 @@ impl<'a> WordExpander<'a> {
     }
 
     fn expand_special_parameter(
-        &mut self,
+        &self,
         parameter: &brush_parser::word::SpecialParameter,
     ) -> Expansion {
         match parameter {

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -68,7 +68,7 @@ async fn apply_unary_predicate(
 pub(crate) fn apply_unary_predicate_to_str(
     op: &ast::UnaryPredicate,
     operand: &str,
-    shell: &mut Shell,
+    shell: &Shell,
     params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
     #[allow(clippy::match_single_binding)]
@@ -472,7 +472,7 @@ pub(crate) fn apply_binary_predicate_to_strs(
     op: &ast::BinaryPredicate,
     left: &str,
     right: &str,
-    shell: &mut Shell,
+    shell: &Shell,
 ) -> Result<bool, error::Error> {
     match op {
         ast::BinaryPredicate::FilesReferToSameDeviceAndInodeNumbers => {
@@ -555,7 +555,7 @@ fn apply_test_binary_arithmetic_predicate(
 }
 
 fn left_file_is_older_or_does_not_exist_when_right_does(
-    shell: &mut Shell,
+    shell: &Shell,
     left: impl AsRef<str>,
     right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
@@ -572,7 +572,7 @@ fn left_file_is_older_or_does_not_exist_when_right_does(
 }
 
 fn left_file_is_newer_or_exists_when_right_does_not(
-    shell: &mut Shell,
+    shell: &Shell,
     left: impl AsRef<str>,
     right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
@@ -589,7 +589,7 @@ fn left_file_is_newer_or_exists_when_right_does_not(
 }
 
 fn files_refer_to_same_device_and_inode_numbers(
-    shell: &mut Shell,
+    shell: &Shell,
     left: impl AsRef<str>,
     right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {

--- a/brush-core/src/functions.rs
+++ b/brush-core/src/functions.rs
@@ -69,7 +69,7 @@ pub struct FunctionRegistration {
 
 impl From<brush_parser::ast::FunctionDefinition> for FunctionRegistration {
     fn from(definition: brush_parser::ast::FunctionDefinition) -> Self {
-        FunctionRegistration {
+        Self {
             definition: Arc::new(definition),
             exported: false,
         }
@@ -78,17 +78,17 @@ impl From<brush_parser::ast::FunctionDefinition> for FunctionRegistration {
 
 impl FunctionRegistration {
     /// Marks the function for export.
-    pub fn export(&mut self) {
+    pub const fn export(&mut self) {
         self.exported = true;
     }
 
     /// Unmarks the function for export.
-    pub fn unexport(&mut self) {
+    pub const fn unexport(&mut self) {
         self.exported = false;
     }
 
     /// Returns whether this function is exported.
-    pub fn is_exported(&self) -> bool {
+    pub const fn is_exported(&self) -> bool {
         self.exported
     }
 }

--- a/brush-core/src/interfaces/keybindings.rs
+++ b/brush-core/src/interfaces/keybindings.rs
@@ -15,8 +15,8 @@ pub enum KeyAction {
 impl Display for KeyAction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            KeyAction::ShellCommand(command) => write!(f, "shell command: {command}"),
-            KeyAction::DoInputFunction(function) => function.fmt(f),
+            Self::ShellCommand(command) => write!(f, "shell command: {command}"),
+            Self::DoInputFunction(function) => function.fmt(f),
         }
     }
 }
@@ -304,24 +304,24 @@ pub enum Key {
 impl Display for Key {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Key::Character(c @ ('\\' | '\"' | '\'')) => write!(f, "\\{c}")?,
-            Key::Character(c) => write!(f, "{c}")?,
-            Key::Backspace => write!(f, "Backspace")?,
-            Key::Enter => write!(f, "Enter")?,
-            Key::Left => write!(f, "Left")?,
-            Key::Right => write!(f, "Right")?,
-            Key::Up => write!(f, "Up")?,
-            Key::Down => write!(f, "Down")?,
-            Key::Home => write!(f, "Home")?,
-            Key::End => write!(f, "End")?,
-            Key::PageUp => write!(f, "PageUp")?,
-            Key::PageDown => write!(f, "PageDown")?,
-            Key::Tab => write!(f, "Tab")?,
-            Key::BackTab => write!(f, "BackTab")?,
-            Key::Delete => write!(f, "Delete")?,
-            Key::Insert => write!(f, "Insert")?,
-            Key::F(n) => write!(f, "F{n}")?,
-            Key::Escape => write!(f, "Esc")?,
+            Self::Character(c @ ('\\' | '\"' | '\'')) => write!(f, "\\{c}")?,
+            Self::Character(c) => write!(f, "{c}")?,
+            Self::Backspace => write!(f, "Backspace")?,
+            Self::Enter => write!(f, "Enter")?,
+            Self::Left => write!(f, "Left")?,
+            Self::Right => write!(f, "Right")?,
+            Self::Up => write!(f, "Up")?,
+            Self::Down => write!(f, "Down")?,
+            Self::Home => write!(f, "Home")?,
+            Self::End => write!(f, "End")?,
+            Self::PageUp => write!(f, "PageUp")?,
+            Self::PageDown => write!(f, "PageDown")?,
+            Self::Tab => write!(f, "Tab")?,
+            Self::BackTab => write!(f, "BackTab")?,
+            Self::Delete => write!(f, "Delete")?,
+            Self::Insert => write!(f, "Insert")?,
+            Self::F(n) => write!(f, "F{n}")?,
+            Self::Escape => write!(f, "Esc")?,
         }
 
         Ok(())

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -1,8 +1,6 @@
 //! Core implementation of the brush shell. Implements the shell's abstraction, its interpreter, and
 //! various facilities used internally by the shell.
 
-#![deny(missing_docs)]
-
 pub mod completion;
 
 mod arithmetic;

--- a/brush-core/src/namedoptions.rs
+++ b/brush-core/src/namedoptions.rs
@@ -12,8 +12,8 @@ pub(crate) struct OptionDefinition {
 }
 
 impl OptionDefinition {
-    fn new(getter: OptionGetter, setter: OptionSetter) -> OptionDefinition {
-        OptionDefinition { getter, setter }
+    fn new(getter: OptionGetter, setter: OptionSetter) -> Self {
+        Self { getter, setter }
     }
 }
 

--- a/brush-core/src/openfiles.rs
+++ b/brush-core/src/openfiles.rs
@@ -39,15 +39,15 @@ impl Clone for OpenFile {
 
 impl OpenFile {
     /// Tries to duplicate the open file.
-    pub fn try_dup(&self) -> Result<OpenFile, error::Error> {
+    pub fn try_dup(&self) -> Result<Self, error::Error> {
         let result = match self {
-            OpenFile::Stdin => OpenFile::Stdin,
-            OpenFile::Stdout => OpenFile::Stdout,
-            OpenFile::Stderr => OpenFile::Stderr,
-            OpenFile::Null => OpenFile::Null,
-            OpenFile::File(f) => OpenFile::File(f.try_clone()?),
-            OpenFile::PipeReader(f) => OpenFile::PipeReader(f.try_clone()?),
-            OpenFile::PipeWriter(f) => OpenFile::PipeWriter(f.try_clone()?),
+            Self::Stdin => Self::Stdin,
+            Self::Stdout => Self::Stdout,
+            Self::Stderr => Self::Stderr,
+            Self::Null => Self::Null,
+            Self::File(f) => Self::File(f.try_clone()?),
+            Self::PipeReader(f) => Self::PipeReader(f.try_clone()?),
+            Self::PipeWriter(f) => Self::PipeWriter(f.try_clone()?),
         };
 
         Ok(result)
@@ -57,13 +57,13 @@ impl OpenFile {
     #[cfg(unix)]
     pub(crate) fn into_owned_fd(self) -> Result<std::os::fd::OwnedFd, error::Error> {
         match self {
-            OpenFile::Stdin => Ok(std::io::stdin().as_fd().try_clone_to_owned()?),
-            OpenFile::Stdout => Ok(std::io::stdout().as_fd().try_clone_to_owned()?),
-            OpenFile::Stderr => Ok(std::io::stderr().as_fd().try_clone_to_owned()?),
-            OpenFile::Null => error::unimp("to_owned_fd for null open file"),
-            OpenFile::File(f) => Ok(f.into()),
-            OpenFile::PipeReader(r) => Ok(OwnedFd::from(r)),
-            OpenFile::PipeWriter(w) => Ok(OwnedFd::from(w)),
+            Self::Stdin => Ok(std::io::stdin().as_fd().try_clone_to_owned()?),
+            Self::Stdout => Ok(std::io::stdout().as_fd().try_clone_to_owned()?),
+            Self::Stderr => Ok(std::io::stderr().as_fd().try_clone_to_owned()?),
+            Self::Null => error::unimp("to_owned_fd for null open file"),
+            Self::File(f) => Ok(f.into()),
+            Self::PipeReader(r) => Ok(OwnedFd::from(r)),
+            Self::PipeWriter(w) => Ok(OwnedFd::from(w)),
         }
     }
 
@@ -72,33 +72,33 @@ impl OpenFile {
     #[allow(dead_code)]
     pub(crate) fn as_raw_fd(&self) -> Result<i32, error::Error> {
         match self {
-            OpenFile::Stdin => Ok(std::io::stdin().as_raw_fd()),
-            OpenFile::Stdout => Ok(std::io::stdout().as_raw_fd()),
-            OpenFile::Stderr => Ok(std::io::stderr().as_raw_fd()),
-            OpenFile::Null => error::unimp("as_raw_fd for null open file"),
-            OpenFile::File(f) => Ok(f.as_raw_fd()),
-            OpenFile::PipeReader(r) => Ok(r.as_raw_fd()),
-            OpenFile::PipeWriter(w) => Ok(w.as_raw_fd()),
+            Self::Stdin => Ok(std::io::stdin().as_raw_fd()),
+            Self::Stdout => Ok(std::io::stdout().as_raw_fd()),
+            Self::Stderr => Ok(std::io::stderr().as_raw_fd()),
+            Self::Null => error::unimp("as_raw_fd for null open file"),
+            Self::File(f) => Ok(f.as_raw_fd()),
+            Self::PipeReader(r) => Ok(r.as_raw_fd()),
+            Self::PipeWriter(w) => Ok(w.as_raw_fd()),
         }
     }
 
     pub(crate) fn is_dir(&self) -> bool {
         match self {
-            OpenFile::Stdin | OpenFile::Stdout | OpenFile::Stderr | OpenFile::Null => false,
-            OpenFile::File(file) => file.metadata().map(|m| m.is_dir()).unwrap_or(false),
-            OpenFile::PipeReader(_) | OpenFile::PipeWriter(_) => false,
+            Self::Stdin | Self::Stdout | Self::Stderr | Self::Null => false,
+            Self::File(file) => file.metadata().map(|m| m.is_dir()).unwrap_or(false),
+            Self::PipeReader(_) | Self::PipeWriter(_) => false,
         }
     }
 
     pub(crate) fn is_term(&self) -> bool {
         match self {
-            OpenFile::Stdin => std::io::stdin().is_terminal(),
-            OpenFile::Stdout => std::io::stdout().is_terminal(),
-            OpenFile::Stderr => std::io::stderr().is_terminal(),
-            OpenFile::Null => false,
-            OpenFile::File(f) => f.is_terminal(),
-            OpenFile::PipeReader(_) => false,
-            OpenFile::PipeWriter(_) => false,
+            Self::Stdin => std::io::stdin().is_terminal(),
+            Self::Stdout => std::io::stdout().is_terminal(),
+            Self::Stderr => std::io::stderr().is_terminal(),
+            Self::Null => false,
+            Self::File(f) => f.is_terminal(),
+            Self::PipeReader(_) => false,
+            Self::PipeWriter(_) => false,
         }
     }
 
@@ -110,13 +110,13 @@ impl OpenFile {
         }
 
         let result = match self {
-            OpenFile::Stdin => Some(sys::terminal::get_term_attr(std::io::stdin())?),
-            OpenFile::Stdout => Some(sys::terminal::get_term_attr(std::io::stdout())?),
-            OpenFile::Stderr => Some(sys::terminal::get_term_attr(std::io::stderr())?),
-            OpenFile::Null => None,
-            OpenFile::File(f) => Some(sys::terminal::get_term_attr(f)?),
-            OpenFile::PipeReader(_) => None,
-            OpenFile::PipeWriter(_) => None,
+            Self::Stdin => Some(sys::terminal::get_term_attr(std::io::stdin())?),
+            Self::Stdout => Some(sys::terminal::get_term_attr(std::io::stdout())?),
+            Self::Stderr => Some(sys::terminal::get_term_attr(std::io::stderr())?),
+            Self::Null => None,
+            Self::File(f) => Some(sys::terminal::get_term_attr(f)?),
+            Self::PipeReader(_) => None,
+            Self::PipeWriter(_) => None,
         };
         Ok(result)
     }
@@ -126,13 +126,13 @@ impl OpenFile {
         termios: &sys::terminal::TerminalSettings,
     ) -> Result<(), error::Error> {
         match self {
-            OpenFile::Stdin => sys::terminal::set_term_attr_now(std::io::stdin(), termios)?,
-            OpenFile::Stdout => sys::terminal::set_term_attr_now(std::io::stdout(), termios)?,
-            OpenFile::Stderr => sys::terminal::set_term_attr_now(std::io::stderr(), termios)?,
-            OpenFile::Null => (),
-            OpenFile::File(f) => sys::terminal::set_term_attr_now(f, termios)?,
-            OpenFile::PipeReader(_) => (),
-            OpenFile::PipeWriter(_) => (),
+            Self::Stdin => sys::terminal::set_term_attr_now(std::io::stdin(), termios)?,
+            Self::Stdout => sys::terminal::set_term_attr_now(std::io::stdout(), termios)?,
+            Self::Stderr => sys::terminal::set_term_attr_now(std::io::stderr(), termios)?,
+            Self::Null => (),
+            Self::File(f) => sys::terminal::set_term_attr_now(f, termios)?,
+            Self::PipeReader(_) => (),
+            Self::PipeWriter(_) => (),
         }
         Ok(())
     }
@@ -140,17 +140,17 @@ impl OpenFile {
 
 impl From<std::fs::File> for OpenFile {
     fn from(file: std::fs::File) -> Self {
-        OpenFile::File(file)
+        Self::File(file)
     }
 }
 
 impl From<OpenFile> for Stdio {
     fn from(open_file: OpenFile) -> Self {
         match open_file {
-            OpenFile::Stdin => Stdio::inherit(),
-            OpenFile::Stdout => Stdio::inherit(),
-            OpenFile::Stderr => Stdio::inherit(),
-            OpenFile::Null => Stdio::null(),
+            OpenFile::Stdin => Self::inherit(),
+            OpenFile::Stdout => Self::inherit(),
+            OpenFile::Stderr => Self::inherit(),
+            OpenFile::Null => Self::null(),
             OpenFile::File(f) => f.into(),
             OpenFile::PipeReader(f) => f.into(),
             OpenFile::PipeWriter(f) => f.into(),
@@ -161,19 +161,19 @@ impl From<OpenFile> for Stdio {
 impl std::io::Read for OpenFile {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
-            OpenFile::Stdin => std::io::stdin().read(buf),
-            OpenFile::Stdout => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
+            Self::Stdin => std::io::stdin().read(buf),
+            Self::Stdout => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
                 "stdout",
             ))),
-            OpenFile::Stderr => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
+            Self::Stderr => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
                 "stderr",
             ))),
-            OpenFile::Null => Ok(0),
-            OpenFile::File(f) => f.read(buf),
-            OpenFile::PipeReader(reader) => reader.read(buf),
-            OpenFile::PipeWriter(_) => Err(std::io::Error::other(
-                error::Error::OpenFileNotReadable("pipe writer"),
-            )),
+            Self::Null => Ok(0),
+            Self::File(f) => f.read(buf),
+            Self::PipeReader(reader) => reader.read(buf),
+            Self::PipeWriter(_) => Err(std::io::Error::other(error::Error::OpenFileNotReadable(
+                "pipe writer",
+            ))),
         }
     }
 }
@@ -181,29 +181,29 @@ impl std::io::Read for OpenFile {
 impl std::io::Write for OpenFile {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
-            OpenFile::Stdin => Err(std::io::Error::other(error::Error::OpenFileNotWritable(
+            Self::Stdin => Err(std::io::Error::other(error::Error::OpenFileNotWritable(
                 "stdin",
             ))),
-            OpenFile::Stdout => std::io::stdout().write(buf),
-            OpenFile::Stderr => std::io::stderr().write(buf),
-            OpenFile::Null => Ok(buf.len()),
-            OpenFile::File(f) => f.write(buf),
-            OpenFile::PipeReader(_) => Err(std::io::Error::other(
-                error::Error::OpenFileNotWritable("pipe reader"),
-            )),
-            OpenFile::PipeWriter(writer) => writer.write(buf),
+            Self::Stdout => std::io::stdout().write(buf),
+            Self::Stderr => std::io::stderr().write(buf),
+            Self::Null => Ok(buf.len()),
+            Self::File(f) => f.write(buf),
+            Self::PipeReader(_) => Err(std::io::Error::other(error::Error::OpenFileNotWritable(
+                "pipe reader",
+            ))),
+            Self::PipeWriter(writer) => writer.write(buf),
         }
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         match self {
-            OpenFile::Stdin => Ok(()),
-            OpenFile::Stdout => std::io::stdout().flush(),
-            OpenFile::Stderr => std::io::stderr().flush(),
-            OpenFile::Null => Ok(()),
-            OpenFile::File(f) => f.flush(),
-            OpenFile::PipeReader(_) => Ok(()),
-            OpenFile::PipeWriter(writer) => writer.flush(),
+            Self::Stdin => Ok(()),
+            Self::Stdout => std::io::stdout().flush(),
+            Self::Stderr => std::io::stderr().flush(),
+            Self::Null => Ok(()),
+            Self::File(f) => f.flush(),
+            Self::PipeReader(_) => Ok(()),
+            Self::PipeWriter(writer) => writer.flush(),
         }
     }
 }
@@ -230,13 +230,13 @@ impl Default for OpenFiles {
 #[allow(dead_code)]
 impl OpenFiles {
     /// Tries to clone the open files.
-    pub fn try_clone(&self) -> Result<OpenFiles, error::Error> {
+    pub fn try_clone(&self) -> Result<Self, error::Error> {
         let mut files = HashMap::new();
         for (fd, file) in &self.files {
             files.insert(*fd, file.try_dup()?);
         }
 
-        Ok(OpenFiles { files })
+        Ok(Self { files })
     }
 
     /// Retrieves the file backing standard input in this context.

--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -191,7 +191,7 @@ impl RuntimeOptions {
     /// # Arguments
     ///
     /// * `create_options` - The options used to create the shell.
-    pub fn defaults_from(create_options: &CreateOptions) -> RuntimeOptions {
+    pub fn defaults_from(create_options: &CreateOptions) -> Self {
         // There's a set of options enabled by default for all shells.
         let mut options = Self {
             interactive: create_options.interactive,

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -16,8 +16,8 @@ pub(crate) enum PatternPiece {
 impl PatternPiece {
     pub fn as_str(&self) -> &str {
         match self {
-            PatternPiece::Pattern(s) => s,
-            PatternPiece::Literal(s) => s,
+            Self::Pattern(s) => s,
+            Self::Literal(s) => s,
         }
     }
 }
@@ -92,7 +92,7 @@ impl Pattern {
     /// # Arguments
     ///
     /// * `value` - Whether or not to enable extended globbing (extglob).
-    pub fn set_extended_globbing(mut self, value: bool) -> Pattern {
+    pub const fn set_extended_globbing(mut self, value: bool) -> Self {
         self.enable_extended_globbing = value;
         self
     }
@@ -103,7 +103,7 @@ impl Pattern {
     ///
     /// * `value` - Whether or not to enable multiline matching.
     #[allow(dead_code)]
-    pub fn set_multiline(mut self, value: bool) -> Pattern {
+    pub const fn set_multiline(mut self, value: bool) -> Self {
         self.multiline = value;
         self
     }
@@ -113,7 +113,7 @@ impl Pattern {
     /// # Arguments
     ///
     /// * `value` - Whether or not to enable case-insensitive matching.
-    pub fn set_case_insensitive(mut self, value: bool) -> Pattern {
+    pub const fn set_case_insensitive(mut self, value: bool) -> Self {
         self.case_insensitive = value;
         self
     }
@@ -124,7 +124,7 @@ impl Pattern {
     }
 
     /// Placeholder function that always returns true.
-    pub(crate) fn accept_all_expand_filter(_path: &Path) -> bool {
+    pub(crate) const fn accept_all_expand_filter(_path: &Path) -> bool {
         true
     }
 
@@ -233,7 +233,7 @@ impl Pattern {
 
             let current_paths = std::mem::take(&mut paths_so_far);
             for current_path in current_paths {
-                let subpattern = Pattern::from(&component)
+                let subpattern = Self::from(&component)
                     .set_extended_globbing(self.enable_extended_globbing)
                     .set_case_insensitive(self.case_insensitive);
 
@@ -657,6 +657,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cognitive_complexity)]
     fn test_matching() -> Result<()> {
         assert!(Pattern::from("abc").exactly_matches("abc")?);
 

--- a/brush-core/src/processes.rs
+++ b/brush-core/src/processes.rs
@@ -24,7 +24,7 @@ impl ChildProcess {
         }
     }
 
-    pub fn pid(&self) -> Option<sys::process::ProcessId> {
+    pub const fn pid(&self) -> Option<sys::process::ProcessId> {
         self.pid
     }
 

--- a/brush-core/src/regex.rs
+++ b/brush-core/src/regex.rs
@@ -16,8 +16,8 @@ pub(crate) enum RegexPiece {
 impl RegexPiece {
     fn to_regex_str(&self) -> Cow<'_, str> {
         match self {
-            RegexPiece::Pattern(s) => Cow::Borrowed(s.as_str()),
-            RegexPiece::Literal(s) => escape_literal_regex_piece(s.as_str()),
+            Self::Pattern(s) => Cow::Borrowed(s.as_str()),
+            Self::Literal(s) => escape_literal_regex_piece(s.as_str()),
         }
     }
 }
@@ -48,7 +48,7 @@ impl Regex {
     /// # Arguments
     ///
     /// * `value` - The new case sensitivity value.
-    pub fn set_case_insensitive(mut self, value: bool) -> Self {
+    pub const fn set_case_insensitive(mut self, value: bool) -> Self {
         self.case_insensitive = value;
         self
     }
@@ -60,7 +60,7 @@ impl Regex {
     /// # Arguments
     ///
     /// * `value` - The new multiline value.
-    pub fn set_multiline(mut self, value: bool) -> Self {
+    pub const fn set_multiline(mut self, value: bool) -> Self {
         self.multiline = value;
         self
     }
@@ -172,7 +172,7 @@ fn escape_literal_regex_piece(s: &str) -> Cow<'_, str> {
     result.into()
 }
 
-fn regex_char_is_special(c: char) -> bool {
+const fn regex_char_is_special(c: char) -> bool {
     matches!(
         c,
         '\\' | '^' | '$' | '.' | '|' | '?' | '*' | '+' | '(' | ')' | '[' | ']' | '{' | '}'

--- a/brush-core/src/sys/unix/resource.rs
+++ b/brush-core/src/sys/unix/resource.rs
@@ -20,7 +20,7 @@ pub(crate) fn get_children_user_and_system_time()
     ))
 }
 
-fn convert_rusage_time(time: nix::sys::time::TimeVal) -> std::time::Duration {
+const fn convert_rusage_time(time: nix::sys::time::TimeVal) -> std::time::Duration {
     #[allow(clippy::cast_sign_loss)]
     #[allow(clippy::cast_possible_truncation)]
     std::time::Duration::new(time.tv_sec() as u64, time.tv_usec() as u32 * 1000)

--- a/brush-core/src/timing.rs
+++ b/brush-core/src/timing.rs
@@ -9,7 +9,7 @@ struct StopwatchTime {
 }
 
 impl StopwatchTime {
-    fn minus(&self, other: &StopwatchTime) -> Result<StopwatchTiming, error::Error> {
+    fn minus(&self, other: &Self) -> Result<StopwatchTiming, error::Error> {
         let user = (self.self_user - other.self_user) + (self.children_user - other.children_user);
         let system =
             (self.self_system - other.self_system) + (self.children_system - other.children_system);

--- a/brush-core/src/traps.rs
+++ b/brush-core/src/traps.rs
@@ -29,7 +29,7 @@ impl Display for TrapSignal {
 
 impl TrapSignal {
     /// Returns all possible values of [`TrapSignal`].
-    pub fn iterator() -> impl Iterator<Item = TrapSignal> {
+    pub fn iterator() -> impl Iterator<Item = Self> {
         const SIGNALS: &[TrapSignal] = &[TrapSignal::Debug, TrapSignal::Err, TrapSignal::Exit];
         let iter = SIGNALS.iter().copied();
 
@@ -46,10 +46,10 @@ impl TrapSignal {
     pub const fn as_str(self) -> &'static str {
         match self {
             #[cfg(unix)]
-            TrapSignal::Signal(s) => s.as_str(),
-            TrapSignal::Debug => "DEBUG",
-            TrapSignal::Err => "ERR",
-            TrapSignal::Exit => "EXIT",
+            Self::Signal(s) => s.as_str(),
+            Self::Debug => "DEBUG",
+            Self::Err => "ERR",
+            Self::Exit => "EXIT",
         }
     }
 }
@@ -75,11 +75,11 @@ pub fn format_signals(
 // implement s.parse::<TrapSignal>()
 impl FromStr for TrapSignal {
     type Err = error::Error;
-    fn from_str(s: &str) -> Result<Self, <TrapSignal as FromStr>::Err> {
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
         if let Ok(n) = s.parse::<i32>() {
-            TrapSignal::try_from(n)
+            Self::try_from(n)
         } else {
-            TrapSignal::try_from(s)
+            Self::try_from(s)
         }
     }
 }
@@ -92,9 +92,9 @@ impl TryFrom<i32> for TrapSignal {
         // available on bsd-like systems),
         // and don't have persistent numbers across platforms, so we skip them here.
         Ok(match value {
-            0 => TrapSignal::Exit,
+            0 => Self::Exit,
             #[cfg(unix)]
-            value => TrapSignal::Signal(
+            value => Self::Signal(
                 nix::sys::signal::Signal::try_from(value)
                     .map_err(|_| error::Error::InvalidSignal(value.to_string()))?,
             ),
@@ -112,9 +112,9 @@ impl TryFrom<&str> for TrapSignal {
         let mut s = value.to_ascii_uppercase();
 
         Ok(match s.as_str() {
-            "DEBUG" => TrapSignal::Debug,
-            "ERR" => TrapSignal::Err,
-            "EXIT" => TrapSignal::Exit,
+            "DEBUG" => Self::Debug,
+            "ERR" => Self::Err,
+            "EXIT" => Self::Exit,
 
             #[cfg(unix)]
             _ => {
@@ -142,7 +142,7 @@ impl TryFrom<TrapSignal> for i32 {
     fn try_from(value: TrapSignal) -> Result<Self, Self::Error> {
         Ok(match value {
             #[cfg(unix)]
-            TrapSignal::Signal(s) => s as i32,
+            TrapSignal::Signal(s) => s as Self,
             TrapSignal::Exit => 0,
             _ => return Err(TrapSignalNumberError),
         })

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -65,45 +65,45 @@ impl ShellVariable {
     pub fn new(value: ShellValue) -> Self {
         Self {
             value,
-            ..ShellVariable::default()
+            ..Self::default()
         }
     }
 
     /// Returns the value associated with the variable.
-    pub fn value(&self) -> &ShellValue {
+    pub const fn value(&self) -> &ShellValue {
         &self.value
     }
 
     /// Returns whether or not the variable is exported to child processes.
-    pub fn is_exported(&self) -> bool {
+    pub const fn is_exported(&self) -> bool {
         self.exported
     }
 
     /// Marks the variable as exported to child processes.
-    pub fn export(&mut self) -> &mut Self {
+    pub const fn export(&mut self) -> &mut Self {
         self.exported = true;
         self
     }
 
     /// Marks the variable as not exported to child processes.
-    pub fn unexport(&mut self) -> &mut Self {
+    pub const fn unexport(&mut self) -> &mut Self {
         self.exported = false;
         self
     }
 
     /// Returns whether or not the variable is read-only.
-    pub fn is_readonly(&self) -> bool {
+    pub const fn is_readonly(&self) -> bool {
         self.readonly
     }
 
     /// Marks the variable as read-only.
-    pub fn set_readonly(&mut self) -> &mut Self {
+    pub const fn set_readonly(&mut self) -> &mut Self {
         self.readonly = true;
         self
     }
 
     /// Marks the variable as not read-only.
-    pub fn unset_readonly(&mut self) -> Result<&mut Self, error::Error> {
+    pub const fn unset_readonly(&mut self) -> Result<&mut Self, error::Error> {
         if self.readonly {
             return Err(error::Error::ReadonlyVariable);
         }
@@ -113,73 +113,73 @@ impl ShellVariable {
     }
 
     /// Returns whether or not the variable is traced.
-    pub fn is_trace_enabled(&self) -> bool {
+    pub const fn is_trace_enabled(&self) -> bool {
         self.trace
     }
 
     /// Marks the variable as traced.
-    pub fn enable_trace(&mut self) -> &mut Self {
+    pub const fn enable_trace(&mut self) -> &mut Self {
         self.trace = true;
         self
     }
 
     /// Marks the variable as not traced.
-    pub fn disable_trace(&mut self) -> &mut Self {
+    pub const fn disable_trace(&mut self) -> &mut Self {
         self.trace = false;
         self
     }
 
     /// Returns whether or not the variable should be enumerated in the shell's environment.
-    pub fn is_enumerable(&self) -> bool {
+    pub const fn is_enumerable(&self) -> bool {
         self.enumerable
     }
 
     /// Marks the variable as not enumerable in the shell's environment.
-    pub fn hide_from_enumeration(&mut self) -> &mut Self {
+    pub const fn hide_from_enumeration(&mut self) -> &mut Self {
         self.enumerable = false;
         self
     }
 
     /// Return the update transform associated with the variable.
-    pub fn get_update_transform(&self) -> ShellVariableUpdateTransform {
+    pub const fn get_update_transform(&self) -> ShellVariableUpdateTransform {
         self.transform_on_update
     }
 
     /// Set the update transform associated with the variable.
-    pub fn set_update_transform(&mut self, transform: ShellVariableUpdateTransform) {
+    pub const fn set_update_transform(&mut self, transform: ShellVariableUpdateTransform) {
         self.transform_on_update = transform;
     }
 
     /// Returns whether or not the variable should be treated as an integer.
-    pub fn is_treated_as_integer(&self) -> bool {
+    pub const fn is_treated_as_integer(&self) -> bool {
         self.treat_as_integer
     }
 
     /// Marks the variable as being treated as an integer.
-    pub fn treat_as_integer(&mut self) -> &mut Self {
+    pub const fn treat_as_integer(&mut self) -> &mut Self {
         self.treat_as_integer = true;
         self
     }
 
     /// Marks the variable as not being treated as an integer.
-    pub fn unset_treat_as_integer(&mut self) -> &mut Self {
+    pub const fn unset_treat_as_integer(&mut self) -> &mut Self {
         self.treat_as_integer = false;
         self
     }
 
     /// Returns whether or not the variable should be treated as a name reference.
-    pub fn is_treated_as_nameref(&self) -> bool {
+    pub const fn is_treated_as_nameref(&self) -> bool {
         self.treat_as_nameref
     }
 
     /// Marks the variable as being treated as a name reference.
-    pub fn treat_as_nameref(&mut self) -> &mut Self {
+    pub const fn treat_as_nameref(&mut self) -> &mut Self {
         self.treat_as_nameref = true;
         self
     }
 
     /// Marks the variable as not being treated as a name reference.
-    pub fn unset_treat_as_nameref(&mut self) -> &mut Self {
+    pub const fn unset_treat_as_nameref(&mut self) -> &mut Self {
         self.treat_as_nameref = false;
         self
     }
@@ -548,7 +548,10 @@ impl ShellVariable {
         ) {
             result.push('A');
         }
-        if let ShellVariableUpdateTransform::Capitalize = self.get_update_transform() {
+        if matches!(
+            self.get_update_transform(),
+            ShellVariableUpdateTransform::Capitalize
+        ) {
             result.push('c');
         }
         if self.is_treated_as_integer() {
@@ -560,13 +563,19 @@ impl ShellVariable {
         if self.is_readonly() {
             result.push('r');
         }
-        if let ShellVariableUpdateTransform::Lowercase = self.get_update_transform() {
+        if matches!(
+            self.get_update_transform(),
+            ShellVariableUpdateTransform::Lowercase
+        ) {
             result.push('l');
         }
         if self.is_trace_enabled() {
             result.push('t');
         }
-        if let ShellVariableUpdateTransform::Uppercase = self.get_update_transform() {
+        if matches!(
+            self.get_update_transform(),
+            ShellVariableUpdateTransform::Uppercase
+        ) {
             result.push('u');
         }
         if self.is_exported() {
@@ -623,8 +632,8 @@ pub enum ShellValueLiteral {
 impl ShellValueLiteral {
     pub(crate) fn fmt_for_tracing(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ShellValueLiteral::Scalar(s) => Self::fmt_scalar_for_tracing(s.as_str(), f),
-            ShellValueLiteral::Array(elements) => {
+            Self::Scalar(s) => Self::fmt_scalar_for_tracing(s.as_str(), f),
+            Self::Array(elements) => {
                 write!(f, "(")?;
                 for (i, (key, value)) in elements.0.iter().enumerate() {
                     if i > 0 {
@@ -656,19 +665,19 @@ impl Display for ShellValueLiteral {
 
 impl From<&str> for ShellValueLiteral {
     fn from(value: &str) -> Self {
-        ShellValueLiteral::Scalar(value.to_owned())
+        Self::Scalar(value.to_owned())
     }
 }
 
 impl From<String> for ShellValueLiteral {
     fn from(value: String) -> Self {
-        ShellValueLiteral::Scalar(value)
+        Self::Scalar(value)
     }
 }
 
 impl From<Vec<&str>> for ShellValueLiteral {
     fn from(value: Vec<&str>) -> Self {
-        ShellValueLiteral::Array(ArrayLiteral(
+        Self::Array(ArrayLiteral(
             value.into_iter().map(|s| (None, s.to_owned())).collect(),
         ))
     }
@@ -689,20 +698,20 @@ pub enum FormatStyle {
 
 impl ShellValue {
     /// Returns whether or not the value is an array.
-    pub fn is_array(&self) -> bool {
+    pub const fn is_array(&self) -> bool {
         matches!(
             self,
-            ShellValue::IndexedArray(_)
-                | ShellValue::AssociativeArray(_)
-                | ShellValue::Unset(
+            Self::IndexedArray(_)
+                | Self::AssociativeArray(_)
+                | Self::Unset(
                     ShellValueUnsetType::IndexedArray | ShellValueUnsetType::AssociativeArray
                 )
         )
     }
 
     /// Returns whether or not the value is set.
-    pub fn is_set(&self) -> bool {
-        !matches!(self, ShellValue::Unset(_))
+    pub const fn is_set(&self) -> bool {
+        !matches!(self, Self::Unset(_))
     }
 
     /// Returns a new indexed array value constructed from the given slice of owned strings.
@@ -719,7 +728,7 @@ impl ShellValue {
             owned_values.insert(i as u64, value);
         }
 
-        ShellValue::IndexedArray(owned_values)
+        Self::IndexedArray(owned_values)
     }
 
     /// Returns a new indexed array value constructed from the given slice of unowned strings.
@@ -733,7 +742,7 @@ impl ShellValue {
             owned_values.insert(i as u64, (*value).to_string());
         }
 
-        ShellValue::IndexedArray(owned_values)
+        Self::IndexedArray(owned_values)
     }
 
     /// Returns a new indexed array value constructed from the given literals.
@@ -741,11 +750,11 @@ impl ShellValue {
     /// # Arguments
     ///
     /// * `literals` - The literals to construct the indexed array from.
-    pub fn indexed_array_from_literals(literals: ArrayLiteral) -> ShellValue {
+    pub fn indexed_array_from_literals(literals: ArrayLiteral) -> Self {
         let mut values = BTreeMap::new();
-        ShellValue::update_indexed_array_from_literals(&mut values, literals);
+        Self::update_indexed_array_from_literals(&mut values, literals);
 
-        ShellValue::IndexedArray(values)
+        Self::IndexedArray(values)
     }
 
     fn update_indexed_array_from_literals(
@@ -773,13 +782,11 @@ impl ShellValue {
     /// # Arguments
     ///
     /// * `literals` - The literals to construct the associative array from.
-    pub fn associative_array_from_literals(
-        literals: ArrayLiteral,
-    ) -> Result<ShellValue, error::Error> {
+    pub fn associative_array_from_literals(literals: ArrayLiteral) -> Result<Self, error::Error> {
         let mut values = BTreeMap::new();
-        ShellValue::update_associative_array_from_literals(&mut values, literals)?;
+        Self::update_associative_array_from_literals(&mut values, literals)?;
 
-        Ok(ShellValue::AssociativeArray(values))
+        Ok(Self::AssociativeArray(values))
     }
 
     fn update_associative_array_from_literals(
@@ -815,8 +822,8 @@ impl ShellValue {
     /// * `style` - The style to use for formatting the value.
     pub fn format(&self, style: FormatStyle, shell: &Shell) -> Result<Cow<'_, str>, error::Error> {
         match self {
-            ShellValue::Unset(_) => Ok("".into()),
-            ShellValue::String(s) => match style {
+            Self::Unset(_) => Ok("".into()),
+            Self::String(s) => match style {
                 FormatStyle::Basic => Ok(escape::quote_if_needed(
                     s.as_str(),
                     escape::QuoteMode::SingleQuote,
@@ -825,7 +832,7 @@ impl ShellValue {
                     Ok(escape::force_quote(s.as_str(), escape::QuoteMode::DoubleQuote).into())
                 }
             },
-            ShellValue::AssociativeArray(values) => {
+            Self::AssociativeArray(values) => {
                 let mut result = String::new();
                 result.push('(');
 
@@ -844,7 +851,7 @@ impl ShellValue {
                 result.push(')');
                 Ok(result.into())
             }
-            ShellValue::IndexedArray(values) => {
+            Self::IndexedArray(values) => {
                 let mut result = String::new();
                 result.push('(');
 
@@ -861,7 +868,7 @@ impl ShellValue {
                 result.push(')');
                 Ok(result.into())
             }
-            ShellValue::Dynamic { getter, .. } => {
+            Self::Dynamic { getter, .. } => {
                 let dynamic_value = getter(shell);
                 let result = dynamic_value.format(style, shell)?.to_string();
                 Ok(result.into())
@@ -876,18 +883,18 @@ impl ShellValue {
     /// * `index` - The index at which to retrieve the value.
     pub fn get_at(&self, index: &str, shell: &Shell) -> Result<Option<Cow<'_, str>>, error::Error> {
         match self {
-            ShellValue::Unset(_) => Ok(None),
-            ShellValue::String(s) => {
+            Self::Unset(_) => Ok(None),
+            Self::String(s) => {
                 if index.parse::<u64>().unwrap_or(0) == 0 {
                     Ok(Some(Cow::Borrowed(s)))
                 } else {
                     Ok(None)
                 }
             }
-            ShellValue::AssociativeArray(values) => {
+            Self::AssociativeArray(values) => {
                 Ok(values.get(index).map(|s| Cow::Borrowed(s.as_str())))
             }
-            ShellValue::IndexedArray(values) => {
+            Self::IndexedArray(values) => {
                 let mut index_value = index.parse::<i64>().unwrap_or(0);
 
                 #[allow(clippy::cast_possible_wrap)]
@@ -905,7 +912,7 @@ impl ShellValue {
 
                 Ok(values.get(&index_value).map(|s| Cow::Borrowed(s.as_str())))
             }
-            ShellValue::Dynamic { getter, .. } => {
+            Self::Dynamic { getter, .. } => {
                 let dynamic_value = getter(shell);
                 let result = dynamic_value.get_at(index, shell)?;
                 Ok(result.map(|s| s.to_string().into()))
@@ -916,22 +923,22 @@ impl ShellValue {
     /// Returns the keys of the elements in this variable.
     pub fn get_element_keys(&self, shell: &Shell) -> Vec<String> {
         match self {
-            ShellValue::Unset(_) => vec![],
-            ShellValue::String(_) => vec!["0".to_owned()],
-            ShellValue::AssociativeArray(array) => array.keys().map(|k| k.to_owned()).collect(),
-            ShellValue::IndexedArray(array) => array.keys().map(|k| k.to_string()).collect(),
-            ShellValue::Dynamic { getter, .. } => getter(shell).get_element_keys(shell),
+            Self::Unset(_) => vec![],
+            Self::String(_) => vec!["0".to_owned()],
+            Self::AssociativeArray(array) => array.keys().map(|k| k.to_owned()).collect(),
+            Self::IndexedArray(array) => array.keys().map(|k| k.to_string()).collect(),
+            Self::Dynamic { getter, .. } => getter(shell).get_element_keys(shell),
         }
     }
 
     /// Returns the values of the elements in this variable.
     pub fn get_element_values(&self, shell: &Shell) -> Vec<String> {
         match self {
-            ShellValue::Unset(_) => vec![],
-            ShellValue::String(s) => vec![s.to_owned()],
-            ShellValue::AssociativeArray(array) => array.values().map(|v| v.to_owned()).collect(),
-            ShellValue::IndexedArray(array) => array.values().map(|v| v.to_owned()).collect(),
-            ShellValue::Dynamic { getter, .. } => getter(shell).get_element_values(shell),
+            Self::Unset(_) => vec![],
+            Self::String(s) => vec![s.to_owned()],
+            Self::AssociativeArray(array) => array.values().map(|v| v.to_owned()).collect(),
+            Self::IndexedArray(array) => array.values().map(|v| v.to_owned()).collect(),
+            Self::Dynamic { getter, .. } => getter(shell).get_element_values(shell),
         }
     }
 
@@ -949,7 +956,7 @@ impl ShellValue {
     /// or otherwise doesn't exist.
     pub fn try_get_cow_str(&self, shell: &Shell) -> Option<Cow<'_, str>> {
         match self {
-            ShellValue::Dynamic { getter, .. } => {
+            Self::Dynamic { getter, .. } => {
                 let dynamic_value = getter(shell);
                 dynamic_value
                     .try_get_cow_str(shell)
@@ -961,13 +968,11 @@ impl ShellValue {
 
     fn try_get_cow_str_without_dynamic_support(&self) -> Option<Cow<'_, str>> {
         match self {
-            ShellValue::Unset(_) => None,
-            ShellValue::String(s) => Some(Cow::Borrowed(s.as_str())),
-            ShellValue::AssociativeArray(values) => {
-                values.get("0").map(|s| Cow::Borrowed(s.as_str()))
-            }
-            ShellValue::IndexedArray(values) => values.get(&0).map(|s| Cow::Borrowed(s.as_str())),
-            ShellValue::Dynamic { .. } => None,
+            Self::Unset(_) => None,
+            Self::String(s) => Some(Cow::Borrowed(s.as_str())),
+            Self::AssociativeArray(values) => values.get("0").map(|s| Cow::Borrowed(s.as_str())),
+            Self::IndexedArray(values) => values.get(&0).map(|s| Cow::Borrowed(s.as_str())),
+            Self::Dynamic { .. } => None,
         }
     }
 
@@ -978,11 +983,9 @@ impl ShellValue {
     /// * `index` - The index at which to retrieve the value, if indexing is to be performed.
     pub fn to_assignable_str(&self, index: Option<&str>, shell: &Shell) -> String {
         match self {
-            ShellValue::Unset(_) => String::new(),
-            ShellValue::String(s) => {
-                escape::force_quote(s.as_str(), escape::QuoteMode::SingleQuote)
-            }
-            ShellValue::AssociativeArray(_) | ShellValue::IndexedArray(_) => {
+            Self::Unset(_) => String::new(),
+            Self::String(s) => escape::force_quote(s.as_str(), escape::QuoteMode::SingleQuote),
+            Self::AssociativeArray(_) | Self::IndexedArray(_) => {
                 if let Some(index) = index {
                     if let Ok(Some(value)) = self.get_at(index, shell) {
                         escape::force_quote(value.as_ref(), escape::QuoteMode::SingleQuote)
@@ -995,37 +998,37 @@ impl ShellValue {
                         .into_owned()
                 }
             }
-            ShellValue::Dynamic { getter, .. } => getter(shell).to_assignable_str(index, shell),
+            Self::Dynamic { getter, .. } => getter(shell).to_assignable_str(index, shell),
         }
     }
 }
 
 impl From<&str> for ShellValue {
     fn from(value: &str) -> Self {
-        ShellValue::String(value.to_owned())
+        Self::String(value.to_owned())
     }
 }
 
 impl From<&String> for ShellValue {
     fn from(value: &String) -> Self {
-        ShellValue::String(value.clone())
+        Self::String(value.clone())
     }
 }
 
 impl From<String> for ShellValue {
     fn from(value: String) -> Self {
-        ShellValue::String(value)
+        Self::String(value)
     }
 }
 
 impl From<Vec<String>> for ShellValue {
     fn from(values: Vec<String>) -> Self {
-        ShellValue::indexed_array_from_strings(values)
+        Self::indexed_array_from_strings(values)
     }
 }
 
 impl From<Vec<&str>> for ShellValue {
     fn from(values: Vec<&str>) -> Self {
-        ShellValue::indexed_array_from_strs(values.as_slice())
+        Self::indexed_array_from_strs(values.as_slice())
     }
 }

--- a/brush-interactive/src/basic/term_line_reader.rs
+++ b/brush-interactive/src/basic/term_line_reader.rs
@@ -118,7 +118,7 @@ impl<'a> ReadLineState<'a> {
         Ok(())
     }
 
-    fn display_newline(&mut self) -> Result<(), ShellError> {
+    fn display_newline(&self) -> Result<(), ShellError> {
         self.raw_mode.disable()?;
         eprintln!();
         self.raw_mode.enable()?;
@@ -127,7 +127,7 @@ impl<'a> ReadLineState<'a> {
         Ok(())
     }
 
-    fn clear_screen(&mut self) -> Result<(), ShellError> {
+    fn clear_screen(&self) -> Result<(), ShellError> {
         std::io::stderr()
             .execute(crossterm::terminal::Clear(
                 crossterm::terminal::ClearType::All,
@@ -237,7 +237,7 @@ impl<'a> ReadLineState<'a> {
     }
 
     fn handle_multiple_completions(
-        &mut self,
+        &self,
         completions: &brush_core::completion::Completions,
     ) -> Result<(), ShellError> {
         // Display replacements.

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -32,7 +32,7 @@ pub struct InteractivePrompt {
 }
 
 /// Represents a shell capable of taking commands from standard input.
-pub trait InteractiveShell {
+pub trait InteractiveShell: Send {
     /// Returns an immutable reference to the inner shell object.
     fn shell(&self) -> impl AsRef<brush_core::Shell> + Send;
 
@@ -67,7 +67,9 @@ pub trait InteractiveShell {
     /// normally exits or until a fatal error occurs.
     // NOTE: we use desugared async here because [async_fn_in_trait] "warning: use of `async fn` in
     // public traits is discouraged as auto trait bounds cannot be specified"
-    fn run_interactively(&mut self) -> impl std::future::Future<Output = Result<(), ShellError>> {
+    fn run_interactively(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<(), ShellError>> + Send {
         async {
             // TODO: Consider finding a better place for this.
             let _ = brush_core::TerminalControl::acquire()?;
@@ -122,7 +124,8 @@ pub trait InteractiveShell {
     /// Runs the interactive shell loop once, reading a single command from standard input.
     fn run_interactively_once(
         &mut self,
-    ) -> impl std::future::Future<Output = Result<InteractiveExecutionResult, ShellError>> {
+    ) -> impl std::future::Future<Output = Result<InteractiveExecutionResult, ShellError>> + Send
+    {
         async {
             let mut shell = self.shell_mut();
             let shell_mut = shell.as_mut();

--- a/brush-interactive/src/lib.rs
+++ b/brush-interactive/src/lib.rs
@@ -1,7 +1,5 @@
 //! Library implementing interactive command input and completion for the brush shell.
 
-#![deny(missing_docs)]
-
 mod error;
 pub use error::ShellError;
 

--- a/brush-interactive/src/reedline/completer.rs
+++ b/brush-interactive/src/reedline/completer.rs
@@ -20,8 +20,11 @@ impl ReedlineCompleter {
     async fn complete_async(&self, line: &str, pos: usize) -> Vec<reedline::Suggestion> {
         let mut shell_guard = self.shell.lock().await;
         let shell = shell_guard.borrow_mut().as_mut();
-
         let completions = completion::complete_async(shell, line, pos).await;
+
+        // We're done with the shell, so drop it eagerly.
+        drop(shell_guard);
+
         let insertion_index = completions.insertion_index;
         let delete_count = completions.delete_count;
         let options = completions.options;

--- a/brush-interactive/src/reedline/edit_mode.rs
+++ b/brush-interactive/src/reedline/edit_mode.rs
@@ -187,7 +187,7 @@ fn translate_action_to_reedline_event(action: &KeyAction) -> Option<reedline::Re
     }
 }
 
-fn translate_reedline_keycode(keycode: reedline::KeyCode) -> Option<Key> {
+const fn translate_reedline_keycode(keycode: reedline::KeyCode) -> Option<Key> {
     match keycode {
         reedline::KeyCode::Backspace => Some(Key::Backspace),
         reedline::KeyCode::Enter => Some(Key::Enter),

--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -76,12 +76,14 @@ pub(crate) struct ReedlineHighlighter {
 }
 
 impl reedline::Highlighter for ReedlineHighlighter {
+    #[allow(clippy::significant_drop_tightening)]
     fn highlight(&self, line: &str, cursor: usize) -> reedline::StyledText {
         let shell = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(self.shell.lock())
         });
 
         let mut styled_input = StyledInputLine::new(shell.as_ref(), line, cursor);
+
         styled_input.style_and_append_program(line, 0);
 
         styled_input.styled
@@ -258,7 +260,7 @@ impl<'a> StyledInputLine<'a> {
         self.append_style(Style::new(), dest, dest);
     }
 
-    fn set_next_missing_style(&mut self, style: Style) {
+    const fn set_next_missing_style(&mut self, style: Style) {
         self.next_missing_style = Some(style);
     }
 

--- a/brush-interactive/src/reedline/reedline_shell.rs
+++ b/brush-interactive/src/reedline/reedline_shell.rs
@@ -21,7 +21,7 @@ impl ReedlineShell {
     /// # Arguments
     ///
     /// * `options` - Options for creating the interactive shell.
-    pub async fn new(mut options: crate::Options) -> Result<ReedlineShell, ShellError> {
+    pub async fn new(mut options: crate::Options) -> Result<Self, ShellError> {
         // Set up key bindings.
         let key_bindings = compose_key_bindings(COMPLETION_MENU_NAME);
 
@@ -99,7 +99,7 @@ impl ReedlineShell {
             }
         }
 
-        Ok(ReedlineShell {
+        Ok(Self {
             reedline: Some(reedline),
             shell: shell_ref,
         })

--- a/brush-parser/benches/parser.rs
+++ b/brush-parser/benches/parser.rs
@@ -1,3 +1,7 @@
+//! Benchmarks for the brush-parser crate.
+
+#![allow(missing_docs)]
+
 #[cfg(unix)]
 mod unix {
     use brush_parser::{Token, parse_tokens};
@@ -67,6 +71,7 @@ criterion::criterion_group! {
     config = criterion::Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
     targets = unix::criterion_benchmark
 }
+
 #[cfg(unix)]
 criterion::criterion_main!(benches);
 

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -46,8 +46,8 @@ pub enum SeparatorOperator {
 impl Display for SeparatorOperator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SeparatorOperator::Async => write!(f, "&"),
-            SeparatorOperator::Sequence => write!(f, ";"),
+            Self::Async => write!(f, "&"),
+            Self::Sequence => write!(f, ";"),
         }
     }
 }
@@ -89,7 +89,7 @@ impl PartialEq<AndOr> for PipelineOperator {
     fn eq(&self, other: &AndOr) -> bool {
         matches!(
             (self, other),
-            (PipelineOperator::And, AndOr::And(_)) | (PipelineOperator::Or, AndOr::Or(_))
+            (Self::And, AndOr::And(_)) | (Self::Or, AndOr::Or(_))
         )
     }
 }
@@ -99,8 +99,8 @@ impl PartialEq<AndOr> for PipelineOperator {
 impl Into<PipelineOperator> for AndOr {
     fn into(self) -> PipelineOperator {
         match self {
-            AndOr::And(_) => PipelineOperator::And,
-            AndOr::Or(_) => PipelineOperator::Or,
+            Self::And(_) => PipelineOperator::And,
+            Self::Or(_) => PipelineOperator::Or,
         }
     }
 }
@@ -171,8 +171,8 @@ pub enum AndOr {
 impl Display for AndOr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AndOr::And(pipeline) => write!(f, " && {pipeline}"),
-            AndOr::Or(pipeline) => write!(f, " || {pipeline}"),
+            Self::And(pipeline) => write!(f, " && {pipeline}"),
+            Self::Or(pipeline) => write!(f, " || {pipeline}"),
         }
     }
 }
@@ -241,16 +241,16 @@ pub enum Command {
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Command::Simple(simple_command) => write!(f, "{simple_command}"),
-            Command::Compound(compound_command, redirect_list) => {
+            Self::Simple(simple_command) => write!(f, "{simple_command}"),
+            Self::Compound(compound_command, redirect_list) => {
                 write!(f, "{compound_command}")?;
                 if let Some(redirect_list) = redirect_list {
                     write!(f, "{redirect_list}")?;
                 }
                 Ok(())
             }
-            Command::Function(function_definition) => write!(f, "{function_definition}"),
-            Command::ExtendedTest(extended_test_expr) => {
+            Self::Function(function_definition) => write!(f, "{function_definition}"),
+            Self::ExtendedTest(extended_test_expr) => {
                 write!(f, "[[ {extended_test_expr} ]]")
             }
         }
@@ -286,23 +286,23 @@ pub enum CompoundCommand {
 impl Display for CompoundCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CompoundCommand::Arithmetic(arithmetic_command) => write!(f, "{arithmetic_command}"),
-            CompoundCommand::ArithmeticForClause(arithmetic_for_clause_command) => {
+            Self::Arithmetic(arithmetic_command) => write!(f, "{arithmetic_command}"),
+            Self::ArithmeticForClause(arithmetic_for_clause_command) => {
                 write!(f, "{arithmetic_for_clause_command}")
             }
-            CompoundCommand::BraceGroup(brace_group_command) => {
+            Self::BraceGroup(brace_group_command) => {
                 write!(f, "{brace_group_command}")
             }
-            CompoundCommand::Subshell(subshell_command) => write!(f, "{subshell_command}"),
-            CompoundCommand::ForClause(for_clause_command) => write!(f, "{for_clause_command}"),
-            CompoundCommand::CaseClause(case_clause_command) => {
+            Self::Subshell(subshell_command) => write!(f, "{subshell_command}"),
+            Self::ForClause(for_clause_command) => write!(f, "{for_clause_command}"),
+            Self::CaseClause(case_clause_command) => {
                 write!(f, "{case_clause_command}")
             }
-            CompoundCommand::IfClause(if_clause_command) => write!(f, "{if_clause_command}"),
-            CompoundCommand::WhileClause(while_or_until_clause_command) => {
+            Self::IfClause(if_clause_command) => write!(f, "{if_clause_command}"),
+            Self::WhileClause(while_or_until_clause_command) => {
                 write!(f, "while {while_or_until_clause_command}")
             }
-            CompoundCommand::UntilClause(while_or_until_clause_command) => {
+            Self::UntilClause(while_or_until_clause_command) => {
                 write!(f, "until {while_or_until_clause_command}")
             }
         }
@@ -593,9 +593,9 @@ pub enum CaseItemPostAction {
 impl Display for CaseItemPostAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CaseItemPostAction::ExitCase => write!(f, ";;"),
-            CaseItemPostAction::UnconditionallyExecuteNextCaseItem => write!(f, ";&"),
-            CaseItemPostAction::ContinueEvaluatingCases => write!(f, ";;&"),
+            Self::ExitCase => write!(f, ";;"),
+            Self::UnconditionallyExecuteNextCaseItem => write!(f, ";&"),
+            Self::ContinueEvaluatingCases => write!(f, ";;&"),
         }
     }
 }
@@ -788,8 +788,8 @@ pub enum ProcessSubstitutionKind {
 impl Display for ProcessSubstitutionKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProcessSubstitutionKind::Read => write!(f, "<"),
-            ProcessSubstitutionKind::Write => write!(f, ">"),
+            Self::Read => write!(f, "<"),
+            Self::Write => write!(f, ">"),
         }
     }
 }
@@ -813,10 +813,10 @@ pub enum CommandPrefixOrSuffixItem {
 impl Display for CommandPrefixOrSuffixItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CommandPrefixOrSuffixItem::IoRedirect(io_redirect) => write!(f, "{io_redirect}"),
-            CommandPrefixOrSuffixItem::Word(word) => write!(f, "{word}"),
-            CommandPrefixOrSuffixItem::AssignmentWord(_assignment, word) => write!(f, "{word}"),
-            CommandPrefixOrSuffixItem::ProcessSubstitution(kind, subshell_command) => {
+            Self::IoRedirect(io_redirect) => write!(f, "{io_redirect}"),
+            Self::Word(word) => write!(f, "{word}"),
+            Self::AssignmentWord(_assignment, word) => write!(f, "{word}"),
+            Self::ProcessSubstitution(kind, subshell_command) => {
                 write!(f, "{kind}({subshell_command})")
             }
         }
@@ -863,8 +863,8 @@ pub enum AssignmentName {
 impl Display for AssignmentName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssignmentName::VariableName(name) => write!(f, "{name}"),
-            AssignmentName::ArrayElementName(name, index) => {
+            Self::VariableName(name) => write!(f, "{name}"),
+            Self::ArrayElementName(name, index) => {
                 write!(f, "{name}[{index}]")
             }
         }
@@ -885,8 +885,8 @@ pub enum AssignmentValue {
 impl Display for AssignmentValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssignmentValue::Scalar(word) => write!(f, "{word}"),
-            AssignmentValue::Array(words) => {
+            Self::Scalar(word) => write!(f, "{word}"),
+            Self::Array(words) => {
                 write!(f, "(")?;
                 for (i, value) in words.iter().enumerate() {
                     if i > 0 {
@@ -936,21 +936,21 @@ pub enum IoRedirect {
 impl Display for IoRedirect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IoRedirect::File(fd_num, kind, target) => {
+            Self::File(fd_num, kind, target) => {
                 if let Some(fd_num) = fd_num {
                     write!(f, "{fd_num}")?;
                 }
 
                 write!(f, "{kind} {target}")?;
             }
-            IoRedirect::OutputAndError(target, append) => {
+            Self::OutputAndError(target, append) => {
                 write!(f, "&>")?;
                 if *append {
                     write!(f, ">")?;
                 }
                 write!(f, " {target}")?;
             }
-            IoRedirect::HereDocument(
+            Self::HereDocument(
                 fd_num,
                 IoHereDocument {
                     remove_tabs,
@@ -973,7 +973,7 @@ impl Display for IoRedirect {
                 write!(f, "{doc}")?;
                 writeln!(f, "{here_end}")?;
             }
-            IoRedirect::HereString(fd_num, s) => {
+            Self::HereString(fd_num, s) => {
                 if let Some(fd_num) = fd_num {
                     write!(f, "{fd_num}")?;
                 }
@@ -1010,13 +1010,13 @@ pub enum IoFileRedirectKind {
 impl Display for IoFileRedirectKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IoFileRedirectKind::Read => write!(f, "<"),
-            IoFileRedirectKind::Write => write!(f, ">"),
-            IoFileRedirectKind::Append => write!(f, ">>"),
-            IoFileRedirectKind::ReadAndWrite => write!(f, "<>"),
-            IoFileRedirectKind::Clobber => write!(f, ">|"),
-            IoFileRedirectKind::DuplicateInput => write!(f, "<&"),
-            IoFileRedirectKind::DuplicateOutput => write!(f, ">&"),
+            Self::Read => write!(f, "<"),
+            Self::Write => write!(f, ">"),
+            Self::Append => write!(f, ">>"),
+            Self::ReadAndWrite => write!(f, "<>"),
+            Self::Clobber => write!(f, ">|"),
+            Self::DuplicateInput => write!(f, "<&"),
+            Self::DuplicateOutput => write!(f, ">&"),
         }
     }
 }
@@ -1038,9 +1038,9 @@ pub enum IoFileRedirectTarget {
 impl Display for IoFileRedirectTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IoFileRedirectTarget::Filename(word) => write!(f, "{word}"),
-            IoFileRedirectTarget::Fd(fd) => write!(f, "{fd}"),
-            IoFileRedirectTarget::ProcessSubstitution(kind, subshell_command) => {
+            Self::Filename(word) => write!(f, "{word}"),
+            Self::Fd(fd) => write!(f, "{fd}"),
+            Self::ProcessSubstitution(kind, subshell_command) => {
                 write!(f, "{kind}{subshell_command}")
             }
         }
@@ -1089,14 +1089,14 @@ pub enum TestExpr {
 impl Display for TestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TestExpr::False => Ok(()),
-            TestExpr::Literal(s) => write!(f, "{s}"),
-            TestExpr::And(left, right) => write!(f, "{left} -a {right}"),
-            TestExpr::Or(left, right) => write!(f, "{left} -o {right}"),
-            TestExpr::Not(expr) => write!(f, "! {expr}"),
-            TestExpr::Parenthesized(expr) => write!(f, "( {expr} )"),
-            TestExpr::UnaryTest(pred, word) => write!(f, "{pred} {word}"),
-            TestExpr::BinaryTest(left, op, right) => write!(f, "{left} {op} {right}"),
+            Self::False => Ok(()),
+            Self::Literal(s) => write!(f, "{s}"),
+            Self::And(left, right) => write!(f, "{left} -a {right}"),
+            Self::Or(left, right) => write!(f, "{left} -o {right}"),
+            Self::Not(expr) => write!(f, "! {expr}"),
+            Self::Parenthesized(expr) => write!(f, "( {expr} )"),
+            Self::UnaryTest(pred, word) => write!(f, "{pred} {word}"),
+            Self::BinaryTest(left, op, right) => write!(f, "{left} {op} {right}"),
         }
     }
 }
@@ -1123,22 +1123,22 @@ pub enum ExtendedTestExpr {
 impl Display for ExtendedTestExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExtendedTestExpr::And(left, right) => {
+            Self::And(left, right) => {
                 write!(f, "{left} && {right}")
             }
-            ExtendedTestExpr::Or(left, right) => {
+            Self::Or(left, right) => {
                 write!(f, "{left} || {right}")
             }
-            ExtendedTestExpr::Not(expr) => {
+            Self::Not(expr) => {
                 write!(f, "! {expr}")
             }
-            ExtendedTestExpr::Parenthesized(expr) => {
+            Self::Parenthesized(expr) => {
                 write!(f, "( {expr} )")
             }
-            ExtendedTestExpr::UnaryTest(pred, word) => {
+            Self::UnaryTest(pred, word) => {
                 write!(f, "{pred} {word}")
             }
-            ExtendedTestExpr::BinaryTest(pred, left, right) => {
+            Self::BinaryTest(pred, left, right) => {
                 write!(f, "{left} {pred} {right}")
             }
         }
@@ -1206,30 +1206,30 @@ pub enum UnaryPredicate {
 impl Display for UnaryPredicate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UnaryPredicate::FileExists => write!(f, "-e"),
-            UnaryPredicate::FileExistsAndIsBlockSpecialFile => write!(f, "-b"),
-            UnaryPredicate::FileExistsAndIsCharSpecialFile => write!(f, "-c"),
-            UnaryPredicate::FileExistsAndIsDir => write!(f, "-d"),
-            UnaryPredicate::FileExistsAndIsRegularFile => write!(f, "-f"),
-            UnaryPredicate::FileExistsAndIsSetgid => write!(f, "-g"),
-            UnaryPredicate::FileExistsAndIsSymlink => write!(f, "-h"),
-            UnaryPredicate::FileExistsAndHasStickyBit => write!(f, "-k"),
-            UnaryPredicate::FileExistsAndIsFifo => write!(f, "-p"),
-            UnaryPredicate::FileExistsAndIsReadable => write!(f, "-r"),
-            UnaryPredicate::FileExistsAndIsNotZeroLength => write!(f, "-s"),
-            UnaryPredicate::FdIsOpenTerminal => write!(f, "-t"),
-            UnaryPredicate::FileExistsAndIsSetuid => write!(f, "-u"),
-            UnaryPredicate::FileExistsAndIsWritable => write!(f, "-w"),
-            UnaryPredicate::FileExistsAndIsExecutable => write!(f, "-x"),
-            UnaryPredicate::FileExistsAndOwnedByEffectiveGroupId => write!(f, "-G"),
-            UnaryPredicate::FileExistsAndModifiedSinceLastRead => write!(f, "-N"),
-            UnaryPredicate::FileExistsAndOwnedByEffectiveUserId => write!(f, "-O"),
-            UnaryPredicate::FileExistsAndIsSocket => write!(f, "-S"),
-            UnaryPredicate::ShellOptionEnabled => write!(f, "-o"),
-            UnaryPredicate::ShellVariableIsSetAndAssigned => write!(f, "-v"),
-            UnaryPredicate::ShellVariableIsSetAndNameRef => write!(f, "-R"),
-            UnaryPredicate::StringHasZeroLength => write!(f, "-z"),
-            UnaryPredicate::StringHasNonZeroLength => write!(f, "-n"),
+            Self::FileExists => write!(f, "-e"),
+            Self::FileExistsAndIsBlockSpecialFile => write!(f, "-b"),
+            Self::FileExistsAndIsCharSpecialFile => write!(f, "-c"),
+            Self::FileExistsAndIsDir => write!(f, "-d"),
+            Self::FileExistsAndIsRegularFile => write!(f, "-f"),
+            Self::FileExistsAndIsSetgid => write!(f, "-g"),
+            Self::FileExistsAndIsSymlink => write!(f, "-h"),
+            Self::FileExistsAndHasStickyBit => write!(f, "-k"),
+            Self::FileExistsAndIsFifo => write!(f, "-p"),
+            Self::FileExistsAndIsReadable => write!(f, "-r"),
+            Self::FileExistsAndIsNotZeroLength => write!(f, "-s"),
+            Self::FdIsOpenTerminal => write!(f, "-t"),
+            Self::FileExistsAndIsSetuid => write!(f, "-u"),
+            Self::FileExistsAndIsWritable => write!(f, "-w"),
+            Self::FileExistsAndIsExecutable => write!(f, "-x"),
+            Self::FileExistsAndOwnedByEffectiveGroupId => write!(f, "-G"),
+            Self::FileExistsAndModifiedSinceLastRead => write!(f, "-N"),
+            Self::FileExistsAndOwnedByEffectiveUserId => write!(f, "-O"),
+            Self::FileExistsAndIsSocket => write!(f, "-S"),
+            Self::ShellOptionEnabled => write!(f, "-o"),
+            Self::ShellVariableIsSetAndAssigned => write!(f, "-v"),
+            Self::ShellVariableIsSetAndNameRef => write!(f, "-R"),
+            Self::StringHasZeroLength => write!(f, "-z"),
+            Self::StringHasNonZeroLength => write!(f, "-n"),
         }
     }
 }
@@ -1278,23 +1278,23 @@ pub enum BinaryPredicate {
 impl Display for BinaryPredicate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BinaryPredicate::FilesReferToSameDeviceAndInodeNumbers => write!(f, "-ef"),
-            BinaryPredicate::LeftFileIsNewerOrExistsWhenRightDoesNot => write!(f, "-nt"),
-            BinaryPredicate::LeftFileIsOlderOrDoesNotExistWhenRightDoes => write!(f, "-ot"),
-            BinaryPredicate::StringExactlyMatchesPattern => write!(f, "=="),
-            BinaryPredicate::StringDoesNotExactlyMatchPattern => write!(f, "!="),
-            BinaryPredicate::StringMatchesRegex => write!(f, "=~"),
-            BinaryPredicate::StringContainsSubstring => write!(f, "=~"),
-            BinaryPredicate::StringExactlyMatchesString => write!(f, "=="),
-            BinaryPredicate::StringDoesNotExactlyMatchString => write!(f, "!="),
-            BinaryPredicate::LeftSortsBeforeRight => write!(f, "<"),
-            BinaryPredicate::LeftSortsAfterRight => write!(f, ">"),
-            BinaryPredicate::ArithmeticEqualTo => write!(f, "-eq"),
-            BinaryPredicate::ArithmeticNotEqualTo => write!(f, "-ne"),
-            BinaryPredicate::ArithmeticLessThan => write!(f, "-lt"),
-            BinaryPredicate::ArithmeticLessThanOrEqualTo => write!(f, "-le"),
-            BinaryPredicate::ArithmeticGreaterThan => write!(f, "-gt"),
-            BinaryPredicate::ArithmeticGreaterThanOrEqualTo => write!(f, "-ge"),
+            Self::FilesReferToSameDeviceAndInodeNumbers => write!(f, "-ef"),
+            Self::LeftFileIsNewerOrExistsWhenRightDoesNot => write!(f, "-nt"),
+            Self::LeftFileIsOlderOrDoesNotExistWhenRightDoes => write!(f, "-ot"),
+            Self::StringExactlyMatchesPattern => write!(f, "=="),
+            Self::StringDoesNotExactlyMatchPattern => write!(f, "!="),
+            Self::StringMatchesRegex => write!(f, "=~"),
+            Self::StringContainsSubstring => write!(f, "=~"),
+            Self::StringExactlyMatchesString => write!(f, "=="),
+            Self::StringDoesNotExactlyMatchString => write!(f, "!="),
+            Self::LeftSortsBeforeRight => write!(f, "<"),
+            Self::LeftSortsAfterRight => write!(f, ">"),
+            Self::ArithmeticEqualTo => write!(f, "-eq"),
+            Self::ArithmeticNotEqualTo => write!(f, "-ne"),
+            Self::ArithmeticLessThan => write!(f, "-lt"),
+            Self::ArithmeticLessThanOrEqualTo => write!(f, "-le"),
+            Self::ArithmeticGreaterThan => write!(f, "-gt"),
+            Self::ArithmeticGreaterThanOrEqualTo => write!(f, "-ge"),
         }
     }
 }
@@ -1317,12 +1317,12 @@ impl Display for Word {
 }
 
 impl From<&tokenizer::Token> for Word {
-    fn from(t: &tokenizer::Token) -> Word {
+    fn from(t: &tokenizer::Token) -> Self {
         match t {
-            tokenizer::Token::Word(value, _) => Word {
+            tokenizer::Token::Word(value, _) => Self {
                 value: value.clone(),
             },
-            tokenizer::Token::Operator(value, _) => Word {
+            tokenizer::Token::Operator(value, _) => Self {
                 value: value.clone(),
             },
         }
@@ -1330,8 +1330,8 @@ impl From<&tokenizer::Token> for Word {
 }
 
 impl From<String> for Word {
-    fn from(s: String) -> Word {
-        Word { value: s }
+    fn from(s: String) -> Self {
+        Self { value: s }
     }
 }
 
@@ -1405,32 +1405,32 @@ impl<'a> arbitrary::Arbitrary<'a> for ArithmeticExpr {
         ])?;
 
         match *variant {
-            "Literal" => Ok(ArithmeticExpr::Literal(i64::arbitrary(u)?)),
-            "Reference" => Ok(ArithmeticExpr::Reference(ArithmeticTarget::arbitrary(u)?)),
-            "UnaryOp" => Ok(ArithmeticExpr::UnaryOp(
+            "Literal" => Ok(Self::Literal(i64::arbitrary(u)?)),
+            "Reference" => Ok(Self::Reference(ArithmeticTarget::arbitrary(u)?)),
+            "UnaryOp" => Ok(Self::UnaryOp(
                 UnaryOperator::arbitrary(u)?,
-                Box::new(ArithmeticExpr::arbitrary(u)?),
+                Box::new(Self::arbitrary(u)?),
             )),
-            "BinaryOp" => Ok(ArithmeticExpr::BinaryOp(
+            "BinaryOp" => Ok(Self::BinaryOp(
                 BinaryOperator::arbitrary(u)?,
-                Box::new(ArithmeticExpr::arbitrary(u)?),
-                Box::new(ArithmeticExpr::arbitrary(u)?),
+                Box::new(Self::arbitrary(u)?),
+                Box::new(Self::arbitrary(u)?),
             )),
-            "Conditional" => Ok(ArithmeticExpr::Conditional(
-                Box::new(ArithmeticExpr::arbitrary(u)?),
-                Box::new(ArithmeticExpr::arbitrary(u)?),
-                Box::new(ArithmeticExpr::arbitrary(u)?),
+            "Conditional" => Ok(Self::Conditional(
+                Box::new(Self::arbitrary(u)?),
+                Box::new(Self::arbitrary(u)?),
+                Box::new(Self::arbitrary(u)?),
             )),
-            "Assignment" => Ok(ArithmeticExpr::Assignment(
+            "Assignment" => Ok(Self::Assignment(
                 ArithmeticTarget::arbitrary(u)?,
-                Box::new(ArithmeticExpr::arbitrary(u)?),
+                Box::new(Self::arbitrary(u)?),
             )),
-            "BinaryAssignment" => Ok(ArithmeticExpr::BinaryAssignment(
+            "BinaryAssignment" => Ok(Self::BinaryAssignment(
                 BinaryOperator::arbitrary(u)?,
                 ArithmeticTarget::arbitrary(u)?,
-                Box::new(ArithmeticExpr::arbitrary(u)?),
+                Box::new(Self::arbitrary(u)?),
             )),
-            "UnaryAssignment" => Ok(ArithmeticExpr::UnaryAssignment(
+            "UnaryAssignment" => Ok(Self::UnaryAssignment(
                 UnaryAssignmentOperator::arbitrary(u)?,
                 ArithmeticTarget::arbitrary(u)?,
             )),
@@ -1442,24 +1442,24 @@ impl<'a> arbitrary::Arbitrary<'a> for ArithmeticExpr {
 impl Display for ArithmeticExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ArithmeticExpr::Literal(literal) => write!(f, "{literal}"),
-            ArithmeticExpr::Reference(target) => write!(f, "{target}"),
-            ArithmeticExpr::UnaryOp(op, operand) => write!(f, "{op}{operand}"),
-            ArithmeticExpr::BinaryOp(op, left, right) => {
+            Self::Literal(literal) => write!(f, "{literal}"),
+            Self::Reference(target) => write!(f, "{target}"),
+            Self::UnaryOp(op, operand) => write!(f, "{op}{operand}"),
+            Self::BinaryOp(op, left, right) => {
                 if matches!(op, BinaryOperator::Comma) {
                     write!(f, "{left}{op} {right}")
                 } else {
                     write!(f, "{left} {op} {right}")
                 }
             }
-            ArithmeticExpr::Conditional(condition, if_branch, else_branch) => {
+            Self::Conditional(condition, if_branch, else_branch) => {
                 write!(f, "{condition} ? {if_branch} : {else_branch}")
             }
-            ArithmeticExpr::Assignment(target, value) => write!(f, "{target} = {value}"),
-            ArithmeticExpr::BinaryAssignment(op, target, operand) => {
+            Self::Assignment(target, value) => write!(f, "{target} = {value}"),
+            Self::BinaryAssignment(op, target, operand) => {
                 write!(f, "{target} {op}= {operand}")
             }
-            ArithmeticExpr::UnaryAssignment(op, target) => match op {
+            Self::UnaryAssignment(op, target) => match op {
                 UnaryAssignmentOperator::PrefixIncrement
                 | UnaryAssignmentOperator::PrefixDecrement => write!(f, "{op}{target}"),
                 UnaryAssignmentOperator::PostfixIncrement
@@ -1519,26 +1519,26 @@ pub enum BinaryOperator {
 impl Display for BinaryOperator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BinaryOperator::Power => write!(f, "**"),
-            BinaryOperator::Multiply => write!(f, "*"),
-            BinaryOperator::Divide => write!(f, "/"),
-            BinaryOperator::Modulo => write!(f, "%"),
-            BinaryOperator::Comma => write!(f, ","),
-            BinaryOperator::Add => write!(f, "+"),
-            BinaryOperator::Subtract => write!(f, "-"),
-            BinaryOperator::ShiftLeft => write!(f, "<<"),
-            BinaryOperator::ShiftRight => write!(f, ">>"),
-            BinaryOperator::LessThan => write!(f, "<"),
-            BinaryOperator::LessThanOrEqualTo => write!(f, "<="),
-            BinaryOperator::GreaterThan => write!(f, ">"),
-            BinaryOperator::GreaterThanOrEqualTo => write!(f, ">="),
-            BinaryOperator::Equals => write!(f, "=="),
-            BinaryOperator::NotEquals => write!(f, "!="),
-            BinaryOperator::BitwiseAnd => write!(f, "&"),
-            BinaryOperator::BitwiseXor => write!(f, "^"),
-            BinaryOperator::BitwiseOr => write!(f, "|"),
-            BinaryOperator::LogicalAnd => write!(f, "&&"),
-            BinaryOperator::LogicalOr => write!(f, "||"),
+            Self::Power => write!(f, "**"),
+            Self::Multiply => write!(f, "*"),
+            Self::Divide => write!(f, "/"),
+            Self::Modulo => write!(f, "%"),
+            Self::Comma => write!(f, ","),
+            Self::Add => write!(f, "+"),
+            Self::Subtract => write!(f, "-"),
+            Self::ShiftLeft => write!(f, "<<"),
+            Self::ShiftRight => write!(f, ">>"),
+            Self::LessThan => write!(f, "<"),
+            Self::LessThanOrEqualTo => write!(f, "<="),
+            Self::GreaterThan => write!(f, ">"),
+            Self::GreaterThanOrEqualTo => write!(f, ">="),
+            Self::Equals => write!(f, "=="),
+            Self::NotEquals => write!(f, "!="),
+            Self::BitwiseAnd => write!(f, "&"),
+            Self::BitwiseXor => write!(f, "^"),
+            Self::BitwiseOr => write!(f, "|"),
+            Self::LogicalAnd => write!(f, "&&"),
+            Self::LogicalOr => write!(f, "||"),
         }
     }
 }
@@ -1561,10 +1561,10 @@ pub enum UnaryOperator {
 impl Display for UnaryOperator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UnaryOperator::UnaryPlus => write!(f, "+"),
-            UnaryOperator::UnaryMinus => write!(f, "-"),
-            UnaryOperator::BitwiseNot => write!(f, "~"),
-            UnaryOperator::LogicalNot => write!(f, "!"),
+            Self::UnaryPlus => write!(f, "+"),
+            Self::UnaryMinus => write!(f, "-"),
+            Self::BitwiseNot => write!(f, "~"),
+            Self::LogicalNot => write!(f, "!"),
         }
     }
 }
@@ -1587,10 +1587,10 @@ pub enum UnaryAssignmentOperator {
 impl Display for UnaryAssignmentOperator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UnaryAssignmentOperator::PrefixIncrement => write!(f, "++"),
-            UnaryAssignmentOperator::PrefixDecrement => write!(f, "--"),
-            UnaryAssignmentOperator::PostfixIncrement => write!(f, "++"),
-            UnaryAssignmentOperator::PostfixDecrement => write!(f, "--"),
+            Self::PrefixIncrement => write!(f, "++"),
+            Self::PrefixDecrement => write!(f, "--"),
+            Self::PostfixIncrement => write!(f, "++"),
+            Self::PostfixDecrement => write!(f, "--"),
         }
     }
 }
@@ -1609,8 +1609,8 @@ pub enum ArithmeticTarget {
 impl Display for ArithmeticTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ArithmeticTarget::Variable(name) => write!(f, "{name}"),
-            ArithmeticTarget::ArrayElement(name, index) => write!(f, "{name}[{index}]"),
+            Self::Variable(name) => write!(f, "{name}"),
+            Self::ArrayElement(name, index) => write!(f, "{name}[{index}]"),
         }
     }
 }

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -1,7 +1,5 @@
 //! Implements a tokenizer and parsers for POSIX / bash shell syntax.
 
-#![deny(missing_docs)]
-
 pub mod arithmetic;
 pub mod ast;
 pub mod pattern;

--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -28,7 +28,7 @@ impl Default for ParserOptions {
 
 impl ParserOptions {
     /// Returns the tokenizer options implied by these parser options.
-    pub fn tokenizer_options(&self) -> TokenizerOptions {
+    pub const fn tokenizer_options(&self) -> TokenizerOptions {
         TokenizerOptions {
             enable_extended_globbing: self.enable_extended_globbing,
             posix_mode: self.posix_mode,
@@ -53,7 +53,7 @@ impl<R: std::io::BufRead> Parser<R> {
     /// * `options` - The options to use when parsing.
     /// * `source_info` - Information about the source of the tokens.
     pub fn new(reader: R, options: &ParserOptions, source_info: &SourceInfo) -> Self {
-        Parser {
+        Self {
             reader,
             options: options.clone(),
             source_info: source_info.clone(),
@@ -916,7 +916,7 @@ fn add_pipe_extension_redirection(c: &mut ast::Command) -> Result<(), &'static s
     Ok(())
 }
 
-fn locations_are_contiguous(
+const fn locations_are_contiguous(
     loc_left: &crate::TokenLocation,
     loc_right: &crate::TokenLocation,
 ) -> bool {
@@ -963,7 +963,7 @@ mod tests {
     use insta::assert_ron_snapshot;
 
     #[derive(serde::Serialize)]
-    struct ParseResult<'a, T: serde::Serialize> {
+    struct ParseResult<'a, T> {
         input: &'a str,
         result: &'a T,
     }

--- a/brush-parser/src/pattern.rs
+++ b/brush-parser/src/pattern.rs
@@ -149,7 +149,7 @@ peg::parser! {
 /// # Arguments
 ///
 /// * `c` - The character to check.
-pub fn regex_char_needs_escaping(c: char) -> bool {
+pub const fn regex_char_needs_escaping(c: char) -> bool {
     matches!(
         c,
         '[' | ']' | '(' | ')' | '{' | '}' | '*' | '?' | '.' | '+' | '^' | '$' | '|' | '\\'

--- a/brush-parser/src/readline_binding.rs
+++ b/brush-parser/src/readline_binding.rs
@@ -3,8 +3,8 @@
 use crate::error;
 
 /// Represents a readline key-sequence binding.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(test, derive(Eq, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct KeySequenceBinding {
     /// Key sequence to bind
     pub seq: KeySequence,
@@ -13,13 +13,13 @@ pub struct KeySequenceBinding {
 }
 
 /// Represents a key sequence.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(test, derive(Eq, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct KeySequence(pub Vec<KeySequenceItem>);
 
 /// Represents an element of a key sequence.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(test, derive(Eq, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub enum KeySequenceItem {
     /// Control
     Control,
@@ -30,8 +30,8 @@ pub enum KeySequenceItem {
 }
 
 /// Represents a single key stroke.
-#[derive(Debug, Default, Clone, PartialEq)]
-#[cfg_attr(test, derive(Eq, serde::Serialize))]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct KeyStroke {
     /// Meta key is held down
     pub meta: bool,

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -389,14 +389,14 @@ impl BraceExpressionOrText {
     /// Generates expansions for this value.
     pub fn generate(self) -> Box<dyn Iterator<Item = String>> {
         match self {
-            BraceExpressionOrText::Expr(members) => {
+            Self::Expr(members) => {
                 let mut iters = vec![];
                 for m in members {
                     iters.push(m.generate());
                 }
                 Box::new(iters.into_iter().flatten())
             }
-            BraceExpressionOrText::Text(text) => Box::new(std::iter::once(text)),
+            Self::Text(text) => Box::new(std::iter::once(text)),
         }
     }
 }
@@ -432,7 +432,7 @@ impl BraceExpressionMember {
     #[allow(clippy::cast_sign_loss)]
     pub fn generate(self) -> Box<dyn Iterator<Item = String>> {
         match self {
-            BraceExpressionMember::NumberSequence {
+            Self::NumberSequence {
                 low,
                 high,
                 increment,
@@ -441,7 +441,7 @@ impl BraceExpressionMember {
                     .step_by(increment as usize)
                     .map(|n| n.to_string()),
             ),
-            BraceExpressionMember::CharSequence {
+            Self::CharSequence {
                 low,
                 high,
                 increment,
@@ -450,7 +450,7 @@ impl BraceExpressionMember {
                     .step_by(increment as usize)
                     .map(|c| c.to_string()),
             ),
-            BraceExpressionMember::Text(text) => Box::new(std::iter::once(text)),
+            Self::Text(text) => Box::new(std::iter::once(text)),
         }
     }
 }

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -1,3 +1,5 @@
+//! Types for brush command-line parsing.
+
 use clap::{Parser, builder::styling};
 use std::io::IsTerminal;
 
@@ -155,6 +157,7 @@ pub struct CommandLineArgs {
 }
 
 impl CommandLineArgs {
+    /// Returns whether or not the arguments indicate that the shell should run in interactive mode.
     pub fn is_interactive(&self) -> bool {
         if self.interactive {
             return true;

--- a/brush-shell/src/brushctl.rs
+++ b/brush-shell/src/brushctl.rs
@@ -66,7 +66,7 @@ impl EventsCommand {
 
         if let Some(event_config) = event_config.as_mut() {
             match self {
-                EventsCommand::Status => {
+                Self::Status => {
                     let enabled_events = event_config.get_enabled_events();
                     for event in enabled_events {
                         writeln!(context.stdout(), "{event}").unwrap(); // Add .unwrap() to handle
@@ -74,8 +74,8 @@ impl EventsCommand {
                         // errors
                     }
                 }
-                EventsCommand::Enable { event } => event_config.enable(*event)?,
-                EventsCommand::Disable { event } => event_config.disable(*event)?,
+                Self::Enable { event } => event_config.enable(*event)?,
+                Self::Disable { event } => event_config.disable(*event)?,
             }
 
             Ok(brush_core::builtins::ExitCode::Success)

--- a/brush-shell/src/events.rs
+++ b/brush-shell/src/events.rs
@@ -1,3 +1,5 @@
+//! Facilities for configuring event tracing in the brush shell.
+
 use std::{collections::HashSet, fmt::Display};
 
 use brush_core::Error;
@@ -46,17 +48,17 @@ pub enum TraceEvent {
 impl Display for TraceEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TraceEvent::Arithmetic => write!(f, "arithmetic"),
-            TraceEvent::Commands => write!(f, "commands"),
-            TraceEvent::Complete => write!(f, "complete"),
-            TraceEvent::Expand => write!(f, "expand"),
-            TraceEvent::Functions => write!(f, "functions"),
-            TraceEvent::Input => write!(f, "input"),
-            TraceEvent::Jobs => write!(f, "jobs"),
-            TraceEvent::Parse => write!(f, "parse"),
-            TraceEvent::Pattern => write!(f, "pattern"),
-            TraceEvent::Tokenize => write!(f, "tokenize"),
-            TraceEvent::Unimplemented => write!(f, "unimplemented"),
+            Self::Arithmetic => write!(f, "arithmetic"),
+            Self::Commands => write!(f, "commands"),
+            Self::Complete => write!(f, "complete"),
+            Self::Expand => write!(f, "expand"),
+            Self::Functions => write!(f, "functions"),
+            Self::Input => write!(f, "input"),
+            Self::Jobs => write!(f, "jobs"),
+            Self::Parse => write!(f, "parse"),
+            Self::Pattern => write!(f, "pattern"),
+            Self::Tokenize => write!(f, "tokenize"),
+            Self::Unimplemented => write!(f, "unimplemented"),
         }
     }
 }
@@ -69,15 +71,12 @@ pub(crate) struct TraceEventConfig {
 }
 
 impl TraceEventConfig {
-    pub fn init(
-        enabled_debug_events: &[TraceEvent],
-        disabled_events: &[TraceEvent],
-    ) -> TraceEventConfig {
+    pub fn init(enabled_debug_events: &[TraceEvent], disabled_events: &[TraceEvent]) -> Self {
         let enabled_debug_events: HashSet<TraceEvent> =
             enabled_debug_events.iter().copied().collect();
         let disabled_events: HashSet<TraceEvent> = disabled_events.iter().copied().collect();
 
-        let mut config = TraceEventConfig {
+        let mut config = Self {
             enabled_debug_events,
             disabled_events,
             ..Default::default()
@@ -149,7 +148,7 @@ impl TraceEventConfig {
         }
     }
 
-    pub fn get_enabled_events(&self) -> &HashSet<TraceEvent> {
+    pub const fn get_enabled_events(&self) -> &HashSet<TraceEvent> {
         &self.enabled_debug_events
     }
 
@@ -171,7 +170,7 @@ impl TraceEventConfig {
         self.reload_filter()
     }
 
-    fn reload_filter(&mut self) -> Result<(), Error> {
+    fn reload_filter(&self) -> Result<(), Error> {
         if let Some(handle) = &self.handle {
             if handle.reload(self.compose_filter()).is_ok() {
                 Ok(())

--- a/brush-shell/src/lib.rs
+++ b/brush-shell/src/lib.rs
@@ -1,3 +1,5 @@
+//! Create for brush, an executable bash-compatible shell.
+
 #![allow(dead_code)]
 
 pub mod args;

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -410,7 +410,7 @@ impl TestCaseSetResults {
                 "Running test case set".blue(),
                 self.name
                     .as_ref()
-                    .unwrap_or(&("(unnamed)".to_owned()))
+                    .map_or_else(|| "(unnamed)", |n| n.as_str())
                     .italic(),
                 self.config_name.magenta(),
             )?;
@@ -545,7 +545,7 @@ impl TestCaseResult {
             "Test case".bright_yellow(),
             self.name
                 .as_ref()
-                .unwrap_or(&("(unnamed)".to_owned()))
+                .map_or_else(|| "(unnamed)", |n| n.as_str())
                 .italic()
         )?;
 
@@ -1170,7 +1170,7 @@ struct RunComparison {
 }
 
 impl RunComparison {
-    pub fn is_failure(&self) -> bool {
+    pub const fn is_failure(&self) -> bool {
         self.exit_status.is_failure()
             || self.stdout.is_failure()
             || self.stderr.is_failure()
@@ -1212,10 +1212,10 @@ enum ExitStatusComparison {
 }
 
 impl ExitStatusComparison {
-    pub fn is_failure(&self) -> bool {
+    pub const fn is_failure(&self) -> bool {
         matches!(
             self,
-            ExitStatusComparison::TestDiffers {
+            Self::TestDiffers {
                 test_exit_status: _,
                 oracle_exit_status: _
             }
@@ -1237,10 +1237,10 @@ enum StringComparison {
 }
 
 impl StringComparison {
-    pub fn is_failure(&self) -> bool {
+    pub const fn is_failure(&self) -> bool {
         matches!(
             self,
-            StringComparison::TestDiffers {
+            Self::TestDiffers {
                 test_string: _,
                 oracle_string: _
             }
@@ -1261,8 +1261,8 @@ enum DirComparison {
 }
 
 impl DirComparison {
-    pub fn is_failure(&self) -> bool {
-        matches!(self, DirComparison::TestDiffers(_))
+    pub const fn is_failure(&self) -> bool {
+        matches!(self, Self::TestDiffers(_))
     }
 }
 

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -48,9 +48,10 @@ impl TestShellWithBashCompletion {
 
     fn find_bash_completion_script() -> Result<PathBuf> {
         // See if an environmental override was provided.
-        let script_path = std::env::var("BASH_COMPLETION_PATH")
-            .map(PathBuf::from)
-            .unwrap_or(PathBuf::from(DEFAULT_BASH_COMPLETION_SCRIPT));
+        let script_path = std::env::var("BASH_COMPLETION_PATH").map_or_else(
+            |_| PathBuf::from(DEFAULT_BASH_COMPLETION_SCRIPT),
+            PathBuf::from,
+        );
 
         if script_path.exists() {
             Ok(script_path)

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![allow(missing_docs)]
 
 use std::sync::LazyLock;
 

--- a/fuzz/fuzz_targets/fuzz_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_parse.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![allow(missing_docs)]
 
 use anyhow::Result;
 use libfuzzer_sys::fuzz_target;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+//! xtask-style command-line tool for building this project.
+
 use std::path::PathBuf;
 
 use anyhow::Result;


### PR DESCRIPTION
Enables a few more groups of lints across the project. Notably:

* Enables many of the `nursery` rules
* Enables a few more documentation checks on crates/modules

Enabling these rules entailed a number of changes, e.g.:

* Replacing explicit named types with `Self`
* Adding `const` annotation to various `const`-able functions
* Adding some missing `+ Send` constraints
* Adding some missing comments