### PR TITLE
fix(local): enable use of local to detect function

### DIFF
--- a/brush-core/src/builtins/declare.rs
+++ b/brush-core/src/builtins/declare.rs
@@ -132,6 +132,11 @@ impl builtins::Command for DeclareCommand {
             _ => DeclareVerb::Declare,
         };
 
+        if matches!(verb, DeclareVerb::Local) && !context.shell.in_function() {
+            writeln!(context.stderr(), "can only be used in a function")?;
+            return Ok(builtins::ExitCode::Custom(1));
+        }
+
         if self.locals_inherit_from_prev_scope {
             return error::unimp("declare -I");
         }

--- a/brush-shell/tests/cases/builtins/declare.yaml
+++ b/brush-shell/tests/cases/builtins/declare.yaml
@@ -162,6 +162,16 @@ cases:
 
       test
 
+  - name: "Using local to detect function presence"
+    stdin: |
+      function test {
+        local something 2>/dev/null && echo "In function"
+      }
+
+      local something 2>/dev/null || echo "Not in function"
+
+      test
+
   - name: "Displaying function names"
     stdin: |
       echo "Dumping function names"


### PR DESCRIPTION
Some scripts (like `ble.sh`) invoke `local` to detect if they're running within a function context. This adds a test case and fixes some behavior in the shared `declare`/`local` builtin implementation to make sure it works as expected.