### PR TITLE
fix: correct exit status handling in assignment-only cmds

### DIFF
--- a/brush-builtins/src/exit.rs
+++ b/brush-builtins/src/exit.rs
@@ -20,7 +20,7 @@ impl builtins::Command for ExitCommand {
         let code_8bit = if let Some(code_32bit) = &self.code {
             (code_32bit & 0xFF) as u8
         } else {
-            context.shell.last_result()
+            context.shell.last_exit_status()
         };
 
         let mut result = ExecutionResult::new(code_8bit);

--- a/brush-builtins/src/return_.rs
+++ b/brush-builtins/src/return_.rs
@@ -21,7 +21,7 @@ impl builtins::Command for ReturnCommand {
         let code_8bit = if let Some(code_32bit) = &self.code {
             (code_32bit & 0xFF) as u8
         } else {
-            context.shell.last_result()
+            context.shell.last_exit_status()
         };
 
         if context.shell.in_function() || context.shell.in_sourced_script() {

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -569,7 +569,7 @@ pub(crate) async fn invoke_command_in_subshell_and_get_output(
     let cmd_result = run_result?;
 
     // Store the status.
-    *shell.last_exit_status_mut() = cmd_result.exit_code.into();
+    shell.set_last_exit_status(cmd_result.exit_code.into());
 
     Ok(output_str)
 }

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1559,7 +1559,7 @@ impl<'a> WordExpander<'a> {
                 Expansion::from(self.shell.current_shell_args().len().to_string())
             }
             brush_parser::word::SpecialParameter::LastExitStatus => {
-                Expansion::from(self.shell.last_result().to_string())
+                Expansion::from(self.shell.last_exit_status().to_string())
             }
             brush_parser::word::SpecialParameter::CurrentOptionFlags => {
                 Expansion::from(self.shell.options.option_flags())

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -234,7 +234,7 @@ async fn run_in_shell(
     }
 
     // Make sure to return the last result observed in the shell.
-    let result = shell.shell().as_ref().last_result();
+    let result = shell.shell().as_ref().last_exit_status();
 
     Ok(result)
 }

--- a/brush-shell/tests/cases/status.yaml
+++ b/brush-shell/tests/cases/status.yaml
@@ -32,3 +32,30 @@ cases:
 
       (cat /non/existent 2>/dev/null)
       echo "[2] Status: $?; pipe status: ${PIPESTATUS[@]}"
+
+  - name: "Stored status"
+    stdin: |
+      false
+      status=$?
+      echo "Stored status from false: $status"
+
+      true
+      status=$?
+      echo "Stored status from true: $status"
+
+  - name: "Status from assignment"
+    stdin: |
+      false
+      false_status=$?
+      assign_status=$?
+
+      echo "Status after assignment: $assign_status"
+
+  - name: "Status within assignments"
+    stdin: |
+      f() {
+        return $1
+      }
+
+      x=$(f 42) y=0 z=$? w=$?
+      echo "x: $x; y: $y; z: $z; w: $w"


### PR DESCRIPTION
Ensure that we don't clobber status in assignment-only commands, but *do* ensure that we reset it **_only_** when the assignment itself went through successfully with no underlying non-zero exit status from, say, command substitutions.

Cleans up naming and moves to a helper function along the way. I'd like us to find a cleaner way of detecting whether status has been reset, but this should work reliably for now.

Resolves #794