### PR TITLE
test: skip confused test

### DIFF
--- a/brush-shell/tests/cases/redirection.yaml
+++ b/brush-shell/tests/cases/redirection.yaml
@@ -166,6 +166,7 @@ cases:
       echo "Read: $line"
 
   - name: "Input file descriptor duplication from stdin"
+    skip: true # Needs revisiting; doesn't behave as seems to have been expected.
     stdin: |
       exec 3<&0
       echo "test" | { read line <&3; echo "Read: $line"; }


### PR DESCRIPTION
This test has been causing failures recently, and on second look, it seems a bit confused with what it's trying to do. Marking it as `skip` for now.