### PR TITLE
docs: add fzf demo tape

### DIFF
--- a/docs/demos/fzf.tape
+++ b/docs/demos/fzf.tape
@@ -1,0 +1,60 @@
+# Works with https://github.com/charmbracelet/vhs
+# This tape assumes that fzf and brush are already pre-installed and ready to go.
+
+Output sample.gif
+
+# Set FontFamily "CaskaydiaMono Nerd Font Mono"
+Set FontSize 20
+Set Theme "Monokai Pro"
+Set Width 1600
+Set Height 600
+Set CursorBlink false
+
+# Setup environment to launch brush in
+Env HISTFILE ""
+Env PS1 '$0$ '
+
+# Launch brush and set up bash-completion
+Hide
+Type `brush --enable-highlighting --norc --noprofile`
+Enter
+Show
+
+# Enable fzf
+Type `# Let's enable fzf with standard bash mode`
+Sleep 0.8s
+Enter
+Type `eval "$(fzf --bash)"`
+Sleep 0.8s
+Enter
+Sleep 1s
+
+Enter
+Enter
+
+Type `# ^^^ we see an error above. Some key combos are missing but more are functional.`
+Enter
+
+Enter
+Enter
+
+# Type some things.
+Type `echo 'We will type something'`
+Enter
+Type `echo '...just to populate history'`
+Enter
+Type `echo 'And now, hit Ctrl+R.'`
+Enter
+Sleep 1s
+
+# Ctrl+R
+Ctrl+R
+Sleep 1.5s
+Up
+Sleep 0.8s
+Enter
+
+Sleep 2s
+Enter
+Sleep 2s
+

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -5,3 +5,4 @@
 * [How to run benchmarks](run-benchmarks.md)
 * [How to release](release.md)
 * [How to upgrade the MSRV](upgrade-msrv.md)
+* [How to record "tapes"](record-tapes.md)

--- a/docs/how-to/record-tapes.md
+++ b/docs/how-to/record-tapes.md
@@ -1,0 +1,16 @@
+# How to record "tapes"
+
+Under the `docs/demos` directory of this repo, we have some `.tape` files checked in.
+These are interactive scripts for recording screencast-style demos of `brush` using
+the [`VHS` tool](https://github.com/charmbracelet/vhs).
+
+## Install `vhs`
+
+You first need to install `vhs`. For consistency, we've found it easiest to install
+`golang` and then follow the instructions on the `vhs` github page to install via
+`go install`. (Also note that there are some native prerequisites required.)
+
+## Run `vhs`
+
+To run `vhs` against the `.tape` file you may need to use `VHS_NO_SANDBOX=1`. For more
+details see [this issue on GitHub](https://github.com/charmbracelet/vhs/issues/504).


### PR DESCRIPTION
Adding the `.tape` I authored while working on fixing issues for `fzf`. While I was at it, I also added some *extremely minimal* notes on how to record a tape using `vhs`.

If and when I have time I'll go back and sort out proper automation for it that takes care of preinstalling fonts, arranging to preinstall tools, etc.