### PR TITLE
feat: enable -o/+o on brush command line

### DIFF
--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -230,6 +230,18 @@ impl RuntimeOptions {
             options.expand_aliases = true;
         }
 
+        // Update any options.
+        for enabled_option in &create_options.enabled_options {
+            if let Some(option) = crate::namedoptions::SET_O_OPTIONS.get(enabled_option.as_str()) {
+                (option.setter)(&mut options, true);
+            }
+        }
+        for disabled_option in &create_options.disabled_options {
+            if let Some(option) = crate::namedoptions::SET_O_OPTIONS.get(disabled_option.as_str()) {
+                (option.setter)(&mut options, false);
+            }
+        }
+
         // Update any shopt options.
         for enabled_option in &create_options.enabled_shopt_options {
             if let Some(shopt_option) =

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -149,6 +149,10 @@ impl AsMut<Self> for Shell {
 /// Options for creating a new shell.
 #[derive(Default)]
 pub struct CreateOptions {
+    /// Disabled options.
+    pub disabled_options: Vec<String>,
+    /// Enabled options.
+    pub enabled_options: Vec<String>,
     /// Disabled shopt options.
     pub disabled_shopt_options: Vec<String>,
     /// Enabled shopt options.

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -88,11 +88,19 @@ pub struct CommandLineArgs {
     #[clap(long = "noenv")]
     pub do_not_inherit_env: bool,
 
-    /// Enable shell option.
-    #[clap(short = 'O', value_name = "OPTION")]
+    /// Enable option (set -o option).
+    #[clap(short = 'o', value_name = "OPTION")]
+    pub enabled_options: Vec<String>,
+
+    /// Disable option (set -o option).
+    #[clap(long = "+o", hide = true)]
+    pub disabled_options: Vec<String>,
+
+    /// Enable shopt option.
+    #[clap(short = 'O', value_name = "SHOPT_OPTION")]
     pub enabled_shopt_options: Vec<String>,
 
-    /// Disable shell option.
+    /// Disable shopt option.
     #[clap(long = "+O", hide = true)]
     pub disabled_shopt_options: Vec<String>,
 
@@ -144,8 +152,13 @@ pub struct CommandLineArgs {
     #[clap(long = "debug", alias = "log-enable", value_name = "EVENT")]
     pub enabled_debug_events: Vec<events::TraceEvent>,
 
-    /// Disable logging for classes of tracing events.
-    #[clap(long = "disable-event", alias = "log-disable", value_name = "EVENT")]
+    /// Disable logging for classes of tracing events (takes same event types as --debug).
+    #[clap(
+        long = "disable-event",
+        alias = "log-disable",
+        value_name = "EVENT",
+        hide_possible_values = true
+    )]
     pub disabled_events: Vec<events::TraceEvent>,
 
     /// Path to script to execute.

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -253,9 +253,11 @@ async fn instantiate_shell(
     // Compose the options we'll use to create the shell.
     let options = brush_interactive::Options {
         shell: brush_core::CreateOptions {
+            disabled_options: args.disabled_options.clone(),
             disabled_shopt_options: args.disabled_shopt_options.clone(),
             disallow_overwriting_regular_files_via_output_redirection: args
                 .disallow_overwriting_regular_files_via_output_redirection,
+            enabled_options: args.enabled_options.clone(),
             enabled_shopt_options: args.enabled_shopt_options.clone(),
             do_not_execute_commands: args.do_not_execute_commands,
             exit_after_one_command: args.exit_after_one_command,


### PR DESCRIPTION
Enable `set -o` style options to be passed on the command line to `brush`.