### PR TITLE
refactor: os_pipe::pipe() -> std::io::pipe()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,6 @@ dependencies = [
  "itertools 0.14.0",
  "nix 0.30.1",
  "normalize-path",
- "os_pipe",
  "procfs 0.18.0",
  "rand 0.9.2",
  "rpds",
@@ -2038,16 +2037,6 @@ dependencies = [
  "plist",
  "serde",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "os_pipe"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -42,7 +42,6 @@ tokio = { version = "1.47.1", features = ["io-util", "macros", "rt"] }
 
 [target.'cfg(any(windows, unix))'.dependencies]
 hostname = "0.4.1"
-os_pipe = { version = "1.2.2", features = ["io_safety"] }
 tokio = { version = "1.47.1", features = [
     "io-util",
     "macros",

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -686,7 +686,7 @@ pub(crate) async fn invoke_command_in_subshell_and_get_output(
     params.process_group_policy = ProcessGroupPolicy::SameProcessGroup;
 
     // Set up pipe so we can read the output.
-    let (reader, writer) = openfiles::pipe()?;
+    let (reader, writer) = std::io::pipe()?;
     params.open_files.set(OpenFiles::STDOUT_FD, writer.into());
 
     // Run the command. Pass ownership of the subshell and params to
@@ -699,7 +699,7 @@ pub(crate) async fn invoke_command_in_subshell_and_get_output(
     *shell.last_exit_status_mut() = result.exit_code;
 
     // Extract output.
-    let output_str = std::io::read_to_string(OpenFile::from(reader))?;
+    let output_str = std::io::read_to_string(reader)?;
 
     Ok(output_str)
 }

--- a/brush-core/src/sys.rs
+++ b/brush-core/src/sys.rs
@@ -23,15 +23,12 @@ pub(crate) mod stubs;
 #[cfg(any(unix, windows))]
 pub(crate) mod hostname;
 #[cfg(any(unix, windows))]
-pub(crate) mod os_pipe;
-#[cfg(any(unix, windows))]
 pub mod tokio_process;
 
 pub mod fs;
 
 pub use platform::input;
 pub(crate) use platform::network;
-pub(crate) use platform::pipes;
 pub use platform::process;
 pub use platform::resource;
 pub use platform::signal;

--- a/brush-core/src/sys/os_pipe.rs
+++ b/brush-core/src/sys/os_pipe.rs
@@ -1,1 +1,0 @@
-pub(crate) use os_pipe::{PipeReader, PipeWriter, pipe};

--- a/brush-core/src/sys/unix.rs
+++ b/brush-core/src/sys/unix.rs
@@ -1,4 +1,3 @@
-pub(crate) use crate::sys::os_pipe as pipes;
 pub mod fs;
 pub mod input;
 pub(crate) mod network;

--- a/brush-core/src/sys/windows.rs
+++ b/brush-core/src/sys/windows.rs
@@ -1,4 +1,3 @@
-pub(crate) use crate::sys::os_pipe as pipes;
 pub use crate::sys::stubs::fs;
 pub use crate::sys::stubs::input;
 pub(crate) mod network;


### PR DESCRIPTION
Now that we can use `std::os::pipe()`, we can remove the dependency on the `os_pipe` crate and remove some of our `sys` module platform abstractions around it.