### PR TITLE
fix: comment unsafe blocks + better harden 1 block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ panic_in_result_fn = "deny"
 string_slice = "deny"
 todo = "deny"
 unwrap_in_result = "deny"
+undocumented_unsafe_blocks = "deny"
 
 # Allowed rules
 bool_to_int_with_if = "allow"

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -431,6 +431,10 @@ pub(crate) fn execute_external_command(
     // the target command.
     #[cfg(unix)]
     if new_pg && child_stdin_is_terminal {
+        // SAFETY:
+        // This arranges for a provided function to run in the context of
+        // the forked process before it exec's the target command. In general,
+        // rust can't guarantee safety of code running in such a context.
         unsafe {
             cmd.pre_exec(setup_process_before_exec);
         }


### PR DESCRIPTION
* Enables clippy rule that requires `unsafe` code blocks be annotated with `SAFETY:` comments.
* Adds missing `SAFETY` comments.
* Adds additional hardening check to the `confstr` wrapper (found in code review).