### PR TITLE
fix: special-casing for OLDPWD

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1555,10 +1555,7 @@ impl Shell {
         self.env.update_or_add(
             "PWD",
             variables::ShellValueLiteral::Scalar(pwd),
-            |var| {
-                var.export();
-                Ok(())
-            },
+            |_| Ok(()),
             EnvironmentLookup::Anywhere,
             EnvironmentScope::Global,
         )?;
@@ -1567,10 +1564,7 @@ impl Shell {
         self.env.update_or_add(
             "OLDPWD",
             variables::ShellValueLiteral::Scalar(oldpwd.to_string_lossy().to_string()),
-            |var| {
-                var.export();
-                Ok(())
-            },
+            |_| Ok(()),
             EnvironmentLookup::Anywhere,
             EnvironmentScope::Global,
         )?;

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -32,6 +32,11 @@ pub(crate) fn initialize_vars(
                 }
             }
 
+            // Special case OLDPWD for bash compatibility.
+            if k == "OLDPWD" {
+                continue;
+            }
+
             let mut var = ShellVariable::new(ShellValue::String(v));
             var.export();
             shell.env.set_global(k, var)?;

--- a/brush-shell/tests/cases/builtins/cd.yaml
+++ b/brush-shell/tests/cases/builtins/cd.yaml
@@ -41,7 +41,6 @@ cases:
       echo $?
       echo "pwd: $PWD"
 
-
   - name: "cd ~"
     stdin: |
       mkdir ./my_home
@@ -62,7 +61,6 @@ cases:
         cd -P ~
         echo "pwd: $(basename $PWD)"
       )
-
 
   - name: "cd with symlink"
     stdin: |
@@ -142,3 +140,32 @@ cases:
         cd ..
         echo "cd .. => $(basename $PWD)"
       )
+
+  - name: "OLDPWD"
+    env:
+      OLDPWD: "/nonexistent/path"
+    stdin: |
+      mkdir subdir
+
+      echo "[0]"
+      echo ${OLDPWD+set}
+
+      echo "[1]"
+      echo ${OLDPWD-NOTSET}
+
+      echo "[2]"
+      declare -p OLDPWD 2>&1 | grep -o "declare -[a-z]* OLDPWD"
+
+      echo "[3]"
+      env | grep "^OLDPWD=" || echo "NOT_IN_ENV"
+
+      echo
+      echo "[Unsetting + cd'ing...]"
+      unset OLDPWD
+      cd $PWD/subdir
+
+      echo "[4]"
+      declare -p OLDPWD 2>&1 | grep -o "declare -[a-z]* OLDPWD"
+
+      echo "[5]"
+      env | grep -o "^OLDPWD="


### PR DESCRIPTION
We've observed different behavior with `OLDPWD` handling in `bash` compared to other standard variables. It appears that `bash` intentionally will block importing it from a parent process.