### PR TITLE
ci: update cd workflow runners

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -55,7 +55,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
           # - target: x86_64-pc-windows-msvc
           #   os: windows-2022
           - target: x86_64-unknown-linux-musl
@@ -65,7 +65,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-14
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
Move away from macOS runners being [being retired](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).