### PR TITLE
fix: correct string indexing in prefix/suffix remove helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ expect_used = "deny"
 format_push_string = "deny"
 panic = "deny"
 panic_in_result_fn = "deny"
+string_slice = "deny"
 todo = "deny"
 unwrap_in_result = "deny"
 

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -891,6 +891,7 @@ impl Config {
     /// * `input` - The input line for which completions are being generated.
     /// * `position` - The 0-based index of the cursor in the input line.
     #[allow(clippy::cast_sign_loss)]
+    #[allow(clippy::string_slice)]
     pub async fn get_completions(
         &self,
         shell: &mut Shell,

--- a/brush-core/src/jobs.rs
+++ b/brush-core/src/jobs.rs
@@ -129,11 +129,9 @@ impl JobManager {
     ///
     /// * `job_spec` - The job specification to resolve.
     pub fn resolve_job_spec(&mut self, job_spec: &str) -> Option<&mut Job> {
-        if !job_spec.starts_with('%') {
-            return None;
-        }
+        let remainder = job_spec.strip_prefix('%')?;
 
-        match &job_spec[1..] {
+        match remainder {
             "%" | "+" => self.current_job_mut(),
             "-" => self.prev_job_mut(),
             s if s.chars().all(char::is_numeric) => {


### PR DESCRIPTION
These are incremental changes to start addressing Unicode / multi-byte character handling issues, spurred on by the issue raised in #639:

* Turn on the `string_slice` clippy check to flag potential issues
* Fix job spec helper
* Fix `remove_{smallest,largest}_matching_{prefix_suffix}` funcs in `patterns.rs` to use `std::string::char_indices()` for safer indexing

For now, we also add a targeted warning ignore in the completion-handling code. As far as I can tell, `reedline` correctly gives us a index that's at a correct char boundary. More inspection (and tests) are needed to convince ourselves that we're really always doing the right thing with completion.

At some point in the future, we should be more intentional around whether we should be using char_indices() or something fancier (e.g., grapheme cluster boundaries).