### PR TITLE
fix(parser): resolve issue with parser confusing subshell for arith expr

### DIFF
--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_arith_and_non_arith_parens.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_arith_and_non_arith_parens.snap
@@ -1,0 +1,62 @@
+---
+source: brush-parser/src/parser.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "( : && ( (( 0 )) || : ) )",
+  result: Program(
+    cmds: [
+      List([
+        Item(AndOr(
+          first: Pipeline(
+            seq: [
+              Compound(Subshell(SubshellCommand(List([
+                Item(AndOr(
+                  first: Pipeline(
+                    seq: [
+                      Simple(Simple(
+                        w: Some(W(
+                          v: ":",
+                        )),
+                      )),
+                    ],
+                  ),
+                  additional: [
+                    And(Pipeline(
+                      seq: [
+                        Compound(Subshell(SubshellCommand(List([
+                          Item(AndOr(
+                            first: Pipeline(
+                              seq: [
+                                Compound(Arithmetic(ArithmeticCommand(
+                                  expr: UnexpandedArithmeticExpr(
+                                    value: "0",
+                                  ),
+                                )), None),
+                              ],
+                            ),
+                            additional: [
+                              Or(Pipeline(
+                                seq: [
+                                  Simple(Simple(
+                                    w: Some(W(
+                                      v: ":",
+                                    )),
+                                  )),
+                                ],
+                              )),
+                            ],
+                          ), Sequence),
+                        ]))), None),
+                      ],
+                    )),
+                  ],
+                ), Sequence),
+              ]))), None),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)


### PR DESCRIPTION
Consider the case of `( : && ( (( 0 )) || : ) )`:

* The 3 consecutive open parens `(` tokenize as 3 repeated operators.
* Visually, with space, it looks like it's intended to be an arithmetic command inside a subshell.
* With space removed, when we see 2 `(` chars, we try to parse an arithmetic command.
* When we see the unmatched `)`, the existing logic keeps going on and includes it in the parsed arithmetic expression.

We should instead recognize that this is a subshell command--the unmatched closing parenthesis should have made that obvious.