### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/brush-core/src/sys/stubs/terminal.rs
+++ b/brush-core/src/sys/stubs/terminal.rs
@@ -67,6 +67,6 @@ pub fn move_to_foreground(_pid: sys::process::ProcessId) -> Result<(), error::Er
 /// Moves the current process to the foreground of the attached terminal.
 ///
 /// This is a stub implementation that returns `None`.
-pub fn move_self_to_foreground() -> Result<(), error::Error> {
+pub fn move_self_to_foreground() -> Result<(), std::io::Error> {
     Ok(())
 }

--- a/brush-core/src/sys/unix/commands.rs
+++ b/brush-core/src/sys/unix/commands.rs
@@ -61,6 +61,6 @@ impl CommandFgControlExt for std::process::Command {
 fn setup_process_before_exec() -> Result<(), std::io::Error> {
     use crate::sys;
 
-    sys::terminal::move_self_to_foreground().map_err(std::io::Error::other)?;
+    sys::terminal::move_self_to_foreground()?;
     Ok(())
 }

--- a/brush-core/src/sys/unix/terminal.rs
+++ b/brush-core/src/sys/unix/terminal.rs
@@ -97,7 +97,8 @@ pub fn move_to_foreground(pid: sys::process::ProcessId) -> Result<(), error::Err
 }
 
 /// Moves the current process to the foreground of the attached terminal.
-pub fn move_self_to_foreground() -> Result<(), error::Error> {
+// This function needs to return `std::io::Error` so that the OS error code can be recovered.
+pub fn move_self_to_foreground() -> Result<(), std::io::Error> {
     if std::io::stdin().is_terminal() {
         let pgid = nix::unistd::getpgid(None)?;
 


### PR DESCRIPTION
`Error::other` allocates memory (see https://github.com/rust-lang/rust/pull/148971). This is bad in multi-threaded programs, which brush AFAIK is. If the fork occurs while the allocator lock is held by another thread, deadlocks can occur, since there's no one left in the new process to unlock the mutex. I do not believe this is UB, and modern libc offer protections against this issue, but this isn't POSIX-compliant and should preferably be avoided.

Luckily, `nix` provides a non-allocating `impl From<Errno> for std::io::Error`, and it passes the correct error code through to the parent process, instead of using the default `-EINVAL` like `Error::other`.

I'm not sure how to best integrate this into your project. I changed the return type of `move_self_to_foreground` to use `std::io::Error`, which works, but feels hacky. If you have a better idea, feel free to apply your own patch and close this PR.