### PR TITLE
fix(expansion): fix parsing escaped single-quotes in ANSI-C strs

### DIFF
--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -694,7 +694,7 @@ peg::parser! {
             "\'" inner:$([^'\'']*) "\'" { inner }
 
         rule ansi_c_quoted_text() -> &'input str =
-            "$\'" inner:$([^'\'']*) "\'" { inner }
+            "$\'" inner:$(("\\'" / [^'\''])*) "\'" { inner }
 
         rule unquoted_literal_text<T>(stop_condition: rule<T>, in_command: bool) -> WordPiece =
             s:$(unquoted_literal_text_piece(<stop_condition()>, in_command)+) { WordPiece::Text(s.to_owned()) }

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -44,7 +44,6 @@ cases:
       echo -n $'\n' | hexdump -C
 
   - name: "ANSI-C quotes with escaped single quote"
-    known_failure: true
     stdin: |
       ansi_c_quoted=$'\''
       echo "ANSI-C quoted single quote len: ${#ansi_c_quoted}"


### PR DESCRIPTION
Adds onto #561 to fix word-parsing of ANSI-C strings containing escaped single-quote chars.