### PR TITLE
fix: hyphenated script args

### DIFF
--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -161,15 +161,8 @@ pub struct CommandLineArgs {
     )]
     pub disabled_events: Vec<events::TraceEvent>,
 
-    /// Path to script to execute.
-    // allow any string as command_name similar to sh
-    #[clap(allow_hyphen_values = true)]
-    pub script_path: Option<String>,
-
-    /// Arguments for script.
-    // `allow_hyphen_values`: do not strip `-` from flags
-    // `num_args=1..`: consume everything
-    #[clap(allow_hyphen_values = true, num_args=1..)]
+    /// Path and arguments for script to execute (optional).
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
     pub script_args: Vec<String>,
 }
 
@@ -183,7 +176,7 @@ impl CommandLineArgs {
         }
 
         // If -c or non-option arguments are provided, then we're not in interactive mode.
-        if self.command.is_some() || self.script_path.is_some() {
+        if self.command.is_some() || !self.script_args.is_empty() {
             return false;
         }
 

--- a/brush-shell/tests/cases/basic.yaml
+++ b/brush-shell/tests/cases/basic.yaml
@@ -40,9 +40,17 @@ cases:
     test_files:
       - path: "script.sh"
         contents: |
-          echo 'hi'
+          echo "ARGS: $@"
           exit 22
-    args: ["./script.sh"]
+    args: ["./script.sh", 1, 2, 3]
+
+  - name: "Passing option-like arg to script"
+    test_files:
+      - path: "script.sh"
+        contents: |
+          echo "ARGS: $@"
+          exit 22
+    args: ["./script.sh", "-v"]
 
   - name: "Ensure ~ is resolvable"
     stdin: "test ~"


### PR DESCRIPTION
Fixes cases where `brush` is given a script and hyphenated script arguments on the command line, e.g.:

`brush some-script.sh -v`

Without this fix, `brush` consumes the `-v` as part of its own options; with this fix, it passes it along to the script.