### PR TITLE
fix(expansion): correct ${!PARAM@...}

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1245,7 +1245,7 @@ impl<'a> WordExpander<'a> {
         if !indirect {
             Ok(self.try_resolve_parameter_to_variable_without_indirect(parameter))
         } else {
-            let expansion = self.expand_parameter(parameter, true).await?;
+            let expansion = self.expand_parameter(parameter, false).await?;
             let parameter_str: String = expansion.into();
             let inner_parameter =
                 brush_parser::word::parse_parameter(parameter_str.as_str(), &self.parser_options)?;

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -804,17 +804,17 @@ peg::parser! {
             "!" variable_name:variable_name() "[@]" {
                 ParameterExpr::MemberKeys { variable_name: variable_name.to_owned(), concatenate: false }
             } /
-            "!" prefix:variable_name() "*" {
-                ParameterExpr::VariableNames { prefix: prefix.to_owned(), concatenate: true }
-            } /
-            "!" prefix:variable_name() "@" {
-                ParameterExpr::VariableNames { prefix: prefix.to_owned(), concatenate: false }
-            } /
             indirect:parameter_indirection() parameter:parameter() ":" offset:substring_offset() length:(":" l:substring_length() { l })? {
                 ParameterExpr::Substring { parameter, indirect, offset, length }
             } /
             indirect:parameter_indirection() parameter:parameter() "@" op:non_posix_parameter_transformation_op() {
                 ParameterExpr::Transform { parameter, indirect, op }
+            } /
+            "!" prefix:variable_name() "*" {
+                ParameterExpr::VariableNames { prefix: prefix.to_owned(), concatenate: true }
+            } /
+            "!" prefix:variable_name() "@" {
+                ParameterExpr::VariableNames { prefix: prefix.to_owned(), concatenate: false }
             } /
             indirect:parameter_indirection() parameter:parameter() "/#" pattern:parameter_search_pattern() replacement:parameter_replacement_str()? {
                 ParameterExpr::ReplaceSubstring { parameter, indirect, pattern, replacement, match_kind: SubstringMatchKind::Prefix }

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -912,6 +912,9 @@ cases:
       declare -ia arr=(1 2 3)
       echo "\${arr@a}: ${arr@a}"
 
+      ref="arr"
+      echo "\${!ref@a}: ${!ref@a}"
+
   - name: "Expansion with curly braces: commas"
     stdin: |
       echo "{a,b} =>"


### PR DESCRIPTION
Fixes parsing and interpreting of parameter transformation expansion with indirection.