### PR TITLE
fix: tokenizer handling of here docs in quoted command substitutions

### DIFF
--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r#\"echo \"$(cat <<HERE\nTEXT\nHERE\n)\"\"#)?"
+---
+TokenizerResult(
+  input: "echo \"$(cat <<HERE\nTEXT\nHERE\n)\"",
+  result: [
+    W("echo", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("\"$(cat <<HERE\nTEXT\nHERE\n)\"", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 31,
+        line: 4,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution_with_space.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution_with_space.snap
@@ -1,0 +1,33 @@
+---
+source: brush-parser/src/tokenizer.rs
+expression: "test_tokenizer(r#\"echo \"$(cat << HERE\nTEXT\nHERE\n)\"\"#)?"
+---
+TokenizerResult(
+  input: "echo \"$(cat << HERE\nTEXT\nHERE\n)\"",
+  result: [
+    W("echo", Loc(
+      start: Pos(
+        idx: 0,
+        line: 1,
+        col: 1,
+      ),
+      end: Pos(
+        idx: 4,
+        line: 1,
+        col: 5,
+      ),
+    )),
+    W("\"$(cat << HERE\nTEXT\nHERE\n)\"", Loc(
+      start: Pos(
+        idx: 5,
+        line: 1,
+        col: 6,
+      ),
+      end: Pos(
+        idx: 32,
+        line: 4,
+        col: 3,
+      ),
+    )),
+  ],
+)

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -384,7 +384,7 @@ impl TokenParseState {
                 cross_token_state.here_state = HereState::NextLineIsHereDoc;
 
                 // Include the trailing \n in the here tag so it's easier to check against.
-                let tag = std::format!("{}\n", self.current_token());
+                let tag = std::format!("{}\n", self.current_token().trim_ascii_start());
                 let tag_was_escaped_or_quoted = tag.contains(is_quoting_char);
 
                 let tag_token_result = TokenizeResult {
@@ -1492,6 +1492,28 @@ SOMETHING
 TEXT
 HERE
 )"
+        )?);
+        Ok(())
+    }
+
+    #[test]
+    fn tokenize_here_doc_in_double_quoted_command_substitution() -> Result<()> {
+        assert_ron_snapshot!(test_tokenizer(
+            r#"echo "$(cat <<HERE
+TEXT
+HERE
+)""#
+        )?);
+        Ok(())
+    }
+
+    #[test]
+    fn tokenize_here_doc_in_double_quoted_command_substitution_with_space() -> Result<()> {
+        assert_ron_snapshot!(test_tokenizer(
+            r#"echo "$(cat << HERE
+TEXT
+HERE
+)""#
         )?);
         Ok(())
     }

--- a/brush-shell/tests/cases/here.yaml
+++ b/brush-shell/tests/cases/here.yaml
@@ -95,6 +95,24 @@ cases:
 
       echo "${test1}"
 
+  - name: "Here doc in a double-quoted command substitution"
+    stdin: |
+      test1="$(cat <<EOF
+      something
+      EOF
+      )"
+
+      echo "${test1}"
+
+  - name: "Here doc in a double-quoted command substitution with spaces"
+    stdin: |
+      test1="$(cat << EOF
+      something
+      EOF
+      )"
+
+      echo "${test1}"
+
   - name: "Here doc in a command substitution with quotes"
     known_failure: true # Issue #421
     stdin: |


### PR DESCRIPTION
Adds test cases and a targeted fix to handle issues tokenizing something like:

```bash
var="$(cat << EOF
something
EOF
)"
```