### PR TITLE
fix(dot): only shadow args when provided to `source`

### DIFF
--- a/brush-shell/tests/cases/builtins/dot.yaml
+++ b/brush-shell/tests/cases/builtins/dot.yaml
@@ -51,6 +51,16 @@ cases:
       source .
       echo "Result: $?"
 
+  - name: "Source script without args"
+    test_files:
+      - path: "script.sh"
+        contents: |
+          echo "In sourced script"
+          echo "Args: $@"
+    stdin: |
+      set -- outer1 outer2 outer3
+      source script.sh
+
   - name: "Source script with args"
     test_files:
       - path: "script.sh"
@@ -58,7 +68,8 @@ cases:
           echo "In sourced script"
           echo "Args: $@"
     stdin: |
-      source script.sh arg1 arg2
+      set -- outer1 outer2 outer3
+      source script.sh inner1 inner2
 
   - name: "Source with redirection"
     test_files:


### PR DESCRIPTION
For compatibility, `.` (or `source`) should only shadow args (e.g., `$@`) from the parent environment when a non-zero number of args were passed. #581 has more details.

Resolves #581