### PR TITLE
fix: do not tilde-expand prompts

### DIFF
--- a/brush-core/src/prompt.rs
+++ b/brush-core/src/prompt.rs
@@ -36,8 +36,9 @@ pub(crate) async fn expand_prompt(
     }
 
     if shell.options.expand_prompt_strings {
-        // Now expand any remaining escape sequences.
-        formatted_prompt = expansion::basic_expand_str(shell, params, &formatted_prompt).await?;
+        // Now expand any remaining escape sequences, but without tilde-expansion.
+        formatted_prompt =
+            expansion::basic_expand_str_without_tilde(shell, params, &formatted_prompt).await?;
     }
 
     Ok(formatted_prompt)

--- a/brush-shell/tests/cases/prompt.yaml
+++ b/brush-shell/tests/cases/prompt.yaml
@@ -141,6 +141,18 @@ cases:
       shopt -u promptvars
       echo "Prompt (dollar-sign escaped, without promptvars): ${prompt@P}"
 
+  - name: "Tilde in prompt"
+    stdin: |
+      HOME=$(pwd)
+
+      prompt='~'
+
+      shopt -s promptvars
+      echo "Prompt (with promptvars): ${prompt@P}"
+
+      shopt -u promptvars
+      echo "Prompt (without promptvars): ${prompt@P}"
+
   - name: "Command substitution in prompt"
     stdin: |
       prompt='$(echo Hello)'


### PR DESCRIPTION
Prompt expansion (when enabled) should not tilde-expand.