### PR TITLE
fix(for/case): allow reserved words in for word lists

### DIFF
--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -476,13 +476,11 @@ peg::parser! {
         rule _in() -> () =
             specific_word("in") { }
 
-        // TODO: validate if this should call non_reserved_word() or word()
         rule wordlist() -> Vec<ast::Word> =
-            (w:non_reserved_word() { ast::Word::from(w) })+
+            (w:word() { ast::Word::from(w) })+
 
-        // TODO: validate if this should call non_reserved_word() or word()
         pub(crate) rule case_clause() -> ast::CaseClauseCommand =
-            specific_word("case") w:non_reserved_word() linebreak() _in() linebreak() first_items:case_item()* last_item:case_item_ns()? specific_word("esac") {
+            specific_word("case") w:word() linebreak() _in() linebreak() first_items:case_item()* last_item:case_item_ns()? specific_word("esac") {
                 let mut cases = first_items;
 
                 if let Some(last_item) = last_item {
@@ -519,7 +517,6 @@ peg::parser! {
                 ast::CaseItemPostAction::UnconditionallyExecuteNextCaseItem
             }
 
-        // TODO: validate if this should call non_reserved_word() or word()
         rule pattern() -> Vec<ast::Word> =
             (w:word() { ast::Word::from(w) }) ++ specific_operator("|")
 

--- a/brush-shell/tests/cases/compound_cmds/case.yaml
+++ b/brush-shell/tests/cases/compound_cmds/case.yaml
@@ -121,3 +121,9 @@ cases:
       x) yield 12;;
       esac
       echo "4: $?"
+
+  - name: "Case with reserved words"
+    stdin: |
+      case case in
+      case) echo "saw case";;
+      esac

--- a/brush-shell/tests/cases/compound_cmds/for.yaml
+++ b/brush-shell/tests/cases/compound_cmds/for.yaml
@@ -156,3 +156,7 @@ cases:
   - name: "For loop output redirection"
     stdin: |
       for f in a b c; do echo $f; done > ./out.txt
+
+  - name: "For reserved word handling"
+    stdin: |
+      for for in for; do echo $for; done


### PR DESCRIPTION
Resolve this issue for `for` and `case`, which was actually predicted a bit by the `TODO` comments but hadn't been resolved.

Also adds test cases to cover.