### PR TITLE
fix(traps): add stub definition for RETURN trap

### DIFF
--- a/brush-core/src/sys/unix/signal.rs
+++ b/brush-core/src/sys/unix/signal.rs
@@ -13,7 +13,10 @@ pub(crate) fn kill_process(
 ) -> Result<(), error::Error> {
     let translated_signal = match signal {
         traps::TrapSignal::Signal(signal) => signal,
-        traps::TrapSignal::Debug | traps::TrapSignal::Err | traps::TrapSignal::Exit => {
+        traps::TrapSignal::Debug
+        | traps::TrapSignal::Err
+        | traps::TrapSignal::Exit
+        | traps::TrapSignal::Return => {
             return Err(error::Error::InvalidSignal(signal.to_string()));
         }
     };

--- a/brush-core/src/traps.rs
+++ b/brush-core/src/traps.rs
@@ -19,6 +19,8 @@ pub enum TrapSignal {
     Err,
     /// The `EXIT` trap.
     Exit,
+    /// The `RETURN` trp.
+    Return,
 }
 
 impl Display for TrapSignal {
@@ -50,6 +52,7 @@ impl TrapSignal {
             Self::Debug => "DEBUG",
             Self::Err => "ERR",
             Self::Exit => "EXIT",
+            Self::Return => "RETURN",
         }
     }
 }
@@ -115,6 +118,7 @@ impl TryFrom<&str> for TrapSignal {
             "DEBUG" => Self::Debug,
             "ERR" => Self::Err,
             "EXIT" => Self::Exit,
+            "RETURN" => Self::Return,
 
             #[cfg(unix)]
             _ => {


### PR DESCRIPTION
This doesn't actually implement the trap but ensures that it's not considered "invalid" when specified to `trap`.