### PR TITLE
perf: avoid CPU-specific optimization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
 
-[build]
-rustflags = ["-C", "target-cpu=native"]
-
 [target.wasm32-unknown-unknown]
 # Select a getrandom backend that will work for this target
 rustflags = ["--cfg", 'getrandom_backend="wasm_js"']


### PR DESCRIPTION

# Background
I've noticed that Nixpkgs's binary cache for brush has stopped working on my devices recently. This issue does not seem to be related to brush versions.

When attempting to run the binary, I encountered the following error:

```console
> nix run 'github:NixOS/nixpkgs/641c8533d1b751f4b0f5cdd3769c3dc2ba26e497#brush' -- --version
brush 0.2.18 (cargo:0.2.18)

> nix run 'github:NixOS/nixpkgs/3016b4b15d13f3089db8a41ef937b13a9e33a8dff#brush' -- --version
Illegal instruction (core dumped)
```

If I add `--offline` for the same revision to avoid the binary cache, it works correctly.

The build https://hydra.nixos.org/build/300564410 from 2025-06-19 appears to be the triggering point.

```console
> hydra-check brush
Build Status for nixpkgs.brush.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.brush.x86_64-linux
⏹ (Cancelled)  brush-0.2.19  2025-07-04  https://hydra.nixos.org/build/301612776
✔              brush-0.2.18  2025-06-19  https://hydra.nixos.org/build/300564410
✔              brush-0.2.18  2025-05-26  https://hydra.nixos.org/build/298258333
✔              brush-0.2.17  2025-05-16  https://hydra.nixos.org/build/297127207
✔              brush-0.2.17  2025-05-06  https://hydra.nixos.org/build/296132248
✔              brush-0.2.17  2025-04-28  https://hydra.nixos.org/build/295880082
✔              brush-0.2.16  2025-04-17  https://hydra.nixos.org/build/294960965
✔              brush-0.2.16  2025-03-28  https://hydra.nixos.org/build/293696490
✔              brush-0.2.15  2025-03-23  https://hydra.nixos.org/build/292985577
✔              brush-0.2.15  2025-03-13  https://hydra.nixos.org/build/292282887
```

While I'm not 100% certain, the most likely cause is that the binary cache was created on a machine with a different CPU feature set.  
This means it might not be a problem for everyone, but it could potentially block users from sharing the binary, even if they have the same CPU architecture (e.g., x86_64).

## Why am I sending this PR to this repository instead of directly to Nixpkgs?

This is a quick question, if you think this approach is not suitable for this repository, please feel free to close this PR. I will then send this patch directly to Nixpkgs.

I am sending this PR because I found a relevant description in #314:

>For now, we're okay with that since we don't publish binaries. We may need to revisit this in the future.

It appears that binaries are now being released in GitHub Releases. Therefore, I would like to confirm whether the current configuration is intentional or not.

refs:

- https://github.com/reubeno/brush/pull/314
- https://github.com/reubeno/brush/issues/69
- https://github.com/reubeno/brush/pull/440
- https://github.com/reubeno/brush/pull/387

Also potentially related to https://github.com/reubeno/brush/issues/528