### PR TITLE
feat: basic support for trap EXIT

### DIFF
--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -261,7 +261,7 @@ async fn invoke_debug_trap_handler_if_registered(
             let _ = context
                 .shell
                 .run_string(debug_trap_handler, &handler_params)
-                .await?;
+                .await;
 
             context.shell.traps.handler_depth -= 1;
         }

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -121,6 +121,9 @@ pub trait InteractiveShell: Send {
                 tracing::debug!("couldn't save history: {e}");
             }
 
+            // Give the shell an opportunity to perform any on-exit operations.
+            self.shell_mut().as_mut().on_exit().await?;
+
             Ok(())
         }
     }

--- a/brush-shell/tests/cases/builtins/trap.yaml
+++ b/brush-shell/tests/cases/builtins/trap.yaml
@@ -25,15 +25,24 @@ cases:
       trap -p INT
 
   - name: "trap EXIT"
-    known_failure: true # TODO: needs triage and debugging
     stdin: |
-      trap "echo [exit]" EXIT
+      trap 'echo "[exit]"' EXIT
       trap -p EXIT
+
+  - name: "trap EXIT: status code handling"
+    stdin: |
+      trap 'echo "[exit]: \$?: $?"' EXIT
+      trap -p EXIT
+      false
 
   - name: "trap DEBUG"
     stdin: |
       trap 'echo [command: ${BASH_COMMAND}]' DEBUG
       trap -p DEBUG
+
+      echo First
+      echo Second
+      false
 
   - name: "trap ERR"
     stdin: |


### PR DESCRIPTION
Adds just enough support for basic `trap EXIT` handlers to get invoked.

_The save/restore of last exit status isn't ideal, but gets the test to pass for now. We should consider coming back and looking more seriously at whether there's a more general pattern there._