### PR TITLE
chore: Update MSRV to 1.88

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,12 +295,14 @@ jobs:
   # Static analysis of the code.
   check:
     name: "Source code checks"
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         # Test latest stable as well as MSRV.
-        rust-version: ["stable", "1.85.0"]
+        rust-version: ["stable", "1.88.0"]
+        # Test Linux and Windows.
+        os: ["ubuntu-24.04", "windows-2025"]
 
     steps:
       - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["cli", "shell", "sh", "bash", "script"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/reubeno/brush"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 
 [workspace.lints.rust]
 warnings = { level = "deny" }


### PR DESCRIPTION
When compiling for Windows, the homedir crate uses features that have been stabilized on 1.88, so let the MSRV match that. Also run the source code checks on Windows, so that those things will be caught by it in the future.

This is the error:

    error[E0658]: `let` expressions in this position are unstable
       --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\homedir-0.3.5\src\windows.rs:203:16
        |
    203 |             if let Err(e) = GetTokenInformation(token_handle, TokenUser, None, 0, &mut buffer_size)
        |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

    For more information about this error, try `rustc --explain E0658`.
    error: could not compile `homedir` (lib) due to 1 previous error