### PR TITLE
fix(tokenizer): handle escaped single-quote in ANSI-C quoted string

### DIFF
--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -38,9 +38,17 @@ cases:
       single_quoted='\n'
       echo "Single quoted len: ${#single_quoted}"
       echo -n '\n' | hexdump -C
+
       ansi_c_quoted=$'\n'
       echo "ANSI-C quoted len: ${#ansi_c_quoted}"
       echo -n $'\n' | hexdump -C
+
+  - name: "ANSI-C quotes with escaped single quote"
+    known_failure: true
+    stdin: |
+      ansi_c_quoted=$'\''
+      echo "ANSI-C quoted single quote len: ${#ansi_c_quoted}"
+      echo -n $'\'' | hexdump -C
 
   - name: "gettext style quotes"
     stdin: |


### PR DESCRIPTION
Fixes incorrect logic in the tokenizer that was getting tripped up by escaped quotes in ANSI-C strings.