### PR TITLE
chore: remove unused global variable

### DIFF
--- a/scripts/run-bash-tests.py
+++ b/scripts/run-bash-tests.py
@@ -124,7 +124,7 @@ elif args.command == "diff":
 
         oracle_cmd += ["-c", f"source {test_script_name} >{oracle_out_path} 2>&1"]
 
-        oracle_test_result = subprocess.run(oracle_cmd, cwd=bash_tests_dir, env=env, check=False)
+        subprocess.run(oracle_cmd, cwd=bash_tests_dir, env=env, check=False)
 
         # -----------------------
 


### PR DESCRIPTION
Potential fix for [https://github.com/reubeno/brush/security/code-scanning/9](https://github.com/reubeno/brush/security/code-scanning/9)

To fix the problem, we should remove the assignment to `oracle_test_result` and simply call `subprocess.run(...)` as a standalone statement. This preserves the side effect of running the subprocess, but eliminates the unused variable. The change should be made in `scripts/run-bash-tests.py`, specifically on line 127, replacing `oracle_test_result = subprocess.run(...)` with `subprocess.run(...)`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
