### PR TITLE
chore: remove unused global variable

### DIFF
--- a/scripts/run-bash-tests.py
+++ b/scripts/run-bash-tests.py
@@ -108,7 +108,7 @@ elif args.command == "diff":
 
         test_cmd += ["-c", f"source {test_script_name} >{out_path} 2>&1"]
 
-        test_result = subprocess.run(test_cmd, cwd=bash_tests_dir, env=env, check=False)
+        subprocess.run(test_cmd, cwd=bash_tests_dir, env=env, check=False)
 
         # ---------------------
 


### PR DESCRIPTION
Potential fix for [https://github.com/reubeno/brush/security/code-scanning/8](https://github.com/reubeno/brush/security/code-scanning/8)

To fix the problem, we should remove the assignment to `test_result` on line 111, leaving only the call to `subprocess.run(...)` so that its side effects are preserved. This means replacing `test_result = subprocess.run(...)` with `subprocess.run(...)`. No other changes are necessary, as the result of the subprocess is not used elsewhere. The change should be made in the file `scripts/run-bash-tests.py`, specifically on line 111.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
