### PR TITLE
fix: correct handling of expansion in parameter exprs with replacements

### DIFF
--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -347,6 +347,8 @@ cases:
       echo ${value:+'x'}
       echo "${value:+\x}"
       echo "${value:+'x'}"
+      echo "${value:+x y}"
+      echo "${value:+z 'x' 'y' w}"
       echo "${value:+x'y'x}"
       echo "${value:+"x y"}"
       echo "${value:+"x\xy"}"


### PR DESCRIPTION
This specifically tackles cases like `"${var:+'x'}"`.

Typically, expansion will quote-remove, so `'x'` will expand to `x`, but in these cases there is specific language indicating that, when this sort of parameter expression is in double quotes, these quotes should be _preserved_.

_It's not the most pleasant logic, but it's the most surgical update I can identify that stands up to the tests we've generated so far._