### PR TITLE
ci: pin rust-toolchain tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
@@ -182,7 +182,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: stable
           components: llvm-tools-preview
@@ -309,7 +309,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up rust toolchain (${{ matrix.rust-version }})
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: ${{ matrix.rust-version }}
           components: clippy, rustfmt
@@ -349,7 +349,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up nightly rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: nightly
 
@@ -381,7 +381,7 @@ jobs:
           ref: main
 
       - name: Set up rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: stable
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,11 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '35 1 * * 3'
+    - cron: "35 1 * * 3"
 
 permissions: {}
 
@@ -24,41 +24,41 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: python
-          build-mode: none
-        - language: rust
-          build-mode: none
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            build-mode: none
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        queries: security-extended,security-and-quality
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended,security-and-quality
 
-    # - name: Set up rust toolchain
-    #   if: ${{ matrix.language == 'rust' }}
-    #   uses: dtolnay/rust-toolchain@stable
-    #   with:
-    #     toolchain: stable
+      # - name: Set up rust toolchain
+      #   if: ${{ matrix.language == 'rust' }}
+      #   uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+      #   with:
+      #     toolchain: stable
 
-    # - name: Enable cargo cache
-    #   if: ${{ matrix.language == 'rust' }}
-    #   uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+      # - name: Enable cargo cache
+      #   if: ${{ matrix.language == 'rust' }}
+      #   uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
-    # - name: Build Rust code
-    #   if: ${{ matrix.language == 'rust' }}
-    #   run: cargo build --all-targets --all-features
-      
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
-      with:
-        category: "/language:${{matrix.language}}"
+      # - name: Build Rust code
+      #   if: ${{ matrix.language == 'rust' }}
+      #   run: cargo build --all-targets --all-features
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: stable
 

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -2,5 +2,3 @@ rules:
   unpinned-uses:
     config:
       policies:
-        # For now, we allow rust-toolchain to be used with a branch.
-        dtolnay/rust-toolchain: any


### PR DESCRIPTION
There now appears to be a `v1` tag that we can pin to in the rust-toolchain git repo.