### PR TITLE
fix: special case for command subst

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1118,7 +1118,7 @@ impl Shell {
         .await
     }
 
-    async fn run_parsed_result(
+    pub(crate) async fn run_parsed_result(
         &mut self,
         parse_result: Result<brush_parser::ast::Program, brush_parser::ParseError>,
         source_info: &brush_parser::SourceInfo,

--- a/brush-shell/tests/cases/command_substitution.yaml
+++ b/brush-shell/tests/cases/command_substitution.yaml
@@ -71,3 +71,15 @@ cases:
   - name: "Positional parameter count not mistaken for comment (backticks)"
     stdin: |
       echo `echo $#`
+
+  - name: "Command substitution with only input redir"
+    stdin: |
+      echo "Some text" >file.txt
+      x=$(<file.txt)
+      echo "x: $x"
+
+  - name: "Backquote with only input redir"
+    stdin: |
+      echo "Some text" >file.txt
+      x=`<file.txt`
+      echo "x: $x"


### PR DESCRIPTION
Handle special case for command substitutions where a bare input redirection is used:

> `$(<SOME-FILE)` should behave like `$(cat SOME_FILE)`
