### PR TITLE
refactor: update Shell::new() to take creation options as owned

### DIFF
--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -67,7 +67,7 @@ mod unimp;
 mod unset;
 mod wait;
 
-pub(crate) use factory::get_default_builtins;
+pub(crate) use factory::{BuiltinSet, default_builtins};
 pub use factory::{SimpleCommand, builtin, simple_builtin};
 
 /// Macro to define a struct that represents a shell built-in flag argument that can be

--- a/brush-core/src/builtins/factory.rs
+++ b/brush-core/src/builtins/factory.rs
@@ -197,9 +197,21 @@ async fn exec_raw_arg_builtin_impl<T: builtins::DeclarationCommand + Default + S
     })
 }
 
-pub(crate) fn get_default_builtins(
-    options: &crate::CreateOptions,
-) -> HashMap<String, builtins::Registration> {
+/// Identifies well-known sets of builtins.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum BuiltinSet {
+    /// Identifies builtins appropriate for POSIX `sh` compatibility.
+    ShMode,
+    /// Identifies builtins appropriate for a more full-featured `bash`-compatible shell.
+    BashMode,
+}
+
+/// Returns the default set of built-in commands.
+///
+/// # Arguments
+///
+/// * `set` - The set of built-ins to return.
+pub(crate) fn default_builtins(set: BuiltinSet) -> HashMap<String, builtins::Registration> {
     let mut m = HashMap::<String, builtins::Registration>::new();
 
     //
@@ -273,7 +285,7 @@ pub(crate) fn get_default_builtins(
     // TODO: implement fc builtin; should be done after history.
     m.insert("fc".into(), builtin::<unimp::UnimplementedCommand>());
 
-    if !options.sh_mode {
+    if matches!(set, BuiltinSet::BashMode) {
         m.insert(
             "builtin".into(),
             raw_arg_builtin::<builtin_::BuiltinCommand>(),

--- a/brush-interactive/src/basic/basic_shell.rs
+++ b/brush-interactive/src/basic/basic_shell.rs
@@ -19,8 +19,8 @@ impl BasicShell {
     /// # Arguments
     ///
     /// * `options` - Options for creating the interactive shell.
-    pub async fn new(options: &crate::Options) -> Result<Self, ShellError> {
-        let shell = brush_core::Shell::new(&options.shell).await?;
+    pub async fn new(options: crate::Options) -> Result<Self, ShellError> {
+        let shell = brush_core::Shell::new(options.shell).await?;
         Ok(Self { shell })
     }
 }

--- a/brush-interactive/src/minimal/minimal_shell.rs
+++ b/brush-interactive/src/minimal/minimal_shell.rs
@@ -17,8 +17,8 @@ impl MinimalShell {
     /// # Arguments
     ///
     /// * `options` - Options for creating the interactive shell.
-    pub async fn new(options: &crate::Options) -> Result<Self, ShellError> {
-        let shell = brush_core::Shell::new(&options.shell).await?;
+    pub async fn new(options: crate::Options) -> Result<Self, ShellError> {
+        let shell = brush_core::Shell::new(options.shell).await?;
         Ok(Self { shell })
     }
 }

--- a/brush-interactive/src/reedline/reedline_shell.rs
+++ b/brush-interactive/src/reedline/reedline_shell.rs
@@ -32,7 +32,7 @@ impl ReedlineShell {
 
         // Set up shell first. Its initialization may influence how the
         // editor needs to operate.
-        let shell = brush_core::Shell::new(&options.shell).await?;
+        let shell = brush_core::Shell::new(options.shell).await?;
 
         // Wrap the shell in an Arc<Mutex> so we can share it with the helper
         // objects we'll need to set up for reedline.

--- a/brush-shell/src/shell_factory.rs
+++ b/brush-shell/src/shell_factory.rs
@@ -85,7 +85,7 @@ impl ShellFactory for BasicShellFactory {
     ) -> Result<Self::ShellType, brush_interactive::ShellError> {
         #[cfg(feature = "basic")]
         {
-            brush_interactive::BasicShell::new(&options).await
+            brush_interactive::BasicShell::new(options).await
         }
         #[cfg(not(feature = "basic"))]
         {
@@ -108,7 +108,7 @@ impl ShellFactory for MinimalShellFactory {
     ) -> Result<Self::ShellType, brush_interactive::ShellError> {
         #[cfg(feature = "minimal")]
         {
-            brush_interactive::MinimalShell::new(&options).await
+            brush_interactive::MinimalShell::new(options).await
         }
         #[cfg(not(feature = "minimal"))]
         {

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -17,17 +17,15 @@ const DEFAULT_BASH_COMPLETION_SCRIPT: &str = "/usr/share/bash-completion/bash_co
 
 impl TestShellWithBashCompletion {
     async fn new() -> Result<Self> {
+        let mut shell = brush_core::Shell::builder()
+            .no_profile(true)
+            .no_rc(true)
+            .build()
+            .await?;
+
         let temp_dir = assert_fs::TempDir::new()?;
-
-        let create_options = brush_core::CreateOptions {
-            no_profile: true,
-            no_rc: true,
-            ..Default::default()
-        };
-
         let bash_completion_script_path = Self::find_bash_completion_script()?;
 
-        let mut shell = brush_core::Shell::new(&create_options).await?;
         let exec_params = shell.default_exec_params();
         let source_result = shell
             .source_script(


### PR DESCRIPTION
In preparation for being able to pass builtins-to-be-registered into `Shell::new()` or `Shell::builder()`, this changes `Shell::new()` to take the creation options as an owned value (instead of by reference).

*This is a breaking API change for `brush_core`, but should only require minimal change in callers.*