### PR TITLE
chore: remove unused import from python script

### DIFF
--- a/scripts/compare-benchmark-results.py
+++ b/scripts/compare-benchmark-results.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import argparse
-import datetime
 import re
 from dataclasses import dataclass
 from typing import Dict


### PR DESCRIPTION
Potential fix for [https://github.com/reubeno/brush/security/code-scanning/7](https://github.com/reubeno/brush/security/code-scanning/7)

To fix the problem, simply remove the unused import statement for `datetime` from the file `scripts/compare-benchmark-results.py`. This involves deleting line 3 (`import datetime`). No other changes are necessary, as this will not affect the functionality of the script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
