### PR TITLE
fix(expansion): support broader set of nested brace expansions

### DIFF
--- a/brush-core/src/braceexpansion.rs
+++ b/brush-core/src/braceexpansion.rs
@@ -1,0 +1,81 @@
+use brush_parser::word;
+use itertools::Itertools;
+
+pub(crate) fn generate_and_combine_brace_expansions(
+    pieces: Vec<brush_parser::word::BraceExpressionOrText>,
+) -> impl IntoIterator<Item = String> {
+    let expansions: Vec<Vec<String>> = pieces
+        .into_iter()
+        .map(|piece| expand_brace_expr_or_text(piece).collect())
+        .collect();
+
+    expansions
+        .into_iter()
+        .multi_cartesian_product()
+        .map(|v| v.join(""))
+}
+
+fn expand_brace_expr_or_text(
+    beot: word::BraceExpressionOrText,
+) -> Box<dyn Iterator<Item = String>> {
+    match beot {
+        word::BraceExpressionOrText::Expr(members) => {
+            // Chain all member iterators together
+            Box::new(members.into_iter().flat_map(expand_brace_expr_member))
+        }
+        word::BraceExpressionOrText::Text(text) => Box::new(std::iter::once(text)),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+fn expand_brace_expr_member(bem: word::BraceExpressionMember) -> Box<dyn Iterator<Item = String>> {
+    match bem {
+        word::BraceExpressionMember::NumberSequence {
+            start,
+            end,
+            increment,
+        } => {
+            let increment = increment.unsigned_abs() as usize;
+
+            if start <= end {
+                Box::new((start..=end).step_by(increment).map(|n| n.to_string()))
+            } else {
+                Box::new(
+                    (end..=start)
+                        .step_by(increment)
+                        .map(|n| n.to_string())
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                        .rev(),
+                )
+            }
+        }
+
+        word::BraceExpressionMember::CharSequence {
+            start,
+            end,
+            increment,
+        } => {
+            let increment = increment.unsigned_abs() as usize;
+
+            if start <= end {
+                Box::new((start..=end).step_by(increment).map(|c| c.to_string()))
+            } else {
+                Box::new(
+                    (end..=start)
+                        .step_by(increment)
+                        .map(|c| c.to_string())
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                        .rev(),
+                )
+            }
+        }
+
+        word::BraceExpressionMember::Child(elements) => {
+            // Chain all element iterators together
+            Box::new(generate_and_combine_brace_expansions(elements).into_iter())
+        }
+    }
+}

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod completion;
 
 mod arithmetic;
+mod braceexpansion;
 pub mod builtins;
 mod commands;
 pub mod env;

--- a/brush-parser/src/snapshots/brush_parser__word__tests__brace_expansion_parsing-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__brace_expansion_parsing-2.snap
@@ -1,0 +1,22 @@
+---
+source: brush-parser/src/word.rs
+expression: "super::parse_brace_expansions(input,\n&options)?.ok_or_else(||\nanyhow::anyhow!(\"Expected brace expansion to be parsed successfully\"))?"
+---
+[
+  Expr([
+    Child([
+      Text("a"),
+    ]),
+    Child([
+      Text("b"),
+      Expr([
+        Child([
+          Text("1"),
+        ]),
+        Child([
+          Text("2"),
+        ]),
+      ]),
+    ]),
+  ]),
+]

--- a/brush-parser/src/snapshots/brush_parser__word__tests__brace_expansion_parsing.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__brace_expansion_parsing.snap
@@ -1,0 +1,16 @@
+---
+source: brush-parser/src/word.rs
+expression: "super::parse_brace_expansions(input,\n&options)?.ok_or_else(||\nanyhow::anyhow!(\"Expected brace expansion to be parsed successfully\"))?"
+---
+[
+  Text("x"),
+  Expr([
+    Child([
+      Text("a"),
+    ]),
+    Child([
+      Text("b"),
+    ]),
+  ]),
+  Text("y"),
+]


### PR DESCRIPTION
We previously supported expanding brace expressions like `{a,{x,y}}` but did *not* support something like `{a,b{x,y}}`. This addresses that, adds a few targeted tests, and consolidates the expansion code back into `brush_core`. (Some of it had been in `brush_parser`.)