### PR TITLE
fix(builtins): suppress error when type -p sees no command

### DIFF
--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -56,7 +56,7 @@ impl builtins::Command for TypeCommand {
             let resolved_types = self.resolve_types(context.shell, name);
 
             if resolved_types.is_empty() {
-                if !self.type_only && !self.force_path_search {
+                if !self.type_only && !self.force_path_search && !self.show_path_only {
                     writeln!(context.stderr(), "type: {name} not found")?;
                 }
 

--- a/brush-shell/tests/cases/builtins/type.yaml
+++ b/brush-shell/tests/cases/builtins/type.yaml
@@ -16,9 +16,13 @@ cases:
   - name: "Test type with -t option and an external command"
     stdin: type -t ls
 
-  - name: "Test type with -t option and an undefined command"
+  - name: "Test type with -t option and non-existent command"
     ignore_stderr: true
-    stdin: type -t undefined_command
+    stdin: type -t non-existent
+
+  - name: "Test type with -a option and non-existent command"
+    ignore_stderr: true
+    stdin: type -a non-existent
 
   - name: "Test type with -a option and a command with multiple definitions"
     stdin: type -a true
@@ -29,11 +33,17 @@ cases:
   - name: Test type with -p option and an external command
     stdin: type -p ls
 
+  - name: Test type with -p option and non-existent command
+    stdin: type -p non-existent
+
   - name: Test type with -P option and a builtin command
     stdin: type -P cd
 
   - name: Test type with -P option and an external command
     stdin: type -P ls
+
+  - name: Test type with -P option and non-existent command
+    stdin: type -P non-existent
 
   - name: Test type with -f option and a function
     ignore_stderr: true


### PR DESCRIPTION
_While not described in #743, it's the *next* issue that `neofetch` seems to run into after getting the fix in #744._

Addresses inconsistency in whether `type -p` should emit anything to `stdout` or `stderr` when it can't find the specified command.