### PR TITLE
fix: getopts short options

### DIFF
--- a/brush-builtins/src/getopts.rs
+++ b/brush-builtins/src/getopts.rs
@@ -108,7 +108,7 @@ impl builtins::Command for GetOptsCommand {
 
                 // Find the char.
                 let c = arg.chars().nth(next_char_index).unwrap();
-                let is_last_char_in_option = next_char_index == arg.len() - 1;
+                let mut is_last_char_in_option = next_char_index == arg.len() - 1;
 
                 // Look up the char.
                 let mut is_error = false;
@@ -116,8 +116,9 @@ impl builtins::Command for GetOptsCommand {
                     variable_value = String::from(c);
 
                     if *takes_arg {
-                        // If the option takes a value but it's not the last option in this
-                        // argument, then this is an error.
+                        // This option takes a value. If it's the last character in the option,
+                        // then we need to look for its value in the next argument. If it's
+                        // not, then the rest of this argument will be its value.
                         if is_last_char_in_option {
                             next_index += 1;
                             next_index_zero_based += 1;
@@ -128,9 +129,14 @@ impl builtins::Command for GetOptsCommand {
 
                             new_optarg = Some(args_to_parse[next_index_zero_based].clone());
                         } else {
-                            is_error = true;
+                            new_optarg = Some(arg.chars().skip(next_char_index + 1).collect());
+
+                            // Note that we have reached the end of the option, and we'll be ready
+                            // to move the next argument.
+                            is_last_char_in_option = true;
                         }
                     } else {
+                        // This option doesn't take a value.
                         new_optarg = None;
                     }
                 } else {

--- a/brush-shell/tests/cases/builtins/getopts.yaml
+++ b/brush-shell/tests/cases/builtins/getopts.yaml
@@ -166,3 +166,21 @@ cases:
       echo "OPTARG: ${OPTARG}"
       echo "OPTIND: ${OPTIND}"
       echo "OPTERR: ${OPTERR}"
+
+  - name: "getopts: short option and value in single arg"
+    stdin: |
+      getopts "p:" myvar -p-
+      echo "Result: $?"
+      echo "myvar: ${myvar}"
+      echo "OPTARG: ${OPTARG}"
+      echo "OPTIND: ${OPTIND}"
+      echo "OPTERR: ${OPTERR}"
+
+      while getopts "abep:" myvar -abpsomething-else; do
+        echo "Result: $?"
+        echo "myvar: ${myvar}"
+        echo "OPTARG: ${OPTARG}"
+        echo "OPTIND: ${OPTIND}"
+        echo "OPTERR: ${OPTERR}"
+        echo "-----------------"
+      done


### PR DESCRIPTION
Fixes `getopts` parsing of short options whose values are appended to the same argument.