### PR TITLE
chore: ack unmaintained crate error

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,7 +24,9 @@ version = 2
 yanked = "deny"
 #db-path = "$CARGO_HOME/advisory-dbs"
 #db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = []
+ignore = [
+    "RUSTSEC-2025-0119", # number_prefix not maintained (replacement will come with next update of uucore)
+]
 #git-fetch-with-cli = true
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
`number_prefix` is now marked as unmaintained and flagging RUSTSEC errors via `cargo deny`. Our dependency on this crate is coming through `uucore`.

Thankfully, the `uucore` folks are on top of this! They've already merged https://github.com/uutils/coreutils/pull/9322, which replaces use with a maintained crate. Until we can receive that change, we're acknowledging the issue and updating our `deny.toml` to ignore this specific advisory.

As soon as `uucore` distributes a new release with this change, Dependabot should flag us to update and we'll update to it and remove this temporary ignore.
