### PR TITLE
fix(arithmetic): correct left shift handling

### DIFF
--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -730,15 +730,24 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
                     // track that the *next* token should be the here-tag.
                     //
                     if self.cross_state.arithmetic_expansion {
-                        // Nothing to do; we're in an arithmetic expansion so << and <<-
-                        // are not here-docs, they're either a left-shift operator or
-                        // a left-shift operator followed by a unary minus operator.
+                        //
+                        // We're in an arithmetic context; don't consider << and <<-
+                        // special. They're not here-docs, they're either a left-shift
+                        // operator or a left-shift operator followed by a unary
+                        // minus operator.
+                        //
+
+                        if state.is_specific_operator(")") && c == ')' {
+                            self.cross_state.arithmetic_expansion = false;
+                        }
                     } else if state.is_specific_operator("<<") {
                         self.cross_state.here_state =
                             HereState::NextTokenIsHereTag { remove_tabs: false };
                     } else if state.is_specific_operator("<<-") {
                         self.cross_state.here_state =
                             HereState::NextTokenIsHereTag { remove_tabs: true };
+                    } else if state.is_specific_operator("(") && c == '(' {
+                        self.cross_state.arithmetic_expansion = true;
                     }
 
                     let reason = if state.current_token() == "\n" {

--- a/brush-shell/tests/cases/arithmetic.yaml
+++ b/brush-shell/tests/cases/arithmetic.yaml
@@ -105,7 +105,6 @@ cases:
       echo " 1 << 4 == $((1<<4))"
 
   - name: Shift arithmetic in conditional"
-    known_failure: true
     stdin: |
       (( 1 >> 1 )) && echo "1. true"
       (( 1 << 1 )) && echo "2. true"

--- a/brush-shell/tests/cases/here.yaml
+++ b/brush-shell/tests/cases/here.yaml
@@ -19,6 +19,19 @@ cases:
           echo "This is after"
     args: ["./script.sh"]
 
+  - name: "Here doc in a function"
+    stdin: |
+      function myfunc() {
+        if true
+        then
+          cat << END-MARKER
+      Something here...
+      END-MARKER
+        fi
+      }
+
+      myfunc
+
   - name: "Here doc with expansions"
     stdin: |
       cat <<END-MARKER


### PR DESCRIPTION
Adds logic to the tokenizer to recognize `(( ... ))` as an arithmetic context, within which `<<` is not indicating a here-document.

_Aside: This is a targeted patch, and motivation for need to improve parsing._

Resolves #484.