### PR TITLE
refactor: Shell struct API improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -386,14 +386,16 @@ jobs:
 
       - name: Compare public APIs with main
         run: |
-          set -euo pipefail
+          set -euxo pipefail
 
           mkdir diffs
 
           for crate in $(./scripts/enum-lib-crates.sh); do
-            echo "# Public API diff for crate: ${crate}"
-            cargo public-api diff -p $crate main..${{ github.ref }} --color=always || true
-          done > ./diffs/api-diff-${crate}.md
+            echo "# Public API diff for crate: ${crate}" >./diffs/api-diff-${crate}.md
+            cargo public-api diff -p $crate main..${GITHUB_REF} --color=always >>./diffs/api-diff-${crate} || true
+          done
+        env:
+          GITHUB_REF: ${{ github.ref }}
 
       - name: Upload test report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -392,7 +392,7 @@ jobs:
 
           for crate in $(./scripts/enum-lib-crates.sh); do
             echo "# Public API diff for crate: ${crate}" >./diffs/api-diff-${crate}.md
-            cargo public-api diff -p $crate main..${GITHUB_REF} --color=always >>./diffs/api-diff-${crate} || true
+            cargo public-api diff -p $crate origin/main..${GITHUB_REF} --color=always >>./diffs/api-diff-${crate} || true
           done
         env:
           GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -400,10 +400,10 @@ jobs:
 
           for crate in $(./scripts/enum-lib-crates.sh); do
             out=./diffs/${crate}.txt
-            cargo public-api diff -p $crate origin/main..target --color=always >${out}
+            cargo public-api diff -sss -p $crate origin/main..target >${out}
 
             # Generate no-op diff as point of comparison
-            cargo public-api diff -p $crate target..target --color=always >${crate}.nop.txt
+            cargo public-api diff -p $crate target..target >${crate}.nop.txt
 
             if [[ $(cat ${out}) != $(cat ${crate}.nop.txt) ]]; then
               echo "# Public API changes for crate: ${crate}" >./reports/api-diff-${crate}.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -396,17 +396,26 @@ jobs:
           set -euxo pipefail
 
           mkdir diffs
+          mkdir reports
 
           for crate in $(./scripts/enum-lib-crates.sh); do
-            echo "# Public API diff for crate: ${crate}" >./diffs/api-diff-${crate}.md
-            cargo public-api diff -p $crate origin/main..target --color=always >>./diffs/api-diff-${crate} || true
+            out=./diffs/${crate}.txt
+            cargo public-api diff -p $crate origin/main..target --color=always >${out}
+
+            # Generate no-op diff as point of comparison
+            cargo public-api diff -p $crate target..target --color=always >${crate}.nop.txt
+
+            if [[ $(cat ${out}) != $(cat ${crate}.nop.txt) ]]; then
+              echo "# Public API changes for crate: ${crate}" >./reports/api-diff-${crate}.md
+              cat ${out} >>./reports/api-diff-${crate}.md
+            fi
           done
 
       - name: Upload test report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-reports-public-api
-          path: diffs/api-diff-*.md
+          path: reports/*.md
 
   # Performance analysis of the code.
   benchmark:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -374,10 +374,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up rust toolchain
+      - name: Set up nightly rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: stable
+          toolchain: nightly
 
       - name: Install cargo-public-api
         uses: taiki-e/install-action@efd8b64311f7a0a9b888ed13d0df78ec9184c163 # v2.62.11

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -384,8 +384,12 @@ jobs:
         with:
           tool: cargo-public-api
 
-      - name: Fetch main branch
-        run: git fetch origin main
+      - name: Set up branches
+        run: |
+          set -euo pipefail
+
+          git checkout -b target
+          git fetch origin main
 
       - name: Compare public APIs with main
         run: |
@@ -395,10 +399,8 @@ jobs:
 
           for crate in $(./scripts/enum-lib-crates.sh); do
             echo "# Public API diff for crate: ${crate}" >./diffs/api-diff-${crate}.md
-            cargo public-api diff -p $crate origin/main..${GITHUB_REF} --color=always >>./diffs/api-diff-${crate} || true
+            cargo public-api diff -p $crate origin/main..target --color=always >>./diffs/api-diff-${crate} || true
           done
-        env:
-          GITHUB_REF: ${{ github.ref }}
 
       - name: Upload test report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,19 +363,57 @@ jobs:
       - name: Check for unused dependencies
         run: cargo udeps --workspace --all-targets --all-features
 
-  # Performance analysis of the code.
-  benchmark:
+  # Analyze public API surface
+  analyze-public-api:
     if: github.event_name == 'pull_request'
-    name: "Benchmarks"
+    name: "Analyze public API"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+
+      - name: Set up rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Install cargo-public-api
+        uses: taiki-e/install-action@efd8b64311f7a0a9b888ed13d0df78ec9184c163 # v2.62.11
+        with:
+          tool: cargo-public-api
+
+      - name: Compare public APIs with main
+        run: |
+          set -euo pipefail
+
+          mkdir diffs
+
+          for crate in $(./scripts/enum-lib-crates.sh); do
+            echo "# Public API diff for crate: ${crate}"
+            cargo public-api diff -p $crate main..${{ github.ref }} --color=always || true
+          done > ./diffs/api-diff-${crate}.md
+
+      - name: Upload test report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-reports-public-api
+          path: diffs/api-diff-*.md
+
+  # Performance analysis of the code.
+  benchmark:
+    if: github.event_name == 'pull_request'
+    name: "Benchmarks"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout PR sources
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
           path: pr
 
-      - name: Checkout
+      - name: Checkout main sources
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -384,6 +384,9 @@ jobs:
         with:
           tool: cargo-public-api
 
+      - name: Fetch main branch
+        run: git fetch origin main
+
       - name: Compare public APIs with main
         run: |
           set -euxo pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -399,15 +399,15 @@ jobs:
           mkdir reports
 
           for crate in $(./scripts/enum-lib-crates.sh); do
-            out=./diffs/${crate}.txt
-            cargo public-api diff -sss -p $crate origin/main..target >${out}
+            diff=./diffs/${crate}.txt
+            report=./reports/api-diff-${crate}.md
 
-            # Generate no-op diff as point of comparison
-            cargo public-api diff -p $crate target..target >${crate}.nop.txt
+            cargo public-api diff -sss -p $crate origin/main..target >${diff}
+            ./scripts/format-api-diff-report.py ${diff} -p ${crate} >${report}
 
-            if [[ $(cat ${out}) != $(cat ${crate}.nop.txt) ]]; then
-              echo "# Public API changes for crate: ${crate}" >./reports/api-diff-${crate}.md
-              cat ${out} >>./reports/api-diff-${crate}.md
+            # If the report is empty, remove it.
+            if [[ ! -s ${report} ]]; then
+              rm -f ${report}
             fi
           done
 

--- a/brush-builtins/src/bind.rs
+++ b/brush-builtins/src/bind.rs
@@ -90,7 +90,7 @@ impl builtins::Command for BindCommand {
         &self,
         context: brush_core::ExecutionContext<'_>,
     ) -> Result<brush_core::builtins::ExitCode, brush_core::Error> {
-        if let Some(key_bindings) = &context.shell.key_bindings {
+        if let Some(key_bindings) = context.shell.key_bindings() {
             Ok(self.execute_impl(key_bindings, &context).await?)
         } else {
             writeln!(

--- a/brush-builtins/src/brushinfo.rs
+++ b/brush-builtins/src/brushinfo.rs
@@ -123,7 +123,7 @@ impl CompleteCommand {
             Self::Line { cursor_index, line } => {
                 let completions = context
                     .shell
-                    .get_completions(line, cursor_index.unwrap_or(line.len()))
+                    .complete(line, cursor_index.unwrap_or(line.len()))
                     .await?;
                 for candidate in completions.candidates {
                     writeln!(context.stdout(), "{candidate}")?;

--- a/brush-builtins/src/builtin_.rs
+++ b/brush-builtins/src/builtin_.rs
@@ -32,7 +32,7 @@ impl builtins::Command for BuiltinCommand {
 
         let builtin_name = args[0].to_string();
 
-        if let Some(builtin) = context.shell.builtins.get(&builtin_name) {
+        if let Some(builtin) = context.shell.builtins().get(&builtin_name) {
             context.command_name = builtin_name;
 
             (builtin.execute_func)(context, args)

--- a/brush-builtins/src/cd.rs
+++ b/brush-builtins/src/cd.rs
@@ -45,7 +45,7 @@ impl builtins::Command for CdCommand {
             // `cd -', equivalent to `cd $OLDPWD'
             if target_dir.as_os_str() == "-" {
                 should_print = true;
-                if let Some(oldpwd) = context.shell.get_env_str("OLDPWD") {
+                if let Some(oldpwd) = context.shell.env_str("OLDPWD") {
                     PathBuf::from(oldpwd.to_string())
                 } else {
                     writeln!(context.stderr(), "OLDPWD not set")?;
@@ -57,7 +57,7 @@ impl builtins::Command for CdCommand {
             }
         // `cd' without arguments is equivalent to `cd $HOME'
         } else {
-            if let Some(home_var) = context.shell.get_env_str("HOME") {
+            if let Some(home_var) = context.shell.env_str("HOME") {
                 PathBuf::from(home_var.to_string())
             } else {
                 writeln!(context.stderr(), "HOME not set")?;
@@ -76,7 +76,7 @@ impl builtins::Command for CdCommand {
                 return error::unimp("cd -e");
             }
 
-            target_dir = context.shell.get_absolute_path(target_dir).canonicalize()?;
+            target_dir = context.shell.absolute_path(target_dir).canonicalize()?;
         }
 
         if let Err(e) = context.shell.set_working_dir(&target_dir) {

--- a/brush-builtins/src/command.rs
+++ b/brush-builtins/src/command.rs
@@ -96,7 +96,7 @@ impl CommandCommand {
     ) -> Option<FoundCommand> {
         // Look in path.
         if command_name.contains(std::path::MAIN_SEPARATOR) {
-            let candidate_path = shell.get_absolute_path(Path::new(command_name));
+            let candidate_path = shell.absolute_path(Path::new(command_name));
             if candidate_path.executable() {
                 Some(FoundCommand::External(
                     candidate_path.to_string_lossy().to_string(),
@@ -105,7 +105,7 @@ impl CommandCommand {
                 None
             }
         } else {
-            if let Some(builtin_cmd) = shell.builtins.get(command_name) {
+            if let Some(builtin_cmd) = shell.builtins().get(command_name) {
                 if !builtin_cmd.disabled {
                     return Some(FoundCommand::Builtin(command_name.to_owned()));
                 }

--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -194,7 +194,7 @@ impl DeclareCommand {
         };
 
         if self.function_names_only || self.function_names_or_defs_only {
-            if let Some(func_registration) = context.shell.funcs.get(name) {
+            if let Some(func_registration) = context.shell.funcs().get(name) {
                 if self.function_names_only {
                     if self.print {
                         writeln!(context.stdout(), "declare -f {name}")?;
@@ -210,7 +210,7 @@ impl DeclareCommand {
                 Ok(false)
             }
         } else if let Some(variable) = context.shell.env.get_using_policy(name, lookup) {
-            let mut cs = variable.get_attribute_flags(context.shell);
+            let mut cs = variable.attribute_flags(context.shell);
             if cs.is_empty() {
                 cs.push('-');
             }
@@ -497,7 +497,7 @@ impl DeclareCommand {
             .sorted_by_key(|v| v.0)
         {
             if self.print {
-                let mut cs = variable.get_attribute_flags(context.shell);
+                let mut cs = variable.attribute_flags(context.shell);
                 if cs.is_empty() {
                     cs.push('-');
                 }
@@ -533,7 +533,7 @@ impl DeclareCommand {
         &self,
         context: &brush_core::ExecutionContext<'_>,
     ) -> Result<(), brush_core::Error> {
-        for (name, registration) in context.shell.funcs.iter().sorted_by_key(|v| v.0) {
+        for (name, registration) in context.shell.funcs().iter().sorted_by_key(|v| v.0) {
             if self.function_names_only {
                 writeln!(context.stdout(), "declare -f {name}")?;
             } else {

--- a/brush-builtins/src/dirs.rs
+++ b/brush-builtins/src/dirs.rs
@@ -33,9 +33,16 @@ impl builtins::Command for DirsCommand {
         if self.clear {
             context.shell.directory_stack.clear();
         } else {
-            let dirs = vec![&context.shell.working_dir]
+            let dirs = vec![context.shell.working_dir()]
                 .into_iter()
-                .chain(context.shell.directory_stack.iter().rev())
+                .chain(
+                    context
+                        .shell
+                        .directory_stack
+                        .iter()
+                        .rev()
+                        .map(|p| p.as_path()),
+                )
                 .collect::<Vec<_>>();
 
             let one_per_line = self.print_one_per_line || self.print_one_per_line_with_index;

--- a/brush-builtins/src/enable.rs
+++ b/brush-builtins/src/enable.rs
@@ -52,7 +52,7 @@ impl builtins::Command for EnableCommand {
 
         if !self.names.is_empty() {
             for name in &self.names {
-                if let Some(builtin) = context.shell.builtins.get_mut(name) {
+                if let Some(builtin) = context.shell.builtin_mut(name) {
                     builtin.disabled = self.disable;
                 } else {
                     writeln!(context.stderr(), "{name}: not a shell builtin")?;
@@ -62,7 +62,7 @@ impl builtins::Command for EnableCommand {
         } else {
             let builtins: Vec<_> = context
                 .shell
-                .builtins
+                .builtins()
                 .iter()
                 .sorted_by_key(|(name, _reg)| *name)
                 .collect();

--- a/brush-builtins/src/exit.rs
+++ b/brush-builtins/src/exit.rs
@@ -18,7 +18,7 @@ impl builtins::Command for ExitCommand {
         let code_8bit = if let Some(code_32bit) = &self.code {
             (code_32bit & 0xFF) as u8
         } else {
-            context.shell.last_exit_status
+            context.shell.last_result()
         };
 
         Ok(builtins::ExitCode::ExitShell(code_8bit))

--- a/brush-builtins/src/export.rs
+++ b/brush-builtins/src/export.rs
@@ -71,7 +71,7 @@ impl ExportCommand {
                 if self.names_are_functions {
                     // Try to find the function already present; if we find it, then mark it
                     // exported.
-                    if let Some(func) = context.shell.funcs.get_mut(s) {
+                    if let Some(func) = context.shell.func_mut(s) {
                         if self.unexport {
                             func.unexport();
                         } else {

--- a/brush-builtins/src/getopts.rs
+++ b/brush-builtins/src/getopts.rs
@@ -67,7 +67,7 @@ impl builtins::Command for GetOptsCommand {
         // If unset, assume OPTIND is 1.
         let mut next_index: usize = context
             .shell
-            .get_env_str("OPTIND")
+            .env_str("OPTIND")
             .unwrap_or(Cow::Borrowed("1"))
             .parse()?;
 
@@ -91,7 +91,7 @@ impl builtins::Command for GetOptsCommand {
                 const DEFAULT_NEXT_CHAR_INDEX: usize = 1;
                 let next_char_index = context
                     .shell
-                    .get_env_str(VAR_GETOPTS_NEXT_CHAR_INDEX)
+                    .env_str(VAR_GETOPTS_NEXT_CHAR_INDEX)
                     .map_or(DEFAULT_NEXT_CHAR_INDEX, |s| {
                         s.parse().unwrap_or(DEFAULT_NEXT_CHAR_INDEX)
                     });

--- a/brush-builtins/src/help.rs
+++ b/brush-builtins/src/help.rs
@@ -45,7 +45,7 @@ impl HelpCommand {
     ) -> Result<(), brush_core::Error> {
         const COLUMN_COUNT: usize = 3;
 
-        if let Some(display_str) = &context.shell.shell_product_display_str {
+        if let Some(display_str) = context.shell.product_display_str() {
             writeln!(context.stdout(), "{display_str}\n")?;
         }
 
@@ -129,7 +129,7 @@ fn get_builtins_sorted_by_name<'a>(
 ) -> Vec<(&'a String, &'a builtins::Registration)> {
     context
         .shell
-        .builtins
+        .builtins()
         .iter()
         .sorted_by_key(|(name, _)| *name)
         .collect()

--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -57,8 +57,8 @@ impl builtins::Command for HistoryCommand {
     ) -> Result<builtins::ExitCode, brush_core::Error> {
         // Retrieve the shell's history config while we still can.
         let config = HistoryConfig {
-            default_history_file_path: context.shell.get_history_file_path(),
-            time_format: context.shell.get_history_time_format(),
+            default_history_file_path: context.shell.history_file_path(),
+            time_format: context.shell.history_time_format(),
         };
 
         if let Some(history) = context.shell.history_mut() {

--- a/brush-builtins/src/jobs.rs
+++ b/brush-builtins/src/jobs.rs
@@ -69,7 +69,7 @@ impl JobsCommand {
         }
 
         if self.show_pids_only {
-            if let Some(pid) = job.get_representative_pid() {
+            if let Some(pid) = job.representative_pid() {
                 writeln!(context.stdout(), "{pid}")?;
             }
         } else {

--- a/brush-builtins/src/pushd.rs
+++ b/brush-builtins/src/pushd.rs
@@ -26,7 +26,7 @@ impl builtins::Command for PushdCommand {
                 .directory_stack
                 .push(std::path::PathBuf::from(&self.dir));
         } else {
-            let prev_working_dir = context.shell.working_dir.clone();
+            let prev_working_dir = context.shell.working_dir().to_path_buf();
 
             let dir = std::path::Path::new(&self.dir);
             context.shell.set_working_dir(dir)?;

--- a/brush-builtins/src/pwd.rs
+++ b/brush-builtins/src/pwd.rs
@@ -19,7 +19,7 @@ impl builtins::Command for PwdCommand {
         &self,
         context: brush_core::ExecutionContext<'_>,
     ) -> Result<brush_core::builtins::ExitCode, brush_core::Error> {
-        let mut cwd: Cow<'_, Path> = context.shell.working_dir.as_path().into();
+        let mut cwd: Cow<'_, Path> = context.shell.working_dir().into();
 
         let should_canonicalize = self.physical
             || context

--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -94,7 +94,7 @@ impl builtins::Command for ReadCommand {
         };
 
         // Retrieve effective value of IFS for splitting.
-        let ifs = context.shell.get_ifs();
+        let ifs = context.shell.ifs();
 
         let stdout_file = context
             .params

--- a/brush-builtins/src/return_.rs
+++ b/brush-builtins/src/return_.rs
@@ -19,7 +19,7 @@ impl builtins::Command for ReturnCommand {
         let code_8bit = if let Some(code_32bit) = &self.code {
             (code_32bit & 0xFF) as u8
         } else {
-            context.shell.last_exit_status
+            context.shell.last_result()
         };
 
         if context.shell.in_function() || context.shell.in_sourced_script() {

--- a/brush-builtins/src/set.rs
+++ b/brush-builtins/src/set.rs
@@ -423,7 +423,7 @@ fn display_all(context: &brush_core::ExecutionContext<'_>) -> Result<(), brush_c
 
     // Display functions... unless we're in posix compliance mode.
     if !context.shell.options.posix_mode {
-        for (_name, registration) in context.shell.funcs.iter().sorted_by_key(|v| v.0) {
+        for (_name, registration) in context.shell.funcs().iter().sorted_by_key(|v| v.0) {
             writeln!(context.stdout(), "{}", registration.definition())?;
         }
     }

--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -161,7 +161,7 @@ impl TypeCommand {
 
             // Check for functions.
             if !self.suppress_func_lookup {
-                if let Some(registration) = shell.funcs.get(name) {
+                if let Some(registration) = shell.funcs().get(name) {
                     types.push(ResolvedType::Function(registration.definition()));
                     if !self.all_locations {
                         return types;
@@ -170,7 +170,7 @@ impl TypeCommand {
             }
 
             // Check for builtins.
-            if shell.builtins.get(name).is_some_and(|b| !b.disabled) {
+            if shell.builtins().get(name).is_some_and(|b| !b.disabled) {
                 types.push(ResolvedType::Builtin);
                 if !self.all_locations {
                     return types;
@@ -180,7 +180,7 @@ impl TypeCommand {
 
         // Look in path.
         if name.contains(std::path::MAIN_SEPARATOR) {
-            if shell.get_absolute_path(Path::new(name)).executable() {
+            if shell.absolute_path(Path::new(name)).executable() {
                 types.push(ResolvedType::File {
                     path: PathBuf::from(name),
                     hashed: false,

--- a/brush-builtins/src/unset.rs
+++ b/brush-builtins/src/unset.rs
@@ -78,7 +78,7 @@ impl builtins::Command for UnsetCommand {
 
             // TODO: Deal with readonly functions
             if unspecified || self.name_interpretation.shell_functions {
-                if context.shell.funcs.remove(name).is_some() {
+                if context.shell.undefine_func(name) {
                     continue;
                 }
             }

--- a/brush-core/examples/call-func.rs
+++ b/brush-core/examples/call-func.rs
@@ -44,7 +44,7 @@ async fn run(suppress_stdout: bool) -> Result<()> {
 
     define_func(&mut shell).await?;
 
-    for (name, _) in shell.funcs.iter() {
+    for (name, _) in shell.funcs().iter() {
         eprintln!("[Found function: {name}]");
     }
 

--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -146,9 +146,7 @@ impl Evaluatable for ast::ArithmeticExpr {
 
 fn deref_lvalue(shell: &mut Shell, lvalue: &ast::ArithmeticTarget) -> Result<i64, EvalError> {
     let value_str: Cow<'_, str> = match lvalue {
-        ast::ArithmeticTarget::Variable(name) => {
-            shell.get_env_str(name).unwrap_or(Cow::Borrowed(""))
-        }
+        ast::ArithmeticTarget::Variable(name) => shell.env_str(name).unwrap_or(Cow::Borrowed("")),
         ast::ArithmeticTarget::ArrayElement(name, index_expr) => {
             let index_str = index_expr.eval(shell)?.to_string();
 

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -88,7 +88,7 @@ pub enum Error {
 
     /// An error occurred while redirecting input or output with the given file.
     #[error("failed to redirect to {0}: {1}")]
-    RedirectionFailure(String, std::io::Error),
+    RedirectionFailure(String, String),
 
     /// An error occurred evaluating an arithmetic expression.
     #[error("arithmetic evaluation error: {0}")]

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -74,47 +74,47 @@ pub(crate) fn apply_unary_predicate_to_str(
         ast::UnaryPredicate::StringHasNonZeroLength => Ok(!operand.is_empty()),
         ast::UnaryPredicate::StringHasZeroLength => Ok(operand.is_empty()),
         ast::UnaryPredicate::FileExists => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists())
         }
         ast::UnaryPredicate::FileExistsAndIsBlockSpecialFile => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists_and_is_block_device())
         }
         ast::UnaryPredicate::FileExistsAndIsCharSpecialFile => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists_and_is_char_device())
         }
         ast::UnaryPredicate::FileExistsAndIsDir => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.is_dir())
         }
         ast::UnaryPredicate::FileExistsAndIsRegularFile => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.is_file())
         }
         ast::UnaryPredicate::FileExistsAndIsSetgid => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists_and_is_setgid())
         }
         ast::UnaryPredicate::FileExistsAndIsSymlink => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.is_symlink())
         }
         ast::UnaryPredicate::FileExistsAndHasStickyBit => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists_and_is_sticky_bit())
         }
         ast::UnaryPredicate::FileExistsAndIsFifo => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists_and_is_fifo())
         }
         ast::UnaryPredicate::FileExistsAndIsReadable => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.readable())
         }
         ast::UnaryPredicate::FileExistsAndIsNotZeroLength => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             if let Ok(metadata) = path.metadata() {
                 Ok(metadata.len() > 0)
             } else {
@@ -133,19 +133,19 @@ pub(crate) fn apply_unary_predicate_to_str(
             }
         }
         ast::UnaryPredicate::FileExistsAndIsSetuid => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists_and_is_setuid())
         }
         ast::UnaryPredicate::FileExistsAndIsWritable => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.writable())
         }
         ast::UnaryPredicate::FileExistsAndIsExecutable => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.executable())
         }
         ast::UnaryPredicate::FileExistsAndOwnedByEffectiveGroupId => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             if !path.exists() {
                 return Ok(false);
             }
@@ -157,7 +157,7 @@ pub(crate) fn apply_unary_predicate_to_str(
             error::unimp("unary extended test predicate: FileExistsAndModifiedSinceLastRead")
         }
         ast::UnaryPredicate::FileExistsAndOwnedByEffectiveUserId => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             if !path.exists() {
                 return Ok(false);
             }
@@ -166,7 +166,7 @@ pub(crate) fn apply_unary_predicate_to_str(
             Ok(md.uid() == users::get_effective_uid()?)
         }
         ast::UnaryPredicate::FileExistsAndIsSocket => {
-            let path = shell.get_absolute_path(Path::new(operand));
+            let path = shell.absolute_path(Path::new(operand));
             Ok(path.exists_and_is_socket())
         }
         ast::UnaryPredicate::ShellOptionEnabled => {
@@ -559,8 +559,8 @@ fn left_file_is_older_or_does_not_exist_when_right_does(
     right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
     let (l_path, r_path) = (
-        shell.get_absolute_path(Path::new(left.as_ref())),
-        shell.get_absolute_path(Path::new(right.as_ref())),
+        shell.absolute_path(Path::new(left.as_ref())),
+        shell.absolute_path(Path::new(right.as_ref())),
     );
 
     match (l_path.metadata(), r_path.metadata()) {
@@ -576,8 +576,8 @@ fn left_file_is_newer_or_exists_when_right_does_not(
     right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
     let (l_path, r_path) = (
-        shell.get_absolute_path(Path::new(left.as_ref())),
-        shell.get_absolute_path(Path::new(right.as_ref())),
+        shell.absolute_path(Path::new(left.as_ref())),
+        shell.absolute_path(Path::new(right.as_ref())),
     );
 
     match (l_path.metadata(), r_path.metadata()) {
@@ -593,8 +593,8 @@ fn files_refer_to_same_device_and_inode_numbers(
     right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
     let (l_path, r_path) = (
-        shell.get_absolute_path(Path::new(left.as_ref())),
-        shell.get_absolute_path(Path::new(right.as_ref())),
+        shell.absolute_path(Path::new(left.as_ref())),
+        shell.absolute_path(Path::new(right.as_ref())),
     );
 
     if !l_path.readable() || !r_path.readable() {

--- a/brush-core/src/functions.rs
+++ b/brush-core/src/functions.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 /// An environment for defined, named functions.
 #[derive(Clone, Default)]
 pub struct FunctionEnv {
-    functions: HashMap<String, FunctionRegistration>,
+    functions: HashMap<String, Registration>,
 }
 
 impl FunctionEnv {
@@ -14,7 +14,7 @@ impl FunctionEnv {
     /// # Arguments
     ///
     /// * `name` - The name of the function to retrieve.
-    pub fn get(&self, name: &str) -> Option<&FunctionRegistration> {
+    pub fn get(&self, name: &str) -> Option<&Registration> {
         self.functions.get(name)
     }
 
@@ -24,7 +24,7 @@ impl FunctionEnv {
     /// # Arguments
     ///
     /// * `name` - The name of the function to retrieve.
-    pub fn get_mut(&mut self, name: &str) -> Option<&mut FunctionRegistration> {
+    pub fn get_mut(&mut self, name: &str) -> Option<&mut Registration> {
         self.functions.get_mut(name)
     }
 
@@ -33,7 +33,7 @@ impl FunctionEnv {
     /// # Arguments
     ///
     /// * `name` - The name of the function to remove.
-    pub fn remove(&mut self, name: &str) -> Option<FunctionRegistration> {
+    pub fn remove(&mut self, name: &str) -> Option<Registration> {
         self.functions.remove(name)
     }
 
@@ -43,7 +43,7 @@ impl FunctionEnv {
     ///
     /// * `name` - The name of the function to update.
     /// * `registration` - The new registration for the function.
-    pub fn update(&mut self, name: String, registration: FunctionRegistration) {
+    pub fn update(&mut self, name: String, registration: Registration) {
         self.functions.insert(name, registration);
     }
 
@@ -53,21 +53,21 @@ impl FunctionEnv {
     }
 
     /// Returns an iterator over the functions registered in this environment.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &FunctionRegistration)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Registration)> {
         self.functions.iter()
     }
 }
 
 /// Encapsulates a registration for a defined function.
 #[derive(Clone)]
-pub struct FunctionRegistration {
+pub struct Registration {
     /// The definition of the function.
     pub(crate) definition: Arc<brush_parser::ast::FunctionDefinition>,
     /// Whether or not this function definition should be exported to children.
     exported: bool,
 }
 
-impl From<brush_parser::ast::FunctionDefinition> for FunctionRegistration {
+impl From<brush_parser::ast::FunctionDefinition> for Registration {
     fn from(definition: brush_parser::ast::FunctionDefinition) -> Self {
         Self {
             definition: Arc::new(definition),
@@ -76,7 +76,7 @@ impl From<brush_parser::ast::FunctionDefinition> for FunctionRegistration {
     }
 }
 
-impl FunctionRegistration {
+impl Registration {
     /// Returns a reference to the function definition.
     pub fn definition(&self) -> &brush_parser::ast::FunctionDefinition {
         &self.definition

--- a/brush-core/src/history.rs
+++ b/brush-core/src/history.rs
@@ -2,7 +2,7 @@
 
 use chrono::Utc;
 use std::{
-    io::{BufRead, Write},
+    io::{BufRead, Read, Write},
     path::Path,
 };
 
@@ -21,20 +21,19 @@ pub struct History {
 }
 
 impl History {
-    /// Constructs a new `History` instance, with its contents initialized from the given saved
-    /// history file.
+    /// Constructs a new `History` instance, with its contents initialized from the given readable
+    /// stream.
     ///
     /// # Arguments
     ///
-    /// * `path` - The path to the history file.
-    pub fn import(path: impl AsRef<Path>) -> Result<Self, error::Error> {
+    /// * `reader` - The readable stream to import history from.
+    pub fn import(reader: impl Read) -> Result<Self, error::Error> {
         let mut history = Self::default();
 
-        let file = std::fs::File::open(path.as_ref())?;
-        let reader = std::io::BufReader::new(file);
+        let buf_reader = std::io::BufReader::new(reader);
 
         let mut next_timestamp = None;
-        for line in reader.lines() {
+        for line in buf_reader.lines() {
             let line = line?;
 
             if let Some(comment) = line.strip_prefix("#") {
@@ -165,7 +164,7 @@ impl History {
         write_timestamps: bool,
     ) -> Result<(), error::Error> {
         // Open the file
-        let mut file_options = std::fs::OpenOptions::new();
+        let mut file_options = std::fs::File::options();
 
         if append {
             file_options.append(true);

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -35,10 +35,13 @@ pub mod timing;
 pub mod trace_categories;
 pub mod traps;
 pub mod variables;
+mod wellknownvars;
 
 pub use commands::{CommandArg, ExecutionContext};
 pub use error::Error;
 pub use interp::{ExecutionParameters, ExecutionResult, ProcessGroupPolicy};
-pub use shell::{CreateOptions, Shell, ShellBuilder, ShellBuilderState};
+pub use shell::{
+    CreateOptions, FunctionCall, ScriptCallType, Shell, ShellBuilder, ShellBuilderState,
+};
 pub use terminal::TerminalControl;
 pub use variables::{ShellValue, ShellVariable};

--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -266,7 +266,7 @@ impl RuntimeOptions {
     }
 
     /// Returns a string representing the current `set`-style option flags set in the shell.
-    pub fn get_option_flags(&self) -> String {
+    pub fn option_flags(&self) -> String {
         let mut cs = vec![];
 
         for o in namedoptions::options(namedoptions::ShellOptionKind::Set).iter() {
@@ -296,7 +296,7 @@ impl RuntimeOptions {
     }
 
     /// Returns a colon-separated list of sorted 'set -o' options enabled.
-    pub fn get_set_o_optstr(&self) -> String {
+    pub fn seto_optstr(&self) -> String {
         let mut cs = vec![];
 
         for option in namedoptions::options(namedoptions::ShellOptionKind::SetO).iter() {
@@ -310,7 +310,7 @@ impl RuntimeOptions {
     }
 
     /// Returns a colon-separated list of sorted 'shopt' options enabled.
-    pub fn get_shopt_optstr(&self) -> String {
+    pub fn shopt_optstr(&self) -> String {
         let mut cs = vec![];
 
         for option in namedoptions::options(namedoptions::ShellOptionKind::Shopt).iter() {

--- a/brush-core/src/prompt.rs
+++ b/brush-core/src/prompt.rs
@@ -109,7 +109,7 @@ fn format_prompt_piece(
 }
 
 fn format_current_working_directory(shell: &Shell, tilde_replaced: bool, basename: bool) -> String {
-    let mut working_dir_str = shell.working_dir.to_string_lossy().to_string();
+    let mut working_dir_str = shell.working_dir().to_string_lossy().to_string();
 
     if tilde_replaced {
         working_dir_str = shell.tilde_shorten(working_dir_str);

--- a/brush-core/src/sys/unix/fs.rs
+++ b/brush-core/src/sys/unix/fs.rs
@@ -156,7 +156,7 @@ fn confstr(name: nix::libc::c_int) -> Result<Option<std::ffi::OsString>, std::io
 
 /// Opens a null file that will discard all I/O.
 pub fn open_null_file() -> Result<std::fs::File, error::Error> {
-    let f = std::fs::OpenOptions::new()
+    let f = std::fs::File::options()
         .read(true)
         .write(true)
         .open("/dev/null")?;

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -529,7 +529,7 @@ impl ShellVariable {
     }
 
     /// Returns the canonical attribute flag string for this variable.
-    pub fn get_attribute_flags(&self, shell: &Shell) -> String {
+    pub fn attribute_flags(&self, shell: &Shell) -> String {
         let value = self.resolve_value(shell);
 
         let mut result = String::new();
@@ -920,24 +920,24 @@ impl ShellValue {
     }
 
     /// Returns the keys of the elements in this variable.
-    pub fn get_element_keys(&self, shell: &Shell) -> Vec<String> {
+    pub fn element_keys(&self, shell: &Shell) -> Vec<String> {
         match self {
             Self::Unset(_) => vec![],
             Self::String(_) => vec!["0".to_owned()],
             Self::AssociativeArray(array) => array.keys().map(|k| k.to_owned()).collect(),
             Self::IndexedArray(array) => array.keys().map(|k| k.to_string()).collect(),
-            Self::Dynamic { getter, .. } => getter(shell).get_element_keys(shell),
+            Self::Dynamic { getter, .. } => getter(shell).element_keys(shell),
         }
     }
 
     /// Returns the values of the elements in this variable.
-    pub fn get_element_values(&self, shell: &Shell) -> Vec<String> {
+    pub fn element_values(&self, shell: &Shell) -> Vec<String> {
         match self {
             Self::Unset(_) => vec![],
             Self::String(s) => vec![s.to_owned()],
             Self::AssociativeArray(array) => array.values().map(|v| v.to_owned()).collect(),
             Self::IndexedArray(array) => array.values().map(|v| v.to_owned()).collect(),
-            Self::Dynamic { getter, .. } => getter(shell).get_element_values(shell),
+            Self::Dynamic { getter, .. } => getter(shell).element_values(shell),
         }
     }
 

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -1,0 +1,529 @@
+use rand::Rng;
+
+use crate::{Shell, ShellValue, ShellVariable, error, sys, variables};
+
+const BASH_MAJOR: u32 = 5;
+const BASH_MINOR: u32 = 2;
+const BASH_PATCH: u32 = 15;
+const BASH_BUILD: u32 = 1;
+const BASH_RELEASE: &str = "release";
+const BASH_MACHINE: &str = "unknown";
+
+#[expect(clippy::too_many_lines)]
+pub(crate) fn initialize_vars(
+    shell: &mut Shell,
+    do_not_inherit_env: bool,
+) -> Result<(), error::Error> {
+    // Seed parameters from environment (unless requested not to do so).
+    if !do_not_inherit_env {
+        for (k, v) in std::env::vars() {
+            // See if it's a function exported by an ancestor process.
+            if let Some(func_name) = k.strip_prefix("BASH_FUNC_") {
+                if let Some(func_name) = func_name.strip_suffix("%%") {
+                    // Intentionally best-effort; don't fail out of the shell if we can't
+                    // parse an incoming function.
+                    if shell.define_func_from_str(func_name, v.as_str()).is_ok() {
+                        shell.func_mut(func_name).unwrap().export();
+                    }
+
+                    continue;
+                }
+            }
+
+            let mut var = ShellVariable::new(ShellValue::String(v));
+            var.export();
+            shell.env.set_global(k, var)?;
+        }
+    }
+
+    let shell_version = shell.version().clone();
+    shell.env.set_global(
+        "BRUSH_VERSION",
+        ShellVariable::new(shell_version.unwrap_or_default()),
+    )?;
+
+    // TODO(#479): implement $_
+
+    // BASH
+    if let Some(shell_name) = &shell.shell_name {
+        shell
+            .env
+            .set_global("BASH", ShellVariable::new(shell_name))?;
+    }
+
+    // BASHOPTS
+    let mut bashopts_var = ShellVariable::new(ShellValue::Dynamic {
+        getter: |shell| shell.options.shopt_optstr().into(),
+        setter: |_| (),
+    });
+    bashopts_var.set_readonly();
+    shell.env.set_global("BASHOPTS", bashopts_var)?;
+
+    // BASHPID
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let mut bashpid_var =
+            ShellVariable::new(ShellValue::String(std::process::id().to_string()));
+        bashpid_var.treat_as_integer();
+        shell.env.set_global("BASHPID", bashpid_var)?;
+    }
+
+    // BASH_ALIASES
+    shell.env.set_global(
+        "BASH_ALIASES",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| {
+                let values = variables::ArrayLiteral(
+                    shell
+                        .aliases
+                        .iter()
+                        .map(|(k, v)| (Some(k.to_owned()), v.to_owned()))
+                        .collect::<Vec<_>>(),
+                );
+
+                ShellValue::associative_array_from_literals(values).unwrap()
+            },
+            setter: |_| (),
+        }),
+    )?;
+
+    // TODO(vars): when extdebug is enabled, BASH_ARGC and BASH_ARGV are set to valid values
+    // TODO(vars): implement BASH_ARGC
+    // TODO(vars): implement BASH_ARGV
+
+    // BASH_ARGV0
+    shell.env.set_global(
+        "BASH_ARGV0",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| {
+                let argv0 = shell.shell_name.as_deref().unwrap_or_default();
+                argv0.to_string().into()
+            },
+            // TODO(vars): implement updating BASH_ARGV0
+            setter: |_| (),
+        }),
+    )?;
+
+    // TODO(vars): implement mutation of BASH_CMDS
+    shell.env.set_global(
+        "BASH_CMDS",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| shell.program_location_cache.to_value().unwrap(),
+            setter: |_| (),
+        }),
+    )?;
+
+    // TODO(vars): implement BASH_COMMAND
+    // TODO(vars): implement BASH_EXECUTIION_STRING
+    // TODO(vars): implement BASH_LINENO
+
+    // BASH_SOURCE
+    shell.env.set_global(
+        "BASH_SOURCE",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| get_bash_source_value(shell),
+            setter: |_| (),
+        }),
+    )?;
+
+    // BASH_SUBSHELL
+    shell.env.set_global(
+        "BASH_SUBSHELL",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| shell.depth().to_string().into(),
+            setter: |_| (),
+        }),
+    )?;
+
+    // BASH_VERSINFO
+    let mut bash_versinfo_var = ShellVariable::new(ShellValue::indexed_array_from_strs(
+        [
+            BASH_MAJOR.to_string().as_str(),
+            BASH_MINOR.to_string().as_str(),
+            BASH_PATCH.to_string().as_str(),
+            BASH_BUILD.to_string().as_str(),
+            BASH_RELEASE,
+            BASH_MACHINE,
+        ]
+        .as_slice(),
+    ));
+    bash_versinfo_var.set_readonly();
+    shell.env.set_global("BASH_VERSINFO", bash_versinfo_var)?;
+
+    // BASH_VERSION
+    // This is the Bash interface version. See BRUSH_VERSION for its implementation version.
+    shell.env.set_global(
+        "BASH_VERSION",
+        ShellVariable::new(std::format!(
+            "{BASH_MAJOR}.{BASH_MINOR}.{BASH_PATCH}({BASH_BUILD})-{BASH_RELEASE}"
+        )),
+    )?;
+
+    // COMP_WORDBREAKS
+    shell
+        .env
+        .set_global("COMP_WORDBREAKS", ShellVariable::new(" \t\n\"\'@><=;|&(:"))?;
+
+    // DIRSTACK
+    shell.env.set_global(
+        "DIRSTACK",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| {
+                shell
+                    .directory_stack
+                    .iter()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .collect::<Vec<_>>()
+                    .into()
+            },
+            setter: |_| (),
+        }),
+    )?;
+
+    // EPOCHREALTIME
+    shell.env.set_global(
+        "EPOCHREALTIME",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |_shell| {
+                let now = std::time::SystemTime::now();
+                let since_epoch = now
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default();
+                since_epoch.as_secs_f64().to_string().into()
+            },
+            setter: |_| (),
+        }),
+    )?;
+
+    // EPOCHSECONDS
+    shell.env.set_global(
+        "EPOCHSECONDS",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |_shell| {
+                let now = std::time::SystemTime::now();
+                let since_epoch = now
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default();
+                since_epoch.as_secs().to_string().into()
+            },
+            setter: |_| (),
+        }),
+    )?;
+
+    // EUID
+    #[cfg(unix)]
+    {
+        let mut euid_var = ShellVariable::new(ShellValue::String(format!(
+            "{}",
+            uzers::get_effective_uid()
+        )));
+        euid_var.treat_as_integer().set_readonly();
+        shell.env.set_global("EUID", euid_var)?;
+    }
+
+    // FUNCNAME
+    shell.env.set_global(
+        "FUNCNAME",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| get_funcname_value(shell),
+            setter: |_| (),
+        }),
+    )?;
+
+    // GROUPS
+    // N.B. We could compute this up front, but we choose to make it dynamic so that we
+    // don't have to make costly system calls if the user never accesses it.
+    shell.env.set_global(
+        "GROUPS",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |_shell| {
+                let groups = get_current_user_gids();
+                ShellValue::indexed_array_from_strings(
+                    groups.into_iter().map(|gid| gid.to_string()),
+                )
+            },
+            setter: |_| (),
+        }),
+    )?;
+
+    // HISTCMD
+    let mut histcmd_var = ShellVariable::new(ShellValue::Dynamic {
+        getter: |shell| {
+            shell
+                .history()
+                .map_or_else(|| "0".into(), |h| h.count().to_string().into())
+        },
+        setter: |_| (),
+    });
+    histcmd_var.treat_as_integer();
+    shell.env.set_global("HISTCMD", histcmd_var)?;
+
+    // HISTFILE (if not already set)
+    if !shell.env.is_set("HISTFILE") {
+        if let Some(home_dir) = shell.home_dir() {
+            let histfile = home_dir.join(".brush_history");
+            shell.env.set_global(
+                "HISTFILE",
+                ShellVariable::new(ShellValue::String(histfile.to_string_lossy().to_string())),
+            )?;
+        }
+    }
+
+    // HOSTNAME
+    shell.env.set_global(
+        "HOSTNAME",
+        ShellVariable::new(
+            sys::network::get_hostname()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string(),
+        ),
+    )?;
+
+    // HOSTTYPE
+    #[cfg(unix)]
+    {
+        if let Ok(info) = nix::sys::utsname::uname() {
+            shell.env.set_global(
+                "HOSTTYPE",
+                ShellVariable::new(info.machine().to_string_lossy().to_string()),
+            )?;
+        }
+    }
+
+    // IFS
+    shell.env.set_global("IFS", ShellVariable::new(" \t\n"))?;
+
+    // LINENO
+    shell.env.set_global(
+        "LINENO",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| shell.current_line_number().to_string().into(),
+            setter: |_| (),
+        }),
+    )?;
+
+    // MACHTYPE
+    shell
+        .env
+        .set_global("MACHTYPE", ShellVariable::new(BASH_MACHINE))?;
+
+    // OLDPWD (initialization)
+    if !shell.env.is_set("OLDPWD") {
+        let mut oldpwd_var =
+            ShellVariable::new(ShellValue::Unset(variables::ShellValueUnsetType::Untyped));
+        oldpwd_var.export();
+        shell.env.set_global("OLDPWD", oldpwd_var)?;
+    }
+
+    // OPTERR
+    shell.env.set_global("OPTERR", ShellVariable::new("1"))?;
+
+    // OPTIND
+    let mut optind_var = ShellVariable::new("1");
+    optind_var.treat_as_integer();
+    shell.env.set_global("OPTIND", optind_var)?;
+
+    // OSTYPE
+    let os_type = match std::env::consts::OS {
+        "linux" => "linux-gnu",
+        "windows" => "windows",
+        _ => "unknown",
+    };
+    shell
+        .env
+        .set_global("OSTYPE", ShellVariable::new(os_type))?;
+
+    // PATH (if not already set)
+    #[cfg(unix)]
+    if !shell.env.is_set("PATH") {
+        use crate::sys;
+
+        let default_path_str = sys::fs::get_default_executable_search_paths().join(":");
+        shell
+            .env
+            .set_global("PATH", ShellVariable::new(default_path_str))?;
+    }
+
+    // PIPESTATUS
+    // TODO: Investigate what happens if this gets unset.
+    // TODO: Investigate if this needs to be saved/preserved across prompt display.
+    shell.env.set_global(
+        "PIPESTATUS",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| {
+                ShellValue::indexed_array_from_strings(
+                    shell.last_pipeline_statuses.iter().map(|s| s.to_string()),
+                )
+            },
+            setter: |_| (),
+        }),
+    )?;
+
+    // PPID
+    if let Some(ppid) = sys::terminal::get_parent_process_id() {
+        let mut ppid_var = ShellVariable::new(ppid.to_string());
+        ppid_var.treat_as_integer().set_readonly();
+        shell.env.set_global("PPID", ppid_var)?;
+    }
+
+    // RANDOM
+    let mut random_var = ShellVariable::new(ShellValue::Dynamic {
+        getter: get_random_value,
+        setter: |_| (),
+    });
+    random_var.treat_as_integer();
+    shell.env.set_global("RANDOM", random_var)?;
+
+    // SECONDS
+    shell.env.set_global(
+        "SECONDS",
+        ShellVariable::new(ShellValue::Dynamic {
+            getter: |shell| {
+                let now = std::time::SystemTime::now();
+                let since_last = now
+                    .duration_since(shell.last_stopwatch_time())
+                    .unwrap_or_default();
+                let total_seconds = since_last.as_secs() + u64::from(shell.last_stopwatch_offset());
+                total_seconds.to_string().into()
+            },
+            // TODO(vars): implement updating SECONDS
+            setter: |_| (),
+        }),
+    )?;
+
+    // SHELL
+    if let Ok(exe_path) = std::env::current_exe() {
+        shell.env.set_global(
+            "SHELL",
+            ShellVariable::new(exe_path.to_string_lossy().to_string()),
+        )?;
+    }
+
+    // SHELLOPTS
+    let mut shellopts_var = ShellVariable::new(ShellValue::Dynamic {
+        getter: |shell| shell.options.seto_optstr().into(),
+        setter: |_| (),
+    });
+    shellopts_var.set_readonly();
+    shell.env.set_global("SHELLOPTS", shellopts_var)?;
+
+    // SHLVL
+    let input_shlvl = shell.env_str("SHLVL").unwrap_or_else(|| "0".into());
+    let updated_shlvl = input_shlvl.as_ref().parse::<u32>().unwrap_or(0) + 1;
+    let mut shlvl_var = ShellVariable::new(updated_shlvl.to_string());
+    shlvl_var.export();
+    shell.env.set_global("SHLVL", shlvl_var)?;
+
+    // SRANDOM
+    let mut random_var = ShellVariable::new(ShellValue::Dynamic {
+        getter: get_srandom_value,
+        setter: |_| (),
+    });
+    random_var.treat_as_integer();
+    shell.env.set_global("SRANDOM", random_var)?;
+
+    // PS1 / PS2
+    if shell.options.interactive {
+        if !shell.env.is_set("PS1") {
+            shell
+                .env
+                .set_global("PS1", ShellVariable::new(r"\s-\v\$ "))?;
+        }
+
+        if !shell.env.is_set("PS2") {
+            shell.env.set_global("PS2", ShellVariable::new("> "))?;
+        }
+    }
+
+    // PS4
+    if !shell.env.is_set("PS4") {
+        shell.env.set_global("PS4", ShellVariable::new("+ "))?;
+    }
+
+    //
+    // PWD
+    //
+    // Reflect our actual working directory. There's a chance
+    // we inherited an out-of-sync version of the variable. Future updates
+    // will be handled by set_working_dir().
+    //
+    let pwd = shell.working_dir().to_string_lossy().to_string();
+    let mut pwd_var = ShellVariable::new(pwd);
+    pwd_var.export();
+    shell.env.set_global("PWD", pwd_var)?;
+
+    // UID
+    #[cfg(unix)]
+    {
+        let mut uid_var =
+            ShellVariable::new(ShellValue::String(format!("{}", uzers::get_current_uid())));
+        uid_var.treat_as_integer().set_readonly();
+        shell.env.set_global("UID", uid_var)?;
+    }
+
+    Ok(())
+}
+
+/// Returns a list of the current user's group IDs, with the effective GID at the front.
+fn get_current_user_gids() -> Vec<u32> {
+    let mut groups = sys::users::get_user_group_ids().unwrap_or_default();
+
+    // If the effective GID is present but not in the first position in the list, then move
+    // it there.
+    if let Ok(gid) = sys::users::get_effective_gid() {
+        if let Some(index) = groups.iter().position(|&g| g == gid) {
+            if index > 0 {
+                // Move it to the front.
+                groups.remove(index);
+                groups.insert(0, gid);
+            }
+        }
+    }
+
+    groups
+}
+
+fn get_random_value(_shell: &Shell) -> ShellValue {
+    let mut rng = rand::rng();
+    let num = rng.random_range(0..32768);
+    let str = num.to_string();
+    str.into()
+}
+
+fn get_srandom_value(_shell: &Shell) -> ShellValue {
+    let mut rng = rand::rng();
+    let num: u32 = rng.random();
+    let str = num.to_string();
+    str.into()
+}
+
+fn get_funcname_value(shell: &Shell) -> variables::ShellValue {
+    if shell.function_call_stack().is_empty() {
+        ShellValue::Unset(variables::ShellValueUnsetType::IndexedArray)
+    } else {
+        shell
+            .function_call_stack()
+            .iter()
+            .map(|s| s.function_name.as_str())
+            .collect::<Vec<_>>()
+            .into()
+    }
+}
+
+fn get_bash_source_value(shell: &Shell) -> variables::ShellValue {
+    if shell.function_call_stack().is_empty() {
+        shell
+            .script_call_stack()
+            .front()
+            .map_or_else(Vec::new, |(_call_type, s)| vec![s.as_ref()])
+            .into()
+    } else {
+        shell
+            .function_call_stack()
+            .iter()
+            .map(|s| s.function_definition.source.as_ref())
+            .collect::<Vec<_>>()
+            .into()
+    }
+}

--- a/brush-interactive/src/completion.rs
+++ b/brush-interactive/src/completion.rs
@@ -10,10 +10,10 @@ pub(crate) async fn complete_async(
     line: &str,
     pos: usize,
 ) -> brush_core::completion::Completions {
-    let working_dir = shell.working_dir.clone();
+    let working_dir = shell.working_dir().to_path_buf();
 
     // Intentionally ignore any errors that arise.
-    let completion_future = shell.get_completions(line, pos);
+    let completion_future = shell.complete(line, pos);
     tokio::pin!(completion_future);
 
     // Wait for the completions to come back or interruption, whichever happens first.

--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -305,9 +305,9 @@ impl<'a> StyledInputLine<'a> {
             return CommandType::Keyword;
         } else if self.shell.aliases.contains_key(name) {
             return CommandType::Alias;
-        } else if self.shell.funcs.get(name).is_some() {
+        } else if self.shell.funcs().get(name).is_some() {
             return CommandType::Function;
-        } else if self.shell.builtins.contains_key(name) {
+        } else if self.shell.builtins().contains_key(name) {
             return CommandType::Builtin;
         }
 
@@ -321,7 +321,7 @@ impl<'a> StyledInputLine<'a> {
 
         if name.contains(std::path::MAIN_SEPARATOR) {
             // TODO: Should check for executable-ness.
-            let candidate_path = self.shell.get_absolute_path(std::path::Path::new(name));
+            let candidate_path = self.shell.absolute_path(std::path::Path::new(name));
             if candidate_path.exists() {
                 CommandType::External
             } else {

--- a/brush-shell/benches/shell.rs
+++ b/brush-shell/benches/shell.rs
@@ -112,7 +112,7 @@ mod unix {
 
         // Benchmark: function invocation.
         let mut shell = rt.block_on(instantiate_shell());
-        shell.funcs.update(
+        shell.define_func(
             String::from("testfunc"),
             brush_parser::ast::FunctionDefinition {
                 fname: String::from("testfunc"),
@@ -125,8 +125,7 @@ mod unix {
                     None,
                 ),
                 source: String::from("/some/path"),
-            }
-            .into(),
+            },
         );
         c.bench_function("function_call", |b| {
             b.iter_batched_ref(

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -68,7 +68,7 @@ impl TestShellWithBashCompletion {
     }
 
     pub async fn complete(&mut self, line: &str, pos: usize) -> Result<Vec<String>> {
-        let completions = self.shell.get_completions(line, pos).await?;
+        let completions = self.shell.complete(line, pos).await?;
         Ok(completions.candidates.into_iter().collect())
     }
 

--- a/scripts/enum-lib-crates.sh
+++ b/scripts/enum-lib-crates.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+cargo metadata --no-deps --format-version 1 | jq -r '
+  .workspace_members as $members
+  | .packages[]
+  | select(.id as $id | $members | index($id))
+  | select(any(.targets[]?; any(.kind[]?; . == "lib")))
+  | .name
+'

--- a/scripts/format-api-diff-report.py
+++ b/scripts/format-api-diff-report.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description='Format API diff report')
+parser.add_argument("-p", dest="crate_name", type=str, help="Name of the crate", required=True)
+parser.add_argument("diff_path", type=str, help="Path to API diff file from cargo-public-api")
+
+args = parser.parse_args()
+
+with open(args.diff_path, "r") as diff_file:
+    diff_lines = diff_file.readlines()
+
+removed_lines = []
+added_lines = []
+changed_lines = []
+
+current_section = None
+
+for line in diff_lines:
+    line = line.strip()
+
+    if "Removed items" in line:
+        current_section = removed_lines
+    elif "Added items" in line:
+        current_section = added_lines
+    elif "Changed items" in line:
+        current_section = changed_lines
+    elif "============" in line:
+        continue
+    elif line == "(none)":
+        continue
+    elif not line:
+        continue
+    elif current_section is not None:
+        current_section.append(line)
+
+if not removed_lines and not added_lines and not changed_lines:
+    sys.stderr.write("note: no API changes detected\n")
+    sys.exit(0)
+
+print(f"# Public API changes for crate: {args.crate_name}")
+
+if removed_lines:
+    print()
+    print("## Removed items")
+
+    print("```")
+    for line in removed_lines:
+        print(line)
+    print("```")
+
+if added_lines:
+    print()
+    print("## Added items")
+
+    print("```")
+    for line in added_lines:
+        print(line)
+    print("```")
+
+if changed_lines:
+    print()
+    print("## Changed items")
+
+    print("```")
+    for line in changed_lines:
+        print(line)
+    print("```")


### PR DESCRIPTION
This PR takes a pass over the `Shell` type:

* Makes more fields private, adding accessors when needed.
* Drops `get_` prefix from most getter names.
* Consolidates more file-open operations through `Shell::open_file()` for future extension.