### PR TITLE
fix: escaping in pattern character sets

### DIFF
--- a/brush-parser/src/pattern.rs
+++ b/brush-parser/src/pattern.rs
@@ -70,7 +70,7 @@ peg::parser! {
         rule bracket_member() -> String =
             char_class_expression() /
             char_range() /
-            char_list()
+            single_char_bracket_member()
 
         rule char_class_expression() -> String =
             e:$("[:" char_class() ":]") { e.to_owned() }
@@ -81,8 +81,10 @@ peg::parser! {
         rule char_range() -> String =
             range:$([_] "-" [c if c != ']']) { range.to_owned() }
 
-        rule char_list() -> String =
-            chars:$([c if c != ']']+) { escape_char_class_char_list(chars) }
+        rule single_char_bracket_member() -> String =
+            s:$(['\\'] [c]) { s.to_owned() } /
+            ['['] { String::from(r"\[") } /
+            [c if c != ']'] { c.to_string() }
 
         rule wildcard() -> String =
             "?" { String::from(".") } /
@@ -154,10 +156,6 @@ pub const fn regex_char_needs_escaping(c: char) -> bool {
         c,
         '[' | ']' | '(' | ')' | '{' | '}' | '*' | '?' | '.' | '+' | '^' | '$' | '|' | '\\'
     )
-}
-
-fn escape_char_class_char_list(s: &str) -> String {
-    s.replace('[', r"\[")
 }
 
 #[cfg(test)]

--- a/brush-shell/tests/cases/patterns/patterns.yaml
+++ b/brush-shell/tests/cases/patterns/patterns.yaml
@@ -116,6 +116,9 @@ cases:
       [[ "x" == [!xyz] ]] && echo "4. Matched"
       [[ "(" == [\(]   ]] && echo "5. Matched"
       [[ "+" == [+-]   ]] && echo "6. Matched"
+      [[ "[" == [\[]   ]] && echo "7. Matched"
+      [[ "]" == [\]]   ]] && echo "8. Matched"
+      [[ "^" == [\^]   ]] && echo "9. Matched"
 
   - name: "Pattern matching: character classes"
     stdin: |


### PR DESCRIPTION
Corrects translation of character sets (`[...]`) in patterns to their counterparts in regex land.