### PR TITLE
fix: history import robustness

### DIFF
--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -303,6 +303,10 @@ pub enum ErrorKind {
     /// Cannot convert open file to native file descriptor.
     #[error("cannot convert open file to native file descriptor")]
     CannotConvertToNativeFd,
+
+    /// History file is too large to import.
+    #[error("history file is too large to import")]
+    HistoryFileTooLargeToImport,
 }
 
 impl BuiltinError for Error {}


### PR DESCRIPTION
* Refines history import read loop's error handling; we continue when the read error indicates invalid data in the file, but we bail early on any other error (including read I/O errors).
* Skip importing history on unreasonably large history files (for now, >= 1 GiB)
* Skip importing history on 0-length history files.
* More cleanly proceed regardless of any history import error.

Resolves #876