### PR TITLE
fix(declare): refine varname validation

### DIFF
--- a/brush-core/src/builtins/factory.rs
+++ b/brush-core/src/builtins/factory.rs
@@ -151,7 +151,9 @@ async fn exec_declaration_builtin_impl<T: builtins::DeclarationCommand + Send + 
 
     for (i, arg) in args.into_iter().enumerate() {
         match arg {
-            CommandArg::String(s) if i == 0 || s.starts_with('-') || s.starts_with('+') => {
+            CommandArg::String(s)
+                if i == 0 || (s.len() > 1 && (s.starts_with('-') || s.starts_with('+'))) =>
+            {
                 options.push(s);
             }
             _ => declarations.push(arg),

--- a/brush-core/src/env.rs
+++ b/brush-core/src/env.rs
@@ -576,3 +576,35 @@ impl ShellVariableMap {
         self.variables.insert(name.into(), var)
     }
 }
+
+pub(crate) fn valid_variable_name(s: &str) -> bool {
+    let mut cs = s.chars();
+    match cs.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {
+            cs.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        Some(_) | None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_variable_name() {
+        assert!(!valid_variable_name(""));
+        assert!(!valid_variable_name("1"));
+        assert!(!valid_variable_name(" a"));
+        assert!(!valid_variable_name(" "));
+
+        assert!(valid_variable_name("_"));
+        assert!(valid_variable_name("_a"));
+        assert!(valid_variable_name("_1"));
+        assert!(valid_variable_name("_a1"));
+        assert!(valid_variable_name("a"));
+        assert!(valid_variable_name("A"));
+        assert!(valid_variable_name("a1"));
+        assert!(valid_variable_name("A1"));
+    }
+}

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1315,7 +1315,7 @@ impl<'a> WordExpander<'a> {
             }
             brush_parser::word::Parameter::Special(s) => Ok(self.expand_special_parameter(s)),
             brush_parser::word::Parameter::Named(n) => {
-                if !valid_variable_name(n.as_str()) {
+                if !env::valid_variable_name(n.as_str()) {
                     Err(error::Error::BadSubstitution)
                 } else if let Some((_, var)) = self.shell.env.get(n) {
                     if matches!(var.value(), ShellValue::Unset(_)) {
@@ -1661,16 +1661,6 @@ fn to_initial_capitals(s: &str) -> String {
     result
 }
 
-fn valid_variable_name(s: &str) -> bool {
-    let mut cs = s.chars();
-    match cs.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {
-            cs.all(|c| c.is_ascii_alphanumeric() || c == '_')
-        }
-        Some(_) | None => false,
-    }
-}
-
 fn transform_expansion(
     expansion: Expansion,
     mut f: impl FnMut(String) -> Result<String, error::Error>,
@@ -1822,22 +1812,5 @@ mod tests {
         assert_eq!(to_initial_capitals("ab bc cd"), String::from("Ab Bc Cd"));
         assert_eq!(to_initial_capitals(" a "), String::from(" A "));
         assert_eq!(to_initial_capitals(""), String::new());
-    }
-
-    #[test]
-    fn test_valid_variable_name() {
-        assert!(!valid_variable_name(""));
-        assert!(!valid_variable_name("1"));
-        assert!(!valid_variable_name(" a"));
-        assert!(!valid_variable_name(" "));
-
-        assert!(valid_variable_name("_"));
-        assert!(valid_variable_name("_a"));
-        assert!(valid_variable_name("_1"));
-        assert!(valid_variable_name("_a1"));
-        assert!(valid_variable_name("a"));
-        assert!(valid_variable_name("A"));
-        assert!(valid_variable_name("a1"));
-        assert!(valid_variable_name("A1"));
     }
 }

--- a/brush-shell/tests/cases/builtins/declare.yaml
+++ b/brush-shell/tests/cases/builtins/declare.yaml
@@ -347,3 +347,9 @@ cases:
       declare -c another
       another+=eFg
       declare -p another
+
+  - name: "Declare invalid identifiers"
+    ignore_stderr: true
+    stdin: |
+      declare 1=x && echo "Set 1"
+      declare @=10 && echo "Set @"

--- a/brush-shell/tests/cases/builtins/set.yaml
+++ b/brush-shell/tests/cases/builtins/set.yaml
@@ -88,3 +88,16 @@ cases:
 
       set a +x
       echo ${*}
+
+  - name: "function-local set"
+    known_failure: true
+    stdin: |
+      function f() {
+          local -
+          set -x
+          echo "In func"
+      }
+
+      echo "Before func"
+      f
+      echo "After func"


### PR DESCRIPTION
* Ensure `declare` et al. validates variable names
* Add TODO comment warning around `local -` being unimplemented
* Add a basic test trying to use `declare` with invalid variable names