### PR TITLE
fix: correct initialization of SHELL var

### DIFF
--- a/brush-core/src/sys/stubs/users.rs
+++ b/brush-core/src/sys/stubs/users.rs
@@ -9,6 +9,10 @@ pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
     None
 }
 
+pub(crate) fn get_current_user_default_shell() -> Option<PathBuf> {
+    None
+}
+
 pub(crate) fn is_root() -> bool {
     false
 }

--- a/brush-core/src/sys/unix/users.rs
+++ b/brush-core/src/sys/unix/users.rs
@@ -25,6 +25,16 @@ pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
     None
 }
 
+pub(crate) fn get_current_user_default_shell() -> Option<PathBuf> {
+    if let Some(username) = uzers::get_current_username() {
+        if let Some(user_info) = uzers::get_user_by_name(&username) {
+            return Some(user_info.shell().to_path_buf());
+        }
+    }
+
+    None
+}
+
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_current_uid() -> Result<u32, error::Error> {
     Ok(uzers::get_current_uid())

--- a/brush-core/src/sys/windows/users.rs
+++ b/brush-core/src/sys/windows/users.rs
@@ -15,6 +15,10 @@ pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
     homedir::my_home().unwrap_or_default()
 }
 
+pub(crate) fn get_current_user_default_shell() -> Option<PathBuf> {
+    None
+}
+
 pub(crate) fn is_root() -> bool {
     // TODO(windows): implement some version of this for Windows
     false

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -380,12 +380,15 @@ pub(crate) fn initialize_vars(
         }),
     )?;
 
-    // SHELL
-    if let Ok(exe_path) = std::env::current_exe() {
-        shell.env.set_global(
-            "SHELL",
-            ShellVariable::new(exe_path.to_string_lossy().to_string()),
-        )?;
+    // SHELL (if not already set)
+    if !shell.env.is_set("SHELL") {
+        // Per docs, this should be the user's default login shell -- not the current shell.
+        if let Some(default_shell) = sys::users::get_current_user_default_shell() {
+            shell.env.set_global(
+                "SHELL",
+                ShellVariable::new(default_shell.to_string_lossy().to_string()),
+            )?;
+        }
     }
 
     // SHELLOPTS

--- a/brush-shell/tests/cases/well_known_vars.yaml
+++ b/brush-shell/tests/cases/well_known_vars.yaml
@@ -171,6 +171,11 @@ cases:
       [[ $first -ge 0 && $first -lt 32768 ]] && echo "RANDOM value is within expected range"
       [[ $second -ge 0 && $second -lt 32768 ]] && echo "RANDOM value is within expected range"
 
+  - name: "SHELL"
+    stdin: |
+      declare -p SHELL
+      echo "SHELL: $SHELL"
+
   - name: "SHELLOPTS"
     stdin: |
       echo "SHELLOPTS: $SHELLOPTS"


### PR DESCRIPTION
Per docs, the `SHELL` var should only get initialized on start if unset. If unset, it should be initialized to the current user's *default shell*, not the currently running shell.

Fixes #799