### PR TITLE
fix: expose -c flag via $-

### DIFF
--- a/brush-core/src/namedoptions.rs
+++ b/brush-core/src/namedoptions.rs
@@ -125,6 +125,13 @@ static SET_OPTIONS: LazyLock<HashMap<&'static str, ShellOptionDef>> = LazyLock::
             ),
         ),
         (
+            "c",
+            ShellOptionDef::new(
+                |options| options.command_string_mode,
+                |options, value| options.command_string_mode = value,
+            ),
+        ),
+        (
             "e",
             ShellOptionDef::new(
                 |options| options.exit_on_nonzero_command_exit,

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -324,6 +324,9 @@ pub struct CreateOptions {
     /// Whether to print verbose output.
     #[builder(default)]
     pub verbose: bool,
+    /// Whether the shell is in command string mode (-c).
+    #[builder(default)]
+    pub command_string_mode: bool,
     /// Maximum function call depth.
     pub max_function_call_depth: Option<usize>,
     /// Key bindings helper for the shell to use.

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -272,8 +272,6 @@ async fn instantiate_shell(
     let read_commands_from_stdin = (args.read_commands_from_stdin && args.command.is_none())
         || (args.script_args.is_empty() && args.command.is_none());
 
-    let interactive = args.is_interactive();
-
     let builtins = brush_builtins::default_builtins(if args.sh_mode {
         brush_builtins::BuiltinSet::ShMode
     } else {
@@ -298,7 +296,8 @@ async fn instantiate_shell(
             do_not_execute_commands: args.do_not_execute_commands,
             exit_after_one_command: args.exit_after_one_command,
             login: args.login || argv0.as_ref().is_some_and(|a0| a0.starts_with('-')),
-            interactive,
+            interactive: args.is_interactive(),
+            command_string_mode: args.command.is_some(),
             no_editing: args.no_editing,
             no_profile: args.no_profile,
             no_rc: args.no_rc,

--- a/brush-shell/tests/cases/options/default.yaml
+++ b/brush-shell/tests/cases/options/default.yaml
@@ -3,3 +3,6 @@ cases:
   - name: "Default options"
     stdin: |
       echo "Default options: $-"
+
+  - name: "Default options (-c)"
+    args: ["-c", 'echo "Default options: $-"']


### PR DESCRIPTION
While not required by the POSIX spec, we match bash's behavior in exposing `-c` flag in `$-`.