### PR TITLE
fix: correct expansion behavior in prompts

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1067,11 +1067,8 @@ impl Shell {
         }
 
         // Expand it.
-        let formatted_prompt = prompt::expand_prompt(self, prompt_spec.into_owned())?;
-
-        // Now expand.
         let params = self.default_exec_params();
-        expansion::basic_expand_str(self, &params, &formatted_prompt).await
+        prompt::expand_prompt(self, &params, prompt_spec.into_owned()).await
     }
 
     fn parameter_or_default<'a>(&'a self, name: &str, default: &'a str) -> Cow<'a, str> {

--- a/brush-shell/tests/cases/prompt.yaml
+++ b/brush-shell/tests/cases/prompt.yaml
@@ -11,6 +11,9 @@ cases:
       prompt='\\'
       echo "Prompt: '${prompt@P}'"
 
+      prompt='\?'
+      echo "Prompt: '${prompt@P}'"
+
       prompt='\81'
       echo "Prompt: '${prompt@P}'"
 
@@ -113,8 +116,32 @@ cases:
       expanded=${prompt@P}
       echo "${expanded}"
 
+  - name: "Escaped dollar-sign"
+    stdin: |
+      prompt='\$'
+      echo "Prompt: '${prompt@P}'"
+
+  - name: "Var in prompt"
+    stdin: |
+      var=value
+
+      prompt="\$var"
+
+      shopt -s promptvars
+      echo "Prompt (dollar-sign not escaped, with promptvars): ${prompt@P}"
+
+      shopt -u promptvars
+      echo "Prompt (dollar-sign not escaped, without promptvars): ${prompt@P}"
+
+      prompt="\\\$var"
+
+      shopt -s promptvars
+      echo "Prompt (dollar-sign escaped, with promptvars): ${prompt@P}"
+
+      shopt -u promptvars
+      echo "Prompt (dollar-sign escaped, without promptvars): ${prompt@P}"
+
   - name: "Command substitution in prompt"
-    known_failure: true # @P expansion doesn't word-expand after prompt expanding
     stdin: |
       prompt='$(echo Hello)'
       echo "Without spaces: ${prompt@P}"
@@ -123,10 +150,19 @@ cases:
       echo "With spaces: ${prompt@P}"
 
   - name: "Backquoted command substitution in prompt"
-    known_failure: true # @P expansion doesn't word-expand after prompt expanding
     stdin: |
       prompt='`echo Hello`'
       echo "Without spaces: ${prompt@P}"
 
       prompt=' `echo Hello` '
       echo "With spaces: ${prompt@P}"
+
+  - name: "Parameter expansion with non-printing chars"
+    stdin: |
+      var=value
+      prompt="\${var:+\[text\]}"
+      echo "Conditional (set): '${prompt@P}'"
+
+      var=
+      prompt="\${var:+\[text\]}"
+      echo "Conditional (unset): '${prompt@P}'"


### PR DESCRIPTION
Resolves issues with complex prompt strings, such as those used by Fedora's `bash-color-prompt.sh` script.