### PR TITLE
feat(args): add --rcfile command-line option

### DIFF
--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -1,7 +1,7 @@
 //! Types for brush command-line parsing.
 
 use clap::{Parser, builder::styling};
-use std::io::IsTerminal;
+use std::{io::IsTerminal, path::PathBuf};
 
 use crate::{events, productinfo};
 
@@ -99,6 +99,10 @@ pub struct CommandLineArgs {
     /// Disable non-POSIX extensions.
     #[clap(long = "posix")]
     pub posix: bool,
+
+    /// Path to the rc file to load in interactive shells (instead of bash.bashrc and ~/.bashrc).
+    #[clap(long = "rcfile", alias = "init-file", value_name = "FILE")]
+    pub rc_file: Option<PathBuf>,
 
     /// Read commands from standard input.
     #[clap(short = 's')]

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -264,6 +264,7 @@ async fn instantiate_shell(
             no_editing: args.no_editing,
             no_profile: args.no_profile,
             no_rc: args.no_rc,
+            rc_file: args.rc_file.clone(),
             do_not_inherit_env: args.do_not_inherit_env,
             posix: args.posix || args.sh_mode,
             print_commands_and_arguments: args.print_commands_and_arguments,


### PR DESCRIPTION
Honors `--rcfile` (or `--init-file`) command-line arguments to override loading `/etc/bash.bashrc` + `~/.bashrc` in interactive shells.