### PR TITLE
feat: implement alternate arithmetic for syntax

### DIFF
--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -413,13 +413,16 @@ peg::parser! {
                 condition:arithmetic_expression()? specific_operator(";")
                 updater:arithmetic_expression()?
             specific_operator(")") specific_operator(")")
-            sequential_sep()
-            body:do_group() {
+            body:arithmetic_for_body() {
                 let start = s.location();
                 let end = &body.loc;
                 let loc = TokenLocation::within(start, end);
                 ast::ArithmeticForClauseCommand { initializer, condition, updater, body, loc }
             }
+
+        rule arithmetic_for_body() -> ast::DoGroupCommand =
+            sequential_sep() body:do_group() { body } /
+            body:brace_group() { ast::DoGroupCommand { list: body.list, loc: body.loc } }
 
         rule extended_test_command() -> ast::ExtendedTestExprCommand =
             s:specific_word("[[") linebreak() expr:extended_test_expression() linebreak() e:specific_word("]]") {

--- a/brush-shell/tests/cases/compound_cmds/arithmetic_for.yaml
+++ b/brush-shell/tests/cases/compound_cmds/arithmetic_for.yaml
@@ -66,3 +66,10 @@ cases:
         fi
       done
       echo "After for"
+
+  - name: "Arithmetic for with alternate syntax"
+    stdin: |
+      for ((i = 0; i < 5; i++)) {
+        echo "Iteration $i"
+      }
+


### PR DESCRIPTION
_This is for one of the parts of #743._

It's an (undocumented?) alternate form of arithmetic-for, where you can do something like:

```bash
for ((i = 0; i < 10; i++)) {
    echo $i
}
```

...without the usual `; do` and `done`.