### PR TITLE
feature: expose key bindings for hint acceptance

### DIFF
--- a/brush-core/src/interfaces/keybindings.rs
+++ b/brush-core/src/interfaces/keybindings.rs
@@ -21,7 +21,8 @@ impl Display for KeyAction {
     }
 }
 
-/// Defines all input functions.
+/// Defines all input functions. Based on standard `readline` functions,
+/// augmented with some `brush`-specific extensions.
 #[derive(Debug, strum_macros::EnumString, strum_macros::Display, strum_macros::EnumIter)]
 #[strum(serialize_all = "kebab-case")]
 #[expect(missing_docs)]
@@ -39,6 +40,8 @@ pub enum InputFunction {
     BeginningOfHistory,
     BeginningOfLine,
     BracketedPasteBegin,
+    BrushAcceptHint,
+    BrushAcceptHintWord,
     CallLastKbdMacro,
     CapitalizeWord,
     CharacterSearch,

--- a/brush-interactive/src/reedline/edit_mode.rs
+++ b/brush-interactive/src/reedline/edit_mode.rs
@@ -244,6 +244,8 @@ fn translate_input_function_to_reedline_event(
         InputFunction::AcceptLine => Some(ReedlineEvent::Enter),
         InputFunction::HistorySearchBackward => Some(ReedlineEvent::SearchHistory),
         InputFunction::RedrawCurrentLine => Some(ReedlineEvent::Repaint),
+        InputFunction::BrushAcceptHint => Some(ReedlineEvent::HistoryHintComplete),
+        InputFunction::BrushAcceptHintWord => Some(ReedlineEvent::HistoryHintWordComplete),
         _ => None,
     }
 }
@@ -400,6 +402,12 @@ fn translate_reedline_event_to_action(event: &reedline::ReedlineEvent) -> Option
         reedline::ReedlineEvent::Repaint => {
             Some(KeyAction::DoInputFunction(InputFunction::RedrawCurrentLine))
         }
+        reedline::ReedlineEvent::HistoryHintComplete => {
+            Some(KeyAction::DoInputFunction(InputFunction::BrushAcceptHint))
+        }
+        reedline::ReedlineEvent::HistoryHintWordComplete => Some(KeyAction::DoInputFunction(
+            InputFunction::BrushAcceptHintWord,
+        )),
         reedline::ReedlineEvent::Multiple(_) => {
             // TODO(input): Try to extract something from these?
             None


### PR DESCRIPTION
Adds new bindable input functions:

* `brush-accept-hint`
* `brush-accept-hint-word`

For example, the following command binds `Ctrl+O` to accepting a suggested hint:

```
$ bind '"\C-o'":brush-accept-hint'
```

Note that binding `Tab` to this function will clobber `Tab`'s typical completion behavior.