### PR TITLE
fix: exclude bind-bound commands from history

### DIFF
--- a/brush-interactive/src/basic/basic_shell.rs
+++ b/brush-interactive/src/basic/basic_shell.rs
@@ -49,6 +49,10 @@ impl InteractiveShell for BasicShell {
                         break;
                     }
                 }
+                ReadResult::BoundCommand(s) => {
+                    result.push_str(s.as_str());
+                    break;
+                }
                 ReadResult::Eof => {
                     if result.is_empty() {
                         return Ok(ReadResult::Eof);

--- a/brush-interactive/src/minimal/minimal_shell.rs
+++ b/brush-interactive/src/minimal/minimal_shell.rs
@@ -47,6 +47,10 @@ impl InteractiveShell for MinimalShell {
                         break;
                     }
                 }
+                ReadResult::BoundCommand(s) => {
+                    result.push_str(s.as_str());
+                    break;
+                }
                 ReadResult::Eof => break,
                 ReadResult::Interrupted => return Ok(ReadResult::Interrupted),
             }

--- a/brush-interactive/src/reedline/edit_mode.rs
+++ b/brush-interactive/src/reedline/edit_mode.rs
@@ -180,11 +180,25 @@ fn translate_key_sequence_to_reedline(
 
 fn translate_action_to_reedline_event(action: &KeyAction) -> Option<reedline::ReedlineEvent> {
     match action {
-        KeyAction::ShellCommand(cmd) => {
-            Some(reedline::ReedlineEvent::ExecuteHostCommand(cmd.to_owned()))
-        }
+        KeyAction::ShellCommand(cmd) => Some(reedline::ReedlineEvent::ExecuteHostCommand(
+            format_reedline_host_command(cmd.as_str()),
+        )),
         KeyAction::DoInputFunction(_input_function) => None, // TODO: implement
     }
+}
+
+fn format_reedline_host_command(cmd: &str) -> String {
+    // NOTE: When this command gets returned from reedline's `read_line` function,
+    // we need a way to know that it didn't come from user input (e.g., so we don't
+    // add it to history, etc.). Since reedline doesn't provide any facilities for
+    // doing this, we apply a workaround of appending a special marker comment at
+    // the end of the command.
+    std::format!("{cmd} # bind-command")
+}
+
+pub(crate) fn is_reedline_host_command(cmd: &str) -> bool {
+    // See the implementation of `format_reedline_host_command`. We look for the marker.
+    cmd.ends_with("# bind-command")
 }
 
 const fn translate_reedline_keycode(keycode: reedline::KeyCode) -> Option<Key> {

--- a/brush-interactive/src/reedline/reedline_shell.rs
+++ b/brush-interactive/src/reedline/reedline_shell.rs
@@ -140,7 +140,13 @@ impl InteractiveShell for ReedlineShell {
     fn read_line(&mut self, prompt: InteractivePrompt) -> Result<ReadResult, ShellError> {
         if let Some(reedline) = &mut self.reedline {
             match reedline.read_line(&prompt) {
-                Ok(reedline::Signal::Success(s)) => Ok(ReadResult::Input(s)),
+                Ok(reedline::Signal::Success(s)) => {
+                    if edit_mode::is_reedline_host_command(s.as_str()) {
+                        Ok(ReadResult::BoundCommand(s))
+                    } else {
+                        Ok(ReadResult::Input(s))
+                    }
+                }
                 Ok(reedline::Signal::CtrlC) => Ok(ReadResult::Interrupted),
                 Ok(reedline::Signal::CtrlD) => Ok(ReadResult::Eof),
                 Err(err) => Err(ShellError::IoError(err)),


### PR DESCRIPTION
We can't presently distinguish when `reedline` returns an input line that was typed by the user vs. a result that was returned because an entered key sequence was previously bound to a `HostCommand`. We need to detect the differences and behave accordingly; for example, bound commands shouldn't end up in the command history.

Ideally, `reedline` would provide a way to differentiate in its returned result; without that, for now we include a commented marker at the tail end of the input line that we can look for when it's returned.

When we detect a bound command was returned, we skip a few steps. Among other things, this corrects behavior we've been seeing when using `bash-preexec.sh` + `atuin` under `brush`.