### PR TITLE
refactor: rename TokenLocation -> SourceSpan

### DIFF
--- a/brush-builtins/src/complete.rs
+++ b/brush-builtins/src/complete.rs
@@ -511,7 +511,7 @@ impl builtins::Command for CompGenCommand {
             token_index: 0,
             tokens: &[&brush_parser::Token::Word(
                 token_to_complete.to_owned(),
-                brush_parser::TokenLocation::default(),
+                brush_parser::SourceSpan::default(),
             )],
             input_line: token_to_complete,
             cursor_index: token_to_complete.len(),

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -957,7 +957,7 @@ impl Config {
         // If the position is after the last token, then we need to insert an empty
         // token for the new token to be generated.
         let empty_token =
-            brush_parser::Token::Word(String::new(), brush_parser::TokenLocation::default());
+            brush_parser::Token::Word(String::new(), brush_parser::SourceSpan::default());
         if completion_token_index == tokens.len() {
             adjusted_tokens.push(&empty_token);
         }
@@ -1188,7 +1188,7 @@ fn simple_tokenize_by_delimiters(input: &str, delimiters: &[char]) -> Vec<brush_
         let end = start + piece.len();
         tokens.push(brush_parser::Token::Word(
             piece.to_string(),
-            brush_parser::TokenLocation {
+            brush_parser::SourceSpan {
                 start: brush_parser::SourcePosition {
                     index: start,
                     line: 1,

--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -267,7 +267,7 @@ impl<'a> StyledInputLine<'a> {
     fn get_style_for_word(
         &self,
         w: &str,
-        token_location: &brush_parser::TokenLocation,
+        token_location: &brush_parser::SourceSpan,
         saw_command_token: &mut bool,
     ) -> Style {
         if !*saw_command_token {
@@ -299,7 +299,7 @@ impl<'a> StyledInputLine<'a> {
     fn classify_possible_command(
         &self,
         name: &str,
-        token_location: &brush_parser::TokenLocation,
+        token_location: &brush_parser::SourceSpan,
     ) -> CommandType {
         if self.shell.is_keyword(name) {
             return CommandType::Keyword;

--- a/brush-parser/src/error.rs
+++ b/brush-parser/src/error.rs
@@ -18,7 +18,7 @@ pub enum ParseError {
         /// The inner error.
         inner: tokenizer::TokenizerError,
         /// Optionally provides the position of the error.
-        position: Option<tokenizer::SourcePosition>,
+        position: Option<crate::SourcePosition>,
     },
 }
 

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -10,6 +10,7 @@ pub mod word;
 
 mod error;
 mod parser;
+mod source;
 mod tokenizer;
 
 #[cfg(test)]
@@ -23,7 +24,8 @@ pub use error::{
 pub use error::miette::PrettyError;
 
 pub use parser::{Parser, ParserBuilder, ParserOptions, SourceInfo, parse_tokens};
+pub use source::{SourcePosition, SourceSpan};
 pub use tokenizer::{
-    SourcePosition, Token, TokenLocation, TokenizerError, TokenizerOptions, tokenize_str,
+    Token, TokenLocation, TokenizerError, TokenizerOptions, tokenize_str,
     tokenize_str_with_options, uncached_tokenize_str, unquote_str,
 };

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_arith_and_non_arith_parens.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_arith_and_non_arith_parens.snap
@@ -18,7 +18,7 @@ ParseResult(
                         Simple(SimpleCommand(
                           word_or_name: Some(Word(
                             value: ":",
-                            loc: Some(TokenLocation(
+                            loc: Some(SourceSpan(
                               start: SourcePosition(
                                 index: 2,
                                 line: 1,
@@ -46,7 +46,7 @@ ParseResult(
                                       expr: UnexpandedArithmeticExpr(
                                         value: "0",
                                       ),
-                                      loc: TokenLocation(
+                                      loc: SourceSpan(
                                         start: SourcePosition(
                                           index: 9,
                                           line: 1,
@@ -67,7 +67,7 @@ ParseResult(
                                       Simple(SimpleCommand(
                                         word_or_name: Some(Word(
                                           value: ":",
-                                          loc: Some(TokenLocation(
+                                          loc: Some(SourceSpan(
                                             start: SourcePosition(
                                               index: 20,
                                               line: 1,
@@ -86,7 +86,7 @@ ParseResult(
                                 ],
                               ), Sequence),
                             ]),
-                            loc: TokenLocation(
+                            loc: SourceSpan(
                               start: SourcePosition(
                                 index: 7,
                                 line: 1,
@@ -104,7 +104,7 @@ ParseResult(
                     ],
                   ), Sequence),
                 ]),
-                loc: TokenLocation(
+                loc: SourceSpan(
                   start: SourcePosition(
                     index: 0,
                     line: 1,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case.snap
@@ -7,7 +7,7 @@ ParseResult(
   result: CaseClauseCommand(
     value: Word(
       value: "x",
-      loc: Some(TokenLocation(
+      loc: Some(SourceSpan(
         start: SourcePosition(
           index: 7,
           line: 2,
@@ -25,7 +25,7 @@ ParseResult(
         patterns: [
           Word(
             value: "x",
-            loc: Some(TokenLocation(
+            loc: Some(SourceSpan(
               start: SourcePosition(
                 index: 12,
                 line: 3,
@@ -46,7 +46,7 @@ ParseResult(
                 Simple(SimpleCommand(
                   word_or_name: Some(Word(
                     value: "echo",
-                    loc: Some(TokenLocation(
+                    loc: Some(SourceSpan(
                       start: SourcePosition(
                         index: 19,
                         line: 4,
@@ -62,7 +62,7 @@ ParseResult(
                   suffix: Some(CommandSuffix([
                     Word(Word(
                       value: "y",
-                      loc: Some(TokenLocation(
+                      loc: Some(SourceSpan(
                         start: SourcePosition(
                           index: 24,
                           line: 4,
@@ -82,7 +82,7 @@ ParseResult(
           ), Sequence),
         ])),
         post_action: ExitCase,
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 12,
             line: 3,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case_ns.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_case_ns.snap
@@ -7,7 +7,7 @@ ParseResult(
   result: CaseClauseCommand(
     value: Word(
       value: "x",
-      loc: Some(TokenLocation(
+      loc: Some(SourceSpan(
         start: SourcePosition(
           index: 7,
           line: 2,
@@ -25,7 +25,7 @@ ParseResult(
         patterns: [
           Word(
             value: "x",
-            loc: Some(TokenLocation(
+            loc: Some(SourceSpan(
               start: SourcePosition(
                 index: 12,
                 line: 3,
@@ -46,7 +46,7 @@ ParseResult(
                 Simple(SimpleCommand(
                   word_or_name: Some(Word(
                     value: "echo",
-                    loc: Some(TokenLocation(
+                    loc: Some(SourceSpan(
                       start: SourcePosition(
                         index: 19,
                         line: 4,
@@ -62,7 +62,7 @@ ParseResult(
                   suffix: Some(CommandSuffix([
                     Word(Word(
                       value: "y",
-                      loc: Some(TokenLocation(
+                      loc: Some(SourceSpan(
                         start: SourcePosition(
                           index: 24,
                           line: 4,
@@ -82,7 +82,7 @@ ParseResult(
           ), Sequence),
         ])),
         post_action: ExitCase,
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 12,
             line: 3,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection-2.snap
@@ -8,7 +8,7 @@ ParseResult(
     Function(FunctionDefinition(
       fname: Word(
         value: "foo",
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 0,
             line: 1,
@@ -29,7 +29,7 @@ ParseResult(
                 Simple(SimpleCommand(
                   word_or_name: Some(Word(
                     value: "echo",
-                    loc: Some(TokenLocation(
+                    loc: Some(SourceSpan(
                       start: SourcePosition(
                         index: 8,
                         line: 1,
@@ -45,7 +45,7 @@ ParseResult(
                   suffix: Some(CommandSuffix([
                     Word(Word(
                       value: "1",
-                      loc: Some(TokenLocation(
+                      loc: Some(SourceSpan(
                         start: SourcePosition(
                           index: 13,
                           line: 1,
@@ -64,7 +64,7 @@ ParseResult(
             ),
           ), Sequence),
         ]),
-        loc: TokenLocation(
+        loc: SourceSpan(
           start: SourcePosition(
             index: 6,
             line: 1,
@@ -84,7 +84,7 @@ ParseResult(
     Simple(SimpleCommand(
       word_or_name: Some(Word(
         value: "cat",
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 21,
             line: 1,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_function_with_pipe_redirection.snap
@@ -8,7 +8,7 @@ ParseResult(
     Function(FunctionDefinition(
       fname: Word(
         value: "foo",
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 0,
             line: 1,
@@ -29,7 +29,7 @@ ParseResult(
                 Simple(SimpleCommand(
                   word_or_name: Some(Word(
                     value: "echo",
-                    loc: Some(TokenLocation(
+                    loc: Some(SourceSpan(
                       start: SourcePosition(
                         index: 8,
                         line: 1,
@@ -45,7 +45,7 @@ ParseResult(
                   suffix: Some(CommandSuffix([
                     Word(Word(
                       value: "1",
-                      loc: Some(TokenLocation(
+                      loc: Some(SourceSpan(
                         start: SourcePosition(
                           index: 13,
                           line: 1,
@@ -64,7 +64,7 @@ ParseResult(
             ),
           ), Sequence),
         ]),
-        loc: TokenLocation(
+        loc: SourceSpan(
           start: SourcePosition(
             index: 6,
             line: 1,
@@ -79,7 +79,7 @@ ParseResult(
       )), Some(RedirectList([
         File(Some(2), DuplicateOutput, Duplicate(Word(
           value: "1",
-          loc: Some(TokenLocation(
+          loc: Some(SourceSpan(
             start: SourcePosition(
               index: 21,
               line: 1,
@@ -98,7 +98,7 @@ ParseResult(
     Simple(SimpleCommand(
       word_or_name: Some(Word(
         value: "cat",
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 25,
             line: 1,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_here_doc_with_no_trailing_newline.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_here_doc_with_no_trailing_newline.snap
@@ -13,7 +13,7 @@ ParseResult(
               Simple(SimpleCommand(
                 word_or_name: Some(Word(
                   value: "cat",
-                  loc: Some(TokenLocation(
+                  loc: Some(SourceSpan(
                     start: SourcePosition(
                       index: 0,
                       line: 1,
@@ -31,7 +31,7 @@ ParseResult(
                     requires_expansion: true,
                     here_end: Word(
                       value: "EOF",
-                      loc: Some(TokenLocation(
+                      loc: Some(SourceSpan(
                         start: SourcePosition(
                           index: 6,
                           line: 1,
@@ -46,7 +46,7 @@ ParseResult(
                     ),
                     doc: Word(
                       value: "Something\n",
-                      loc: Some(TokenLocation(
+                      loc: Some(SourceSpan(
                         start: SourcePosition(
                           index: 10,
                           line: 2,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_program.snap
@@ -15,7 +15,7 @@ ParseResult(
                 values: Some([
                   Word(
                     value: "A",
-                    loc: Some(TokenLocation(
+                    loc: Some(SourceSpan(
                       start: SourcePosition(
                         index: 32,
                         line: 5,
@@ -30,7 +30,7 @@ ParseResult(
                   ),
                   Word(
                     value: "B",
-                    loc: Some(TokenLocation(
+                    loc: Some(SourceSpan(
                       start: SourcePosition(
                         index: 34,
                         line: 5,
@@ -45,7 +45,7 @@ ParseResult(
                   ),
                   Word(
                     value: "C",
-                    loc: Some(TokenLocation(
+                    loc: Some(SourceSpan(
                       start: SourcePosition(
                         index: 36,
                         line: 5,
@@ -67,7 +67,7 @@ ParseResult(
                           Simple(SimpleCommand(
                             word_or_name: Some(Word(
                               value: "echo",
-                              loc: Some(TokenLocation(
+                              loc: Some(SourceSpan(
                                 start: SourcePosition(
                                   index: 60,
                                   line: 8,
@@ -83,7 +83,7 @@ ParseResult(
                             suffix: Some(CommandSuffix([
                               Word(Word(
                                 value: "\"${f@L}\"",
-                                loc: Some(TokenLocation(
+                                loc: Some(SourceSpan(
                                   start: SourcePosition(
                                     index: 65,
                                     line: 8,
@@ -98,7 +98,7 @@ ParseResult(
                               )),
                               IoRedirect(File(None, DuplicateOutput, Duplicate(Word(
                                 value: "2",
-                                loc: Some(TokenLocation(
+                                loc: Some(SourceSpan(
                                   start: SourcePosition(
                                     index: 76,
                                     line: 8,
@@ -117,7 +117,7 @@ ParseResult(
                       ),
                     ), Sequence),
                   ]),
-                  loc: TokenLocation(
+                  loc: SourceSpan(
                     start: SourcePosition(
                       index: 39,
                       line: 5,
@@ -130,7 +130,7 @@ ParseResult(
                     ),
                   ),
                 ),
-                loc: TokenLocation(
+                loc: SourceSpan(
                   start: SourcePosition(
                     index: 23,
                     line: 5,

--- a/brush-parser/src/snapshots/brush_parser__parser__tests__parse_redirection.snap
+++ b/brush-parser/src/snapshots/brush_parser__parser__tests__parse_redirection.snap
@@ -8,7 +8,7 @@ ParseResult(
     Simple(SimpleCommand(
       word_or_name: Some(Word(
         value: "echo",
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 0,
             line: 1,
@@ -28,7 +28,7 @@ ParseResult(
     Simple(SimpleCommand(
       word_or_name: Some(Word(
         value: "wc",
-        loc: Some(TokenLocation(
+        loc: Some(SourceSpan(
           start: SourcePosition(
             index: 8,
             line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"a$((1+2))b c\")?"
 TokenizerResult(
   input: "a$((1+2))b c",
   result: [
-    Word("a$((1+2))b", TokenLocation(
+    Word("a$((1+2))b", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Word("c", TokenLocation(
+    Word("c", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_parens.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_parens.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$(( (0) ))\")?"
 TokenizerResult(
   input: "$(( (0) ))",
   result: [
-    Word("$(( (0) ))", TokenLocation(
+    Word("$(( (0) ))", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_space.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_space.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$(( 1 ))\")?"
 TokenizerResult(
   input: "$(( 1 ))",
   result: [
-    Word("$(( 1 ))", TokenLocation(
+    Word("$(( 1 ))", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_backquote_with_escape.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_backquote_with_escape.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"echo `echo\\`hi`\")?"
 TokenizerResult(
   input: "echo `echo\\`hi`",
   result: [
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("`echo\\`hi`", TokenLocation(
+    Word("`echo\\`hi`", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion-2.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"a${x}b\")?"
 TokenizerResult(
   input: "a${x}b",
   result: [
-    Word("a${x}b", TokenLocation(
+    Word("a${x}b", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"${x}\")?"
 TokenizerResult(
   input: "${x}",
   result: [
-    Word("${x}", TokenLocation(
+    Word("${x}", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion_with_escaping.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion_with_escaping.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"a${x\\}}b\")?"
 TokenizerResult(
   input: "a${x\\}}b",
   result: [
-    Word("a${x\\}}b", TokenLocation(
+    Word("a${x\\}}b", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"a$(echo hi)b c\")?"
 TokenizerResult(
   input: "a$(echo hi)b c",
   result: [
-    Word("a$(echo hi)b", TokenLocation(
+    Word("a$(echo hi)b", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 13,
       ),
     )),
-    Word("c", TokenLocation(
+    Word("c", SourceSpan(
       start: SourcePosition(
         index: 13,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_containing_extglob.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_containing_extglob.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"echo $(echo !(x))\")?"
 TokenizerResult(
   input: "echo $(echo !(x))",
   result: [
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("$(echo !(x))", TokenLocation(
+    Word("$(echo !(x))", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_with_subshell.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_with_subshell.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$( (:) )\")?"
 TokenizerResult(
   input: "$( (:) )",
   result: [
-    Word("$( (:) )", TokenLocation(
+    Word("$( (:) )", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"a #comment\n\")?"
 TokenizerResult(
   input: "a #comment\n",
   result: [
-    Word("a", TokenLocation(
+    Word("a", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 2,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 2,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment_at_eof.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment_at_eof.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"a #comment\")?"
 TokenizerResult(
   input: "a #comment",
   result: [
-    Word("a", TokenLocation(
+    Word("a", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_complex_here_docs_in_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_complex_here_docs_in_command_substitution.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"echo $(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\n
 TokenizerResult(
   input: "echo $(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\nOTHER\nHERE2\n)",
   result: [
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("$(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\nOTHER\nHERE2\n)", TokenLocation(
+    Word("$(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\nOTHER\nHERE2\n)", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quote.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r#\"x\"a b\"y\"#)?"
 TokenizerResult(
   input: "x\"a b\"y",
   result: [
-    Word("x\"a b\"y", TokenLocation(
+    Word("x\"a b\"y", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_arithmetic_expression.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_arithmetic_expression.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r#\"x\"$((1+2))\"y\"#)?"
 TokenizerResult(
   input: "x\"$((1+2))\"y",
   result: [
-    Word("x\"$((1+2))\"y", TokenLocation(
+    Word("x\"$((1+2))\"y", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_command_substitution.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r#\"x\"$(echo hi)\"y\"#)?"
 TokenizerResult(
   input: "x\"$(echo hi)\"y",
   result: [
-    Word("x\"$(echo hi)\"y", TokenLocation(
+    Word("x\"$(echo hi)\"y", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_empty_here_doc.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_empty_here_doc.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<HERE\nHERE\n\")?"
 TokenizerResult(
   input: "cat <<HERE\nHERE\n",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 7,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 6,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Word("", TokenLocation(
+    Word("", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 16,
         line: 3,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 10,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_escaped_whitespace.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_escaped_whitespace.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"1\\ 2 3\")?"
 TokenizerResult(
   input: "1\\ 2 3",
   result: [
-    Word("1\\ 2", TokenLocation(
+    Word("1\\ 2", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("3", TokenLocation(
+    Word("3", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-2.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\n\")?"
 TokenizerResult(
   input: "cat <<HERE\nSOMETHING\nHERE\n",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 7,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 6,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Word("SOMETHING\n", TokenLocation(
+    Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 26,
         line: 4,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 10,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-3.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-3.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\n\n\")?"
 TokenizerResult(
   input: "cat <<HERE\nSOMETHING\nHERE\n\n",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 7,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 6,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Word("SOMETHING\n", TokenLocation(
+    Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 26,
         line: 4,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 10,
         line: 1,
@@ -77,7 +77,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 26,
         line: 4,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-4.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-4.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\")?"
 TokenizerResult(
   input: "cat <<HERE\nSOMETHING\nHERE",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 7,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 6,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Word("SOMETHING\n", TokenLocation(
+    Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 25,
         line: 3,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 10,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<HERE\nSOMETHING\nHERE\necho after\n\")?"
 TokenizerResult(
   input: "cat <<HERE\nSOMETHING\nHERE\necho after\n",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 7,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 6,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Word("SOMETHING\n", TokenLocation(
+    Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 26,
         line: 4,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 10,
         line: 1,
@@ -77,7 +77,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 26,
         line: 4,
@@ -89,7 +89,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("after", TokenLocation(
+    Word("after", SourceSpan(
       start: SourcePosition(
         index: 31,
         line: 4,
@@ -101,7 +101,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 36,
         line: 4,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_command_substitution.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"echo $(cat <<HERE\nTEXT\nHERE\n)\")?"
 TokenizerResult(
   input: "echo $(cat <<HERE\nTEXT\nHERE\n)",
   result: [
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("$(cat <<HERE\nTEXT\nHERE\n)", TokenLocation(
+    Word("$(cat <<HERE\nTEXT\nHERE\n)", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r#\"echo \"$(cat <<HERE\nTEXT\nHERE\n)\"\"#)?"
 TokenizerResult(
   input: "echo \"$(cat <<HERE\nTEXT\nHERE\n)\"",
   result: [
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("\"$(cat <<HERE\nTEXT\nHERE\n)\"", TokenLocation(
+    Word("\"$(cat <<HERE\nTEXT\nHERE\n)\"", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution_with_space.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution_with_space.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r#\"echo \"$(cat << HERE\nTEXT\nHERE\n)\"\"#)?"
 TokenizerResult(
   input: "echo \"$(cat << HERE\nTEXT\nHERE\n)\"",
   result: [
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("\"$(cat << HERE\nTEXT\nHERE\n)\"", TokenLocation(
+    Word("\"$(cat << HERE\nTEXT\nHERE\n)\"", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_other_tokens.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_other_tokens.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<EOF | wc -l\nA B C\n1 2 3\nD E F\nEOF\n\")?
 TokenizerResult(
   input: "cat <<EOF | wc -l\nA B C\n1 2 3\nD E F\nEOF\n",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 7,
       ),
     )),
-    Word("EOF", TokenLocation(
+    Word("EOF", SourceSpan(
       start: SourcePosition(
         index: 6,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 10,
       ),
     )),
-    Word("A B C\n1 2 3\nD E F\n", TokenLocation(
+    Word("A B C\n1 2 3\nD E F\n", SourceSpan(
       start: SourcePosition(
         index: 18,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("EOF", TokenLocation(
+    Word("EOF", SourceSpan(
       start: SourcePosition(
         index: 40,
         line: 6,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("|", TokenLocation(
+    Operator("|", SourceSpan(
       start: SourcePosition(
         index: 9,
         line: 1,
@@ -77,7 +77,7 @@ TokenizerResult(
         column: 12,
       ),
     )),
-    Word("wc", TokenLocation(
+    Word("wc", SourceSpan(
       start: SourcePosition(
         index: 12,
         line: 1,
@@ -89,7 +89,7 @@ TokenizerResult(
         column: 15,
       ),
     )),
-    Word("-l", TokenLocation(
+    Word("-l", SourceSpan(
       start: SourcePosition(
         index: 14,
         line: 1,
@@ -101,7 +101,7 @@ TokenizerResult(
         column: 18,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 17,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_tab_removal.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_tab_removal.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<-HERE\n\tSOMETHING\n\tHERE\n\")?"
 TokenizerResult(
   input: "cat <<-HERE\n\tSOMETHING\n\tHERE\n",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<-", TokenLocation(
+    Operator("<<-", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 8,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 7,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 12,
       ),
     )),
-    Word("SOMETHING\n", TokenLocation(
+    Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
         index: 12,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("HERE", TokenLocation(
+    Word("HERE", SourceSpan(
       start: SourcePosition(
         index: 29,
         line: 4,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_line_continuation.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_line_continuation.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"a\\\nbc\")?"
 TokenizerResult(
   input: "a\\\nbc",
   result: [
-    Word("abc", TokenLocation(
+    Word("abc", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_multiple_here_docs.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_multiple_here_docs.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"cat <<HERE1 <<HERE2\nSOMETHING\nHERE1\nOTHER\nHER
 TokenizerResult(
   input: "cat <<HERE1 <<HERE2\nSOMETHING\nHERE1\nOTHER\nHERE2\necho after\n",
   result: [
-    Word("cat", TokenLocation(
+    Word("cat", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 7,
       ),
     )),
-    Word("HERE1", TokenLocation(
+    Word("HERE1", SourceSpan(
       start: SourcePosition(
         index: 6,
         line: 1,
@@ -41,7 +41,7 @@ TokenizerResult(
         column: 12,
       ),
     )),
-    Word("SOMETHING\n", TokenLocation(
+    Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
         index: 20,
         line: 2,
@@ -53,7 +53,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("HERE1", TokenLocation(
+    Word("HERE1", SourceSpan(
       start: SourcePosition(
         index: 36,
         line: 4,
@@ -65,7 +65,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("<<", TokenLocation(
+    Operator("<<", SourceSpan(
       start: SourcePosition(
         index: 11,
         line: 1,
@@ -77,7 +77,7 @@ TokenizerResult(
         column: 15,
       ),
     )),
-    Word("HERE2", TokenLocation(
+    Word("HERE2", SourceSpan(
       start: SourcePosition(
         index: 14,
         line: 1,
@@ -89,7 +89,7 @@ TokenizerResult(
         column: 20,
       ),
     )),
-    Word("OTHER\n", TokenLocation(
+    Word("OTHER\n", SourceSpan(
       start: SourcePosition(
         index: 36,
         line: 4,
@@ -101,7 +101,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("HERE2", TokenLocation(
+    Word("HERE2", SourceSpan(
       start: SourcePosition(
         index: 48,
         line: 6,
@@ -113,7 +113,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 19,
         line: 1,
@@ -125,7 +125,7 @@ TokenizerResult(
         column: 1,
       ),
     )),
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 48,
         line: 6,
@@ -137,7 +137,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("after", TokenLocation(
+    Word("after", SourceSpan(
       start: SourcePosition(
         index: 53,
         line: 6,
@@ -149,7 +149,7 @@ TokenizerResult(
         column: 11,
       ),
     )),
-    Operator("\n", TokenLocation(
+    Operator("\n", SourceSpan(
       start: SourcePosition(
         index: 58,
         line: 6,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_operators.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_operators.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"a>>b\")?"
 TokenizerResult(
   input: "a>>b",
   result: [
-    Word("a", TokenLocation(
+    Word("a", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 2,
       ),
     )),
-    Operator(">>", TokenLocation(
+    Operator(">>", SourceSpan(
       start: SourcePosition(
         index: 1,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Word("b", TokenLocation(
+    Word("b", SourceSpan(
       start: SourcePosition(
         index: 3,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_simple_backquote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_simple_backquote.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"echo `echo hi`\")?"
 TokenizerResult(
   input: "echo `echo hi`",
   result: [
-    Word("echo", TokenLocation(
+    Word("echo", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 5,
       ),
     )),
-    Word("`echo hi`", TokenLocation(
+    Word("`echo hi`", SourceSpan(
       start: SourcePosition(
         index: 5,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_single_quote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_single_quote.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(r\"x'a b'y\")?"
 TokenizerResult(
   input: "x\'a b\'y",
   result: [
-    Word("x\'a b\'y", TokenLocation(
+    Word("x\'a b\'y", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-2.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$@\")?"
 TokenizerResult(
   input: "$@",
   result: [
-    Word("$@", TokenLocation(
+    Word("$@", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-3.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-3.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$!\")?"
 TokenizerResult(
   input: "$!",
   result: [
-    Word("$!", TokenLocation(
+    Word("$!", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-4.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-4.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$?\")?"
 TokenizerResult(
   input: "$?",
   result: [
-    Word("$?", TokenLocation(
+    Word("$?", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-5.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-5.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$*\")?"
 TokenizerResult(
   input: "$*",
   result: [
-    Word("$*", TokenLocation(
+    Word("$*", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$$\")?"
 TokenizerResult(
   input: "$$",
   result: [
-    Word("$$", TokenLocation(
+    Word("$$", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion-2.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"a$x\")?"
 TokenizerResult(
   input: "a$x",
   result: [
-    Word("a$x", TokenLocation(
+    Word("a$x", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"$x\")?"
 TokenizerResult(
   input: "$x",
   result: [
-    Word("$x", TokenLocation(
+    Word("$x", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_whitespace.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_whitespace.snap
@@ -5,7 +5,7 @@ expression: "test_tokenizer(\"1 2 3\")?"
 TokenizerResult(
   input: "1 2 3",
   result: [
-    Word("1", TokenLocation(
+    Word("1", SourceSpan(
       start: SourcePosition(
         index: 0,
         line: 1,
@@ -17,7 +17,7 @@ TokenizerResult(
         column: 2,
       ),
     )),
-    Word("2", TokenLocation(
+    Word("2", SourceSpan(
       start: SourcePosition(
         index: 2,
         line: 1,
@@ -29,7 +29,7 @@ TokenizerResult(
         column: 4,
       ),
     )),
-    Word("3", TokenLocation(
+    Word("3", SourceSpan(
       start: SourcePosition(
         index: 4,
         line: 1,

--- a/brush-parser/src/source.rs
+++ b/brush-parser/src/source.rs
@@ -1,0 +1,58 @@
+use std::{fmt::Display, sync::Arc};
+
+/// Represents a position in source text.
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    any(test, feature = "serde"),
+    derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)
+)]
+pub struct SourcePosition {
+    /// The 0-based index of the character in the input stream.
+    pub index: usize,
+    /// The 1-based line number.
+    pub line: usize,
+    /// The 1-based column number.
+    pub column: usize,
+}
+
+impl Display for SourcePosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("line {} col {}", self.line, self.column))
+    }
+}
+
+#[cfg(feature = "diagnostics")]
+impl From<&SourcePosition> for miette::SourceOffset {
+    #[allow(clippy::cast_sign_loss)]
+    fn from(position: &SourcePosition) -> Self {
+        position.index.into()
+    }
+}
+
+/// Represents a span within source text.
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "fuzz-testing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    any(test, feature = "serde"),
+    derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)
+)]
+pub struct SourceSpan {
+    /// The start position.
+    pub start: Arc<SourcePosition>,
+    /// The end position of the span (exclusive).
+    pub end: Arc<SourcePosition>,
+}
+
+impl SourceSpan {
+    /// Returns the length of the token in characters.
+    pub fn length(&self) -> usize {
+        self.end.index - self.start.index
+    }
+    pub(crate) fn within(start: &Self, end: &Self) -> Self {
+        Self {
+            start: start.start.clone(),
+            end: end.end.clone(),
+        }
+    }
+}

--- a/brush-shell/benches/shell.rs
+++ b/brush-shell/benches/shell.rs
@@ -5,7 +5,7 @@
 #[cfg(unix)]
 mod unix {
     use brush_builtins::ShellBuilderExt;
-    use brush_parser::TokenLocation;
+    use brush_parser::SourceSpan;
     use criterion::{Criterion, black_box};
 
     async fn instantiate_shell() -> brush_core::Shell {
@@ -121,7 +121,7 @@ mod unix {
                     brush_parser::ast::CompoundCommand::BraceGroup(
                         brush_parser::ast::BraceGroupCommand {
                             list: brush_parser::ast::CompoundList(vec![]),
-                            loc: TokenLocation::default(),
+                            loc: SourceSpan::default(),
                         },
                     ),
                     None,


### PR DESCRIPTION
Now that it's used for more than just tokens, `SourceSpan` is a more fitting name.