### PR TITLE
fix: extended test redirection

### DIFF
--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -541,7 +541,15 @@ impl ExecuteInPipeline for ast::Command {
                 .execute(&mut pipeline_context.shell, &params)
                 .await?
                 .into()),
-            Self::ExtendedTest(e) => {
+            Self::ExtendedTest(e, redirects) => {
+                // Set up any additional redirects.
+                if let Some(redirects) = redirects {
+                    for redirect in &redirects.0 {
+                        setup_redirect(&mut pipeline_context.shell, &mut params, redirect).await?;
+                    }
+                }
+
+                // Evaluate the extended test expression.
                 let result = if extendedtests::eval_extended_test_expr(
                     &e.expr,
                     &mut pipeline_context.shell,

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -375,7 +375,7 @@ pub enum Command {
     /// A command whose side effect is to define a shell function.
     Function(FunctionDefinition),
     /// A command that evaluates an extended test expression.
-    ExtendedTest(ExtendedTestExprCommand),
+    ExtendedTest(ExtendedTestExprCommand, Option<RedirectList>),
 }
 
 impl Node for Command {}
@@ -391,7 +391,7 @@ impl SourceLocation for Command {
                 }
             }
             Self::Function(f) => f.location(),
-            Self::ExtendedTest(e) => e.location(),
+            Self::ExtendedTest(e, _) => e.location(),
         }
     }
 }
@@ -408,8 +408,12 @@ impl Display for Command {
                 Ok(())
             }
             Self::Function(function_definition) => write!(f, "{function_definition}"),
-            Self::ExtendedTest(extended_test_expr) => {
-                write!(f, "[[ {extended_test_expr} ]]")
+            Self::ExtendedTest(extended_test_expr, redirect_list) => {
+                write!(f, "[[ {extended_test_expr} ]]")?;
+                if let Some(redirect_list) = redirect_list {
+                    write!(f, "{redirect_list}")?;
+                }
+                Ok(())
             }
         }
     }

--- a/brush-parser/src/parser.rs
+++ b/brush-parser/src/parser.rs
@@ -305,7 +305,7 @@ peg::parser! {
             c:simple_command() { ast::Command::Simple(c) } /
             c:compound_command() r:redirect_list()? { ast::Command::Compound(c, r) } /
             // N.B. Extended test commands are bash extensions.
-            non_posix_extensions_enabled() c:extended_test_command() { ast::Command::ExtendedTest(c) } /
+            non_posix_extensions_enabled() c:extended_test_command() r:redirect_list()? { ast::Command::ExtendedTest(c, r) } /
             expected!("command")
 
         // N.B. The arithmetic command is a non-sh extension.
@@ -978,7 +978,7 @@ fn add_pipe_extension_redirection(c: &mut ast::Command) -> Result<(), &'static s
         }
         ast::Command::Compound(_, l) => add_to_redirect_list(l, r),
         ast::Command::Function(f) => add_to_redirect_list(&mut f.body.1, r),
-        ast::Command::ExtendedTest(_) => return Err("|& unimplemented for extended tests"),
+        ast::Command::ExtendedTest(..) => return Err("|& unimplemented for extended tests"),
     }
 
     Ok(())

--- a/brush-shell/tests/cases/extended_tests.yaml
+++ b/brush-shell/tests/cases/extended_tests.yaml
@@ -1,5 +1,10 @@
 name: "Extended tests"
 cases:
+  - name: "Extended test with redirect"
+    stdin: |
+      [[ $(echo hello >&2) ]] 2>/dev/null
+      echo "Result: $?"
+
   - name: "File extended tests"
     stdin: |
       [[ -a /tmp ]] && echo "-a correctly checked /tmp"


### PR DESCRIPTION
Adds parsing logic, a new test, and implementation to support redirecting extended test commands.

Resolves #809 