### PR TITLE
fix(functions): allow func names to contain slashes

### DIFF
--- a/brush-shell/tests/cases/functions.yaml
+++ b/brush-shell/tests/cases/functions.yaml
@@ -100,3 +100,11 @@ cases:
       export -f mytestfunc
 
       $0 -c 'mytestfunc'
+
+  - name: "Function names with interesting characters"
+    stdin: |
+      my/func() {
+          echo "In my/func"
+      }
+
+      my/func


### PR DESCRIPTION
`ble.sh` (and others) rely heavily on functions with `/` in their names. This adds a test for this case and fixes the resolution logic in command execution to support them.