### PR TITLE
feat(config): Use platform-specific standard directories for config files, state files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -289,9 +289,10 @@ dependencies = [
  "clap",
  "command-fds",
  "criterion",
+ "directories",
  "fancy-regex",
  "futures",
- "getrandom",
+ "getrandom 0.3.3",
  "homedir",
  "hostname",
  "indexmap",
@@ -335,7 +336,7 @@ dependencies = [
  "brush-core",
  "brush-parser",
  "crossterm 0.29.0",
- "getrandom",
+ "getrandom 0.3.3",
  "indexmap",
  "nu-ansi-term 0.50.1",
  "reedline",
@@ -383,7 +384,7 @@ dependencies = [
  "descape",
  "diff",
  "expectrl",
- "getrandom",
+ "getrandom 0.3.3",
  "git-version",
  "glob",
  "human-panic",
@@ -934,6 +935,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1241,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1556,7 +1589,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1609,6 +1642,16 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1831,6 +1874,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_display"
@@ -2233,7 +2282,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2263,6 +2312,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2668,7 +2728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
@@ -3026,7 +3086,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -34,6 +34,7 @@ strum = "0.27.2"
 strum_macros = "0.27.2"
 thiserror = "2.0.12"
 tracing = "0.1.41"
+directories = "6.0.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 tokio = { version = "1.46.1", features = ["io-util", "macros", "rt"] }

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -5,6 +5,8 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use directories::BaseDirs;
+
 use normalize_path::NormalizePath;
 use rand::Rng;
 use tokio::sync::Mutex;
@@ -736,13 +738,25 @@ impl Shell {
             //     * ~/.bash_profile
             //     * ~/.bash_login
             //     * ~/.profile
+            //     config_dir/brush/.profile
             //
             self.source_if_exists(Path::new("/etc/profile"), &params)
                 .await?;
             if let Some(home_path) = self.get_home_dir() {
                 if options.sh_mode {
-                    self.source_if_exists(home_path.join(".profile").as_path(), &params)
-                        .await?;
+                    if !self
+                        .source_if_exists(home_path.join(".profile").as_path(), &params)
+                        .await?
+                    {
+                        if let Some(base_dirs) = BaseDirs::new() {
+                            let config_dir = base_dirs.config_dir();
+                            self.source_if_exists(
+                                config_dir.join("brush").join(".profile").as_path(),
+                                &params,
+                            )
+                            .await?;
+                        }
+                    }
                 } else {
                     if !self
                         .source_if_exists(home_path.join(".bash_profile").as_path(), &params)
@@ -752,8 +766,19 @@ impl Shell {
                             .source_if_exists(home_path.join(".bash_login").as_path(), &params)
                             .await?
                         {
-                            self.source_if_exists(home_path.join(".profile").as_path(), &params)
-                                .await?;
+                            if !self
+                                .source_if_exists(home_path.join(".profile").as_path(), &params)
+                                .await?
+                            {
+                                if let Some(base_dirs) = BaseDirs::new() {
+                                    let config_dir = base_dirs.config_dir();
+                                    self.source_if_exists(
+                                        config_dir.join("brush").join(".profile").as_path(),
+                                        &params,
+                                    )
+                                    .await?;
+                                }
+                            }
                         }
                     }
                 }
@@ -775,14 +800,31 @@ impl Shell {
                     //
                     //     /etc/bash.bashrc
                     //     ~/.bashrc
+                    //     ~/.brushrc
+                    //     config_dir/brush/.bashrc
+                    //     config_dir/brush/.brushrc
                     //
                     self.source_if_exists(Path::new("/etc/bash.bashrc"), &params)
                         .await?;
+
                     if let Some(home_path) = self.get_home_dir() {
                         self.source_if_exists(home_path.join(".bashrc").as_path(), &params)
                             .await?;
                         self.source_if_exists(home_path.join(".brushrc").as_path(), &params)
                             .await?;
+                    }
+                    if let Some(base_dirs) = BaseDirs::new() {
+                        let config_dir = base_dirs.config_dir();
+                        self.source_if_exists(
+                            config_dir.join("brush").join(".bashrc").as_path(),
+                            &params,
+                        )
+                        .await?;
+                        self.source_if_exists(
+                            config_dir.join("brush").join(".brushrc").as_path(),
+                            &params,
+                        )
+                        .await?;
                     }
                 }
             } else {


### PR DESCRIPTION
Uses https://crates.io/crates/directories to get config directory of user and loads the brush's config file from that directory.