### PR TITLE
fix(redirection): assorted fixes to redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you feel so inclined, we'd love contributions toward any of the above, with b
 
 ## 🧪 Testing strategy
 
-This project is primarily tested by comparing its behavior with other existing shells, leveraging the latter as test oracles. The integration tests implemented in this repo include [620+ test cases](brush-shell/tests/cases) run on both this shell and an oracle, comparing standard output and exit codes.
+This project is primarily tested by comparing its behavior with other existing shells, leveraging the latter as test oracles. The integration tests implemented in this repo include [675+ test cases](brush-shell/tests/cases) run on both this shell and an oracle, comparing standard output and exit codes.
 
 For more details, please consult the [reference documentation on integration testing](docs/reference/integration-testing.md).
 

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -1033,6 +1033,10 @@ pub enum IoFileRedirectTarget {
     /// Process substitution: substitution with the results of executing the given
     /// command in a subshell.
     ProcessSubstitution(ProcessSubstitutionKind, SubshellCommand),
+    /// Item to duplicate in a word redirection. After expansion, this could be a
+    /// filename, a file descriptor, or a file descriptor and a "-" to indicate
+    /// requested closure.
+    Duplicate(Word),
 }
 
 impl Display for IoFileRedirectTarget {
@@ -1043,6 +1047,7 @@ impl Display for IoFileRedirectTarget {
             Self::ProcessSubstitution(kind, subshell_command) => {
                 write!(f, "{kind}{subshell_command}")
             }
+            Self::Duplicate(word) => write!(f, "{word}"),
         }
     }
 }

--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -658,16 +658,15 @@ peg::parser! {
         // N.B. Process substitution forms are extensions to the POSIX standard.
         rule io_file() -> (ast::IoFileRedirectKind, ast::IoFileRedirectTarget) =
             specific_operator("<")  f:io_filename() { (ast::IoFileRedirectKind::Read, f) } /
-            specific_operator("<&") f:io_filename_or_fd() { (ast::IoFileRedirectKind::DuplicateInput, f) } /
+            specific_operator("<&") f:io_fd_duplication_source() { (ast::IoFileRedirectKind::DuplicateInput, f) } /
             specific_operator(">")  f:io_filename() { (ast::IoFileRedirectKind::Write, f) } /
-            specific_operator(">&") f:io_filename_or_fd() { (ast::IoFileRedirectKind::DuplicateOutput, f) } /
+            specific_operator(">&") f:io_fd_duplication_source() { (ast::IoFileRedirectKind::DuplicateOutput, f) } /
             specific_operator(">>") f:io_filename() { (ast::IoFileRedirectKind::Append, f) } /
             specific_operator("<>") f:io_filename() { (ast::IoFileRedirectKind::ReadAndWrite, f) } /
             specific_operator(">|") f:io_filename() { (ast::IoFileRedirectKind::Clobber, f) }
 
-        rule io_filename_or_fd() -> ast::IoFileRedirectTarget =
-            fd:io_fd() { ast::IoFileRedirectTarget::Fd(fd) } /
-            io_filename()
+        rule io_fd_duplication_source() -> ast::IoFileRedirectTarget =
+            w:word() { ast::IoFileRedirectTarget::Duplicate(ast::Word::from(w)) }
 
         rule io_fd() -> u32 =
             w:[Token::Word(_, _)] {? w.to_str().parse().or(Err("io_fd u32")) }

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
@@ -25,7 +25,9 @@ ParseResult(
           ),
         ), Sequence),
       ]))), Some(RedirectList([
-        File(Some(2), DuplicateOutput, Fd(1)),
+        File(Some(2), DuplicateOutput, Duplicate(W(
+          v: "1",
+        ))),
       ]))),
       source: "",
     )),

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
@@ -35,7 +35,9 @@ ParseResult(
                             Word(W(
                               v: "\"${f@L}\"",
                             )),
-                            IoRedirect(File(None, DuplicateOutput, Fd(2))),
+                            IoRedirect(File(None, DuplicateOutput, Duplicate(W(
+                              v: "2",
+                            )))),
                           ])),
                         )),
                       ],

--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -115,3 +115,84 @@ cases:
     ignore_stderr: true
     stdin: |
       echo hi > /non-existent-dir/file.txt; echo following-command
+
+  - name: "Redirection for opening read and write"
+    stdin: |
+      echo hi >file.txt
+      cat <>file.txt
+
+  - name: "Close output file descriptor"
+    ignore_stderr: true
+    stdin: |
+      # Open a new output fd (3).
+      exec 3>test.txt
+      # Write to the file.
+      echo "test" >&3
+      # Close the file.
+      exec 3>&-
+      # Make sure we can't write to it.
+      echo "after close" >&3 || echo "Cannot write to closed fd"
+
+  - name: "Close input file descriptor"
+    ignore_stderr: true
+    test_files:
+      - path: "input.txt"
+        contents: |
+          line1
+          line2
+    stdin: |
+      # Open an input file descriptor (3).
+      exec 3<input.txt
+      # Read from the file.
+      read line <&3
+      echo "Read: $line"
+      # Close the file descriptor.
+      exec 3<&-
+      # Make sure we can't read from it.
+      read line <&3 2>/dev/null || echo "Cannot read from closed fd"
+
+  - name: "Duplicate input file descriptor"
+    test_files:
+      - path: "input.txt"
+        contents: |
+          test input line
+    stdin: |
+      # Open an input file descriptor (3).
+      exec 3<input.txt
+      # Duplicate it to another descriptor (4).
+      exec 4<&3
+      # Read from the new descriptor.
+      read line <&4
+      echo "Read: $line"
+
+  - name: "Input file descriptor duplication from stdin"
+    stdin: |
+      exec 3<&0
+      echo "test" | { read line <&3; echo "Read: $line"; }
+
+  - name: "Multiple file descriptor redirections"
+    ignore_stderr: true
+    stdin: |
+      # Open multiple new output fds
+      exec 3>fd3.txt 4>fd4.txt 5>fd5.txt
+      # Write to the new fds
+      echo "fd3" >&3
+      echo "fd4" >&4
+      echo "fd5" >&5
+      # Close the fds
+      exec 3>&- 4>&- 5>&-
+      # Read from the files to verify
+      echo "[3]"
+      cat fd3.txt
+      echo "[4]"
+      fd4.txt
+      echo "[5]"
+      fd5.txt
+
+  - name: "High file descriptor numbers"
+    stdin: |
+      # Open high numbered file descriptor
+      echo "test" 10>fd10.txt >&10
+      # Dump the file
+      echo "[10]"
+      cat fd10.txt


### PR DESCRIPTION
More correctly handles `>&` cases where expansion is needed, and adds support for `>&-`, `>&N-`, etc.