### PR TITLE
fix: preserve exit code during prompt expansion

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1095,9 +1095,19 @@ impl Shell {
             return Ok(String::new());
         }
 
+        // Save (and later restore) the last exit status.
+        let prev_last_result = self.last_result();
+        let prev_last_pipeline_statuses = self.last_pipeline_statuses.clone();
+
         // Expand it.
         let params = self.default_exec_params();
-        prompt::expand_prompt(self, &params, prompt_spec.into_owned()).await
+        let result = prompt::expand_prompt(self, &params, prompt_spec.into_owned()).await;
+
+        // Restore the last exit status.
+        self.last_pipeline_statuses = prev_last_pipeline_statuses;
+        *self.last_exit_status_mut() = prev_last_result;
+
+        result
     }
 
     fn parameter_or_default<'a>(&'a self, name: &str, default: &'a str) -> Cow<'a, str> {

--- a/brush-shell/tests/cases/prompt.yaml
+++ b/brush-shell/tests/cases/prompt.yaml
@@ -166,3 +166,11 @@ cases:
       var=
       prompt="\${var:+\[text\]}"
       echo "Conditional (unset): '${prompt@P}'"
+
+  - name: "Command substitution in prompt and exit code"
+    args: ["-i"]
+    ignore_stderr: true
+    stdin: |
+      PS1='$(echo Hello)> '
+      false
+      echo $?


### PR DESCRIPTION
Adds a test cases that reproduces the problem described in #797, and mitigates it.

_I'm not thrilled with the surgical logic to save and restore exit status, but there's precedent for what we do with `PROMPT_COMMAND`. As the existing comments in the code identify, `bash` may expand prompts in a subshell that's then promptly (pun intended :smile:) thrown away. When we get a chance, we should look into that more -- but for now, this seems to resolve the specific symptom identified._

Addresses #797 