### PR TITLE
fix(cmdline): correct exit code for `--version` + `--help`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "human-panic",
  "indent",
  "junit-report",
+ "predicates",
  "pretty_assertions",
  "regex",
  "serde",
@@ -1110,6 +1111,15 @@ checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1827,6 +1837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "normalize-path"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,7 +2158,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -80,6 +80,7 @@ expectrl = { git = "https://github.com/zhiburt/expectrl", rev = "a0f4f7816b9a47a
 glob = "0.3.2"
 indent = "0.1.1"
 junit-report = "0.8.3"
+predicates = "3.1.3"
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 regex = "1.11.2"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/brush-shell/src/main.rs
+++ b/brush-shell/src/main.rs
@@ -59,7 +59,16 @@ fn main() {
         Ok(parsed_args) => parsed_args,
         Err(e) => {
             let _ = e.print();
-            std::process::exit(1);
+
+            // Check for whether this is something we'd truly consider fatal. clap returns
+            // errors for `--help`, `--version`, etc.
+            let exit_code = match e.kind() {
+                clap::error::ErrorKind::DisplayVersion => 0,
+                clap::error::ErrorKind::DisplayHelp => 0,
+                _ => 1,
+            };
+
+            std::process::exit(exit_code);
         }
     };
 

--- a/brush-shell/tests/integration_tests.rs
+++ b/brush-shell/tests/integration_tests.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::panic_in_result_fn)]
 
 use anyhow::Context;
+use predicates::prelude::PredicateBooleanExt;
 
 #[test]
 fn get_version_variables() -> anyhow::Result<()> {
@@ -17,6 +18,37 @@ fn get_version_variables() -> anyhow::Result<()> {
         brush_ver_str, bash_ver_str,
         "Should differ for scripting use-case"
     );
+
+    Ok(())
+}
+
+#[test]
+fn version_exit_code() -> anyhow::Result<()> {
+    let mut cmd = assert_cmd::Command::cargo_bin("brush")?;
+    let assert = cmd.arg("--version").assert();
+    assert
+        .success()
+        .stdout(predicates::str::contains(env!("CARGO_PKG_VERSION")));
+
+    Ok(())
+}
+
+#[test]
+fn help_exit_code() -> anyhow::Result<()> {
+    let mut cmd = assert_cmd::Command::cargo_bin("brush")?;
+    let assert = cmd.arg("--help").assert();
+    assert.success().stdout(predicates::str::is_empty().not());
+
+    Ok(())
+}
+
+#[test]
+fn invalid_option_exit_code() -> anyhow::Result<()> {
+    let mut cmd = assert_cmd::Command::cargo_bin("brush")?;
+    let assert = cmd.arg("--unknown-argument-here").assert();
+    assert
+        .failure()
+        .stderr(predicates::str::contains("unexpected argument"));
 
     Ok(())
 }


### PR DESCRIPTION
* Specifically looks for version/help error kinds coming back from `clap` and differentiates exit code.
* Adds a few basic integration test cases to safeguard against further regression.

Resolves #666 