### PR TITLE
fix: escaping and pipeline parse issues

### DIFF
--- a/brush-shell/tests/cases/pipeline.yaml
+++ b/brush-shell/tests/cases/pipeline.yaml
@@ -15,6 +15,13 @@ cases:
       ! true
       echo "! true: $?"
 
+  - name: "Standalone negation (no command)"
+    stdin: |
+      !
+      echo "After !: $?"
+      ! !
+      echo "After ! !: $?"
+
   - name: "Exit codes for piped commands"
     test_files:
       - path: "script.sh"

--- a/brush-shell/tests/cases/word_expansion.yaml
+++ b/brush-shell/tests/cases/word_expansion.yaml
@@ -33,6 +33,12 @@ cases:
     stdin: |
       echo "\""
 
+  - name: "Double quotes: escaping"
+    stdin: |
+      echo "\'"
+      echo "\x"
+      echo "\n"
+
   - name: "ANSI-C quotes"
     stdin: |
       single_quoted='\n'
@@ -48,6 +54,15 @@ cases:
       ansi_c_quoted=$'\''
       echo "ANSI-C quoted single quote len: ${#ansi_c_quoted}"
       echo -n $'\'' | hexdump -C
+
+  - name: "ANSI-C quote syntax inside double quotes (literal, not processed)"
+    stdin: |
+      # When $'...' appears inside double quotes, it should be treated as literal text
+      echo "$'\t'"
+      echo "$'\'abcd\''"
+      x="$'\n'"
+      echo "len: ${#x}"
+      echo "$x"
 
   - name: "gettext style quotes"
     stdin: |


### PR DESCRIPTION
Fixes 3 compat issues:

* Handling of `\'` inside double quotes
* Pipelines with empty `!` and with multiple `!`s
* Parsing of an ANSI-C quoted string showing up in double quotes (e.g., `"$'x'"`)