### PR TITLE
refactor: make Shell fields private

### DIFF
--- a/brush-builtins/src/alias.rs
+++ b/brush-builtins/src/alias.rs
@@ -25,7 +25,7 @@ impl builtins::Command for AliasCommand {
         let mut exit_code = ExecutionResult::success();
 
         if self.print || self.aliases.is_empty() {
-            for (name, value) in &context.shell.aliases {
+            for (name, value) in context.shell.aliases() {
                 writeln!(context.stdout(), "alias {name}='{value}'")?;
             }
         } else {
@@ -33,9 +33,9 @@ impl builtins::Command for AliasCommand {
                 if let Some((name, unexpanded_value)) = alias.split_once('=') {
                     context
                         .shell
-                        .aliases
+                        .aliases_mut()
                         .insert(name.to_owned(), unexpanded_value.to_owned());
-                } else if let Some(value) = context.shell.aliases.get(alias) {
+                } else if let Some(value) = context.shell.aliases().get(alias) {
                     writeln!(context.stdout(), "alias {alias}='{value}'")?;
                 } else {
                     writeln!(

--- a/brush-builtins/src/bg.rs
+++ b/brush-builtins/src/bg.rs
@@ -21,7 +21,7 @@ impl builtins::Command for BgCommand {
 
         if !self.job_specs.is_empty() {
             for job_spec in &self.job_specs {
-                if let Some(job) = context.shell.jobs.resolve_job_spec(job_spec) {
+                if let Some(job) = context.shell.jobs_mut().resolve_job_spec(job_spec) {
                     job.move_to_background()?;
                 } else {
                     writeln!(
@@ -34,7 +34,7 @@ impl builtins::Command for BgCommand {
                 }
             }
         } else {
-            if let Some(job) = context.shell.jobs.current_job_mut() {
+            if let Some(job) = context.shell.jobs_mut().current_job_mut() {
                 job.move_to_background()?;
             } else {
                 writeln!(context.stderr(), "{}: no current job", context.command_name)?;

--- a/brush-builtins/src/bind.rs
+++ b/brush-builtins/src/bind.rs
@@ -171,7 +171,7 @@ impl BindCommand {
         }
 
         if self.list_vars {
-            let options = &context.shell.completion_config.fallback_options;
+            let options = &context.shell.completion_config().fallback_options;
 
             // For now we'll just display a few items and show defaults.
             writeln!(
@@ -187,7 +187,7 @@ impl BindCommand {
         }
 
         if self.list_vars_reusable {
-            let options = &context.shell.completion_config.fallback_options;
+            let options = &context.shell.completion_config().fallback_options;
 
             // For now we'll just display a few items and show defaults.
             writeln!(

--- a/brush-builtins/src/cd.rs
+++ b/brush-builtins/src/cd.rs
@@ -70,7 +70,7 @@ impl builtins::Command for CdCommand {
         if self.use_physical_dir
             || context
                 .shell
-                .options
+                .options()
                 .do_not_resolve_symlinks_when_changing_dir
         {
             // -e is only relevant in physical mode.

--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -211,7 +211,7 @@ impl DeclareCommand {
                 // For some reason, bash does not print an error message in this case.
                 Ok(false)
             }
-        } else if let Some(variable) = context.shell.env.get_using_policy(name, lookup) {
+        } else if let Some(variable) = context.shell.env().get_using_policy(name, lookup) {
             let mut cs = variable.attribute_flags(context.shell);
             if cs.is_empty() {
                 cs.push('-');
@@ -282,7 +282,7 @@ impl DeclareCommand {
         // Look up the variable.
         if let Some(var) = context
             .shell
-            .env
+            .env_mut()
             .get_mut_using_policy(name.as_str(), lookup)
         {
             if self.make_associative_array.is_some() {
@@ -319,7 +319,7 @@ impl DeclareCommand {
                 var.assign(initial_value, false)?;
             }
 
-            if context.shell.options.export_variables_on_modification && !var.value().is_array() {
+            if context.shell.options().export_variables_on_modification && !var.value().is_array() {
                 var.export();
             }
 
@@ -331,7 +331,7 @@ impl DeclareCommand {
                 EnvironmentScope::Global
             };
 
-            context.shell.env.add(name, var, scope)?;
+            context.shell.env_mut().add(name, var, scope)?;
         }
 
         Ok(true)
@@ -490,7 +490,7 @@ impl DeclareCommand {
         // environment.
         for (name, variable) in context
             .shell
-            .env
+            .env()
             .iter_using_policy(iter_policy)
             .filter(|pair| filters.iter().all(|f| f(*pair)))
             .sorted_by_key(|v| v.0)

--- a/brush-builtins/src/dirs.rs
+++ b/brush-builtins/src/dirs.rs
@@ -55,14 +55,14 @@ impl builtins::Command for DirsCommand {
         context: brush_core::ExecutionContext<'_>,
     ) -> Result<brush_core::ExecutionResult, Self::Error> {
         if self.clear {
-            context.shell.directory_stack.clear();
+            context.shell.directory_stack_mut().clear();
         } else {
             let dirs = vec![context.shell.working_dir()]
                 .into_iter()
                 .chain(
                     context
                         .shell
-                        .directory_stack
+                        .directory_stack()
                         .iter()
                         .rev()
                         .map(|p| p.as_path()),

--- a/brush-builtins/src/export.rs
+++ b/brush-builtins/src/export.rs
@@ -87,7 +87,7 @@ impl ExportCommand {
                 }
                 // Try to find the variable already present; if we find it, then mark it
                 // exported.
-                else if let Some((_, variable)) = context.shell.env.get_mut(s) {
+                else if let Some((_, variable)) = context.shell.env_mut().get_mut(s) {
                     if self.unexport {
                         variable.unexport();
                     } else {
@@ -118,7 +118,7 @@ impl ExportCommand {
                 };
 
                 // Update the variable with the provided value and then mark it exported.
-                context.shell.env.update_or_add(
+                context.shell.env_mut().update_or_add(
                     name,
                     value,
                     |var| {
@@ -143,7 +143,7 @@ fn display_all_exported_vars(
     context: &brush_core::ExecutionContext<'_>,
 ) -> Result<(), brush_core::Error> {
     // Enumerate variables, sorted by key.
-    for (name, variable) in context.shell.env.iter().sorted_by_key(|v| v.0) {
+    for (name, variable) in context.shell.env().iter().sorted_by_key(|v| v.0) {
         if variable.is_exported() {
             let value = variable.value().try_get_cow_str(context.shell);
             if let Some(value) = value {

--- a/brush-builtins/src/getopts.rs
+++ b/brush-builtins/src/getopts.rs
@@ -166,12 +166,12 @@ impl builtins::Command for GetOptsCommand {
                     // We're done with this argument, so unset the internal char index variable
                     // and request an update to OPTIND.
                     new_optind = next_index + 1;
-                    context.shell.env.unset(VAR_GETOPTS_NEXT_CHAR_INDEX)?;
+                    context.shell.env_mut().unset(VAR_GETOPTS_NEXT_CHAR_INDEX)?;
                 } else {
                     // We have more to go in this argument, so update the internal char index
                     // and request that OPTIND not be updated.
                     new_optind = next_index;
-                    context.shell.env.update_or_add(
+                    context.shell.env_mut().update_or_add(
                         VAR_GETOPTS_NEXT_CHAR_INDEX,
                         variables::ShellValueLiteral::Scalar((next_char_index + 1).to_string()),
                         |_| Ok(()),
@@ -203,7 +203,7 @@ impl builtins::Command for GetOptsCommand {
         }
 
         // Update variable value.
-        context.shell.env.update_or_add(
+        context.shell.env_mut().update_or_add(
             self.variable_name.as_str(),
             variables::ShellValueLiteral::Scalar(variable_value),
             |_| Ok(()),
@@ -213,7 +213,7 @@ impl builtins::Command for GetOptsCommand {
 
         // Update OPTARG
         if let Some(new_optarg) = new_optarg {
-            context.shell.env.update_or_add(
+            context.shell.env_mut().update_or_add(
                 "OPTARG",
                 variables::ShellValueLiteral::Scalar(new_optarg),
                 |_| Ok(()),
@@ -221,11 +221,11 @@ impl builtins::Command for GetOptsCommand {
                 brush_core::env::EnvironmentScope::Global,
             )?;
         } else {
-            let _ = context.shell.env.unset("OPTARG")?;
+            let _ = context.shell.env_mut().unset("OPTARG")?;
         }
 
         // Update OPTIND
-        context.shell.env.update_or_add(
+        context.shell.env_mut().update_or_add(
             "OPTIND",
             variables::ShellValueLiteral::Scalar(new_optind.to_string()),
             |_| Ok(()),

--- a/brush-builtins/src/hash.rs
+++ b/brush-builtins/src/hash.rs
@@ -39,17 +39,17 @@ impl builtins::Command for HashCommand {
         let mut result = ExecutionResult::success();
 
         if self.remove_all {
-            context.shell.program_location_cache.reset();
+            context.shell.program_location_cache_mut().reset();
         } else if self.remove {
             for name in &self.names {
-                if !context.shell.program_location_cache.unset(name) {
+                if !context.shell.program_location_cache_mut().unset(name) {
                     writeln!(context.stderr(), "{name}: not found")?;
                     result = ExecutionResult::general_error();
                 }
             }
         } else if self.display_paths {
             for name in &self.names {
-                if let Some(path) = context.shell.program_location_cache.get(name) {
+                if let Some(path) = context.shell.program_location_cache().get(name) {
                     if self.display_as_usable_input {
                         writeln!(
                             context.stdout(),
@@ -77,12 +77,15 @@ impl builtins::Command for HashCommand {
             }
         } else if let Some(path) = &self.path_to_use {
             for name in &self.names {
-                context.shell.program_location_cache.set(name, path.clone());
+                context
+                    .shell
+                    .program_location_cache_mut()
+                    .set(name, path.clone());
             }
         } else {
             for name in &self.names {
                 // Remove from the cache if already hashed.
-                let _ = context.shell.program_location_cache.unset(name);
+                let _ = context.shell.program_location_cache_mut().unset(name);
 
                 // Hash the path.
                 if context

--- a/brush-builtins/src/help.rs
+++ b/brush-builtins/src/help.rs
@@ -79,8 +79,8 @@ impl HelpCommand {
         topic_pattern: &str,
     ) -> Result<(), brush_core::Error> {
         let pattern = brush_core::patterns::Pattern::from(topic_pattern)
-            .set_extended_globbing(context.shell.options.extended_globbing)
-            .set_case_insensitive(context.shell.options.case_insensitive_pathname_expansion);
+            .set_extended_globbing(context.shell.options().extended_globbing)
+            .set_case_insensitive(context.shell.options().case_insensitive_pathname_expansion);
 
         let mut found_count = 0;
         for (builtin_name, builtin_registration) in get_builtins_sorted_by_name(context) {

--- a/brush-builtins/src/jobs.rs
+++ b/brush-builtins/src/jobs.rs
@@ -46,7 +46,7 @@ impl builtins::Command for JobsCommand {
         }
 
         if self.job_specs.is_empty() {
-            for job in &context.shell.jobs.jobs {
+            for job in &context.shell.jobs().jobs {
                 self.display_job(&context, job)?;
             }
         } else {

--- a/brush-builtins/src/kill.rs
+++ b/brush-builtins/src/kill.rs
@@ -107,7 +107,7 @@ impl builtins::Command for KillCommand {
             let pid_or_job_spec = pid_or_job_spec.unwrap();
             if pid_or_job_spec.starts_with('%') {
                 // It's a job spec.
-                if let Some(job) = context.shell.jobs.resolve_job_spec(pid_or_job_spec) {
+                if let Some(job) = context.shell.jobs_mut().resolve_job_spec(pid_or_job_spec) {
                     job.kill(trap_signal)?;
                 } else {
                     writeln!(

--- a/brush-builtins/src/mapfile.rs
+++ b/brush-builtins/src/mapfile.rs
@@ -68,7 +68,7 @@ impl builtins::Command for MapFileCommand {
         let results = self.read_entries(input_file)?;
 
         // Assign!
-        context.shell.env.update_or_add(
+        context.shell.env_mut().update_or_add(
             &self.array_var_name,
             variables::ShellValueLiteral::Array(results),
             |_| Ok(()),

--- a/brush-builtins/src/popd.rs
+++ b/brush-builtins/src/popd.rs
@@ -19,7 +19,7 @@ impl builtins::Command for PopdCommand {
         &self,
         context: brush_core::ExecutionContext<'_>,
     ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if let Some(popped) = context.shell.directory_stack.pop() {
+        if let Some(popped) = context.shell.directory_stack_mut().pop() {
             if !self.no_directory_change {
                 context.shell.set_working_dir(&popped)?;
             }

--- a/brush-builtins/src/pushd.rs
+++ b/brush-builtins/src/pushd.rs
@@ -25,7 +25,7 @@ impl builtins::Command for PushdCommand {
         if self.no_directory_change {
             context
                 .shell
-                .directory_stack
+                .directory_stack_mut()
                 .push(std::path::PathBuf::from(&self.dir));
         } else {
             let prev_working_dir = context.shell.working_dir().to_path_buf();
@@ -33,7 +33,7 @@ impl builtins::Command for PushdCommand {
             let dir = std::path::Path::new(&self.dir);
             context.shell.set_working_dir(dir)?;
 
-            context.shell.directory_stack.push(prev_working_dir);
+            context.shell.directory_stack_mut().push(prev_working_dir);
         }
 
         // Display dirs.

--- a/brush-builtins/src/pwd.rs
+++ b/brush-builtins/src/pwd.rs
@@ -26,7 +26,7 @@ impl builtins::Command for PwdCommand {
         let should_canonicalize = self.physical
             || context
                 .shell
-                .options
+                .options()
                 .do_not_resolve_symlinks_when_changing_dir;
 
         if should_canonicalize {

--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -117,7 +117,7 @@ impl builtins::Command for ReadCommand {
                 vec![]
             };
 
-            context.shell.env.update_or_add(
+            context.shell.env_mut().update_or_add(
                 array_variable,
                 variables::ShellValueLiteral::Array(variables::ArrayLiteral(literal_fields)),
                 |_| Ok(()),
@@ -138,7 +138,7 @@ impl builtins::Command for ReadCommand {
             for (i, name) in self.variable_names.iter().enumerate() {
                 if fields.is_empty() {
                     // Ensure the var is empty.
-                    context.shell.env.update_or_add(
+                    context.shell.env_mut().update_or_add(
                         name,
                         variables::ShellValueLiteral::Scalar(String::new()),
                         |_| Ok(()),
@@ -151,7 +151,7 @@ impl builtins::Command for ReadCommand {
                 let last = i == self.variable_names.len() - 1;
                 if !last {
                     let next_field = fields.pop_front().unwrap();
-                    context.shell.env.update_or_add(
+                    context.shell.env_mut().update_or_add(
                         name,
                         variables::ShellValueLiteral::Scalar(next_field),
                         |_| Ok(()),
@@ -160,7 +160,7 @@ impl builtins::Command for ReadCommand {
                     )?;
                 } else {
                     let remaining_fields = fields.into_iter().join(" ");
-                    context.shell.env.update_or_add(
+                    context.shell.env_mut().update_or_add(
                         name,
                         variables::ShellValueLiteral::Scalar(remaining_fields),
                         |_| Ok(()),
@@ -175,7 +175,7 @@ impl builtins::Command for ReadCommand {
 
             // If no variable names were specified, then place everything into the
             // REPLY variable.
-            context.shell.env.update_or_add(
+            context.shell.env_mut().update_or_add(
                 "REPLY",
                 variables::ShellValueLiteral::Scalar(input_line),
                 |_| Ok(()),

--- a/brush-builtins/src/set.rs
+++ b/brush-builtins/src/set.rs
@@ -198,80 +198,83 @@ impl builtins::Command for SetCommand {
         let mut saw_option = false;
 
         if let Some(value) = self.print_commands_and_arguments.to_bool() {
-            context.shell.options.print_commands_and_arguments = value;
+            context.shell.options_mut().print_commands_and_arguments = value;
             saw_option = true;
         }
 
         if let Some(value) = self.export_variables_on_modification.to_bool() {
-            context.shell.options.export_variables_on_modification = value;
+            context.shell.options_mut().export_variables_on_modification = value;
             saw_option = true;
         }
 
         if let Some(value) = self.notify_job_termination_immediately.to_bool() {
-            context.shell.options.notify_job_termination_immediately = value;
+            context
+                .shell
+                .options_mut()
+                .notify_job_termination_immediately = value;
             saw_option = true;
         }
 
         if let Some(value) = self.exit_on_nonzero_command_exit.to_bool() {
-            context.shell.options.exit_on_nonzero_command_exit = value;
+            context.shell.options_mut().exit_on_nonzero_command_exit = value;
             saw_option = true;
         }
 
         if let Some(value) = self.disable_filename_globbing.to_bool() {
-            context.shell.options.disable_filename_globbing = value;
+            context.shell.options_mut().disable_filename_globbing = value;
             saw_option = true;
         }
 
         if let Some(value) = self.remember_command_locations.to_bool() {
-            context.shell.options.remember_command_locations = value;
+            context.shell.options_mut().remember_command_locations = value;
             saw_option = true;
         }
 
         if let Some(value) = self.place_all_assignment_args_in_command_env.to_bool() {
             context
                 .shell
-                .options
+                .options_mut()
                 .place_all_assignment_args_in_command_env = value;
             saw_option = true;
         }
 
         if let Some(value) = self.enable_job_control.to_bool() {
-            context.shell.options.enable_job_control = value;
+            context.shell.options_mut().enable_job_control = value;
             saw_option = true;
         }
 
         if let Some(value) = self.do_not_execute_commands.to_bool() {
-            context.shell.options.do_not_execute_commands = value;
+            context.shell.options_mut().do_not_execute_commands = value;
             saw_option = true;
         }
 
         if let Some(value) = self.real_effective_uid_mismatch.to_bool() {
-            context.shell.options.real_effective_uid_mismatch = value;
+            context.shell.options_mut().real_effective_uid_mismatch = value;
             saw_option = true;
         }
 
         if let Some(value) = self.exit_after_one_command.to_bool() {
-            context.shell.options.exit_after_one_command = value;
+            context.shell.options_mut().exit_after_one_command = value;
             saw_option = true;
         }
 
         if let Some(value) = self.treat_unset_variables_as_error.to_bool() {
-            context.shell.options.treat_unset_variables_as_error = value;
+            context.shell.options_mut().treat_unset_variables_as_error = value;
             saw_option = true;
         }
 
         if let Some(value) = self.print_shell_input_lines.to_bool() {
-            context.shell.options.print_shell_input_lines = value;
+            context.shell.options_mut().print_shell_input_lines = value;
             saw_option = true;
         }
 
         if let Some(value) = self.print_commands_and_arguments.to_bool() {
-            context.shell.options.print_commands_and_arguments = value;
+            context.shell.options_mut().print_commands_and_arguments = value;
             saw_option = true;
         }
 
         if let Some(value) = self.perform_brace_expansion.to_bool() {
-            context.shell.options.perform_brace_expansion = value;
+            context.shell.options_mut().perform_brace_expansion = value;
             saw_option = true;
         }
 
@@ -281,25 +284,28 @@ impl builtins::Command for SetCommand {
         {
             context
                 .shell
-                .options
+                .options_mut()
                 .disallow_overwriting_regular_files_via_output_redirection = value;
             saw_option = true;
         }
 
         if let Some(value) = self.shell_functions_inherit_err_trap.to_bool() {
-            context.shell.options.shell_functions_inherit_err_trap = value;
+            context.shell.options_mut().shell_functions_inherit_err_trap = value;
             saw_option = true;
         }
 
         if let Some(value) = self.enable_bang_style_history_substitution.to_bool() {
-            context.shell.options.enable_bang_style_history_substitution = value;
+            context
+                .shell
+                .options_mut()
+                .enable_bang_style_history_substitution = value;
             saw_option = true;
         }
 
         if let Some(value) = self.do_not_resolve_symlinks_when_changing_dir.to_bool() {
             context
                 .shell
-                .options
+                .options_mut()
                 .do_not_resolve_symlinks_when_changing_dir = value;
             saw_option = true;
         }
@@ -310,7 +316,7 @@ impl builtins::Command for SetCommand {
         {
             context
                 .shell
-                .options
+                .options_mut()
                 .shell_functions_inherit_debug_and_return_traps = value;
             saw_option = true;
         }
@@ -325,7 +331,7 @@ impl builtins::Command for SetCommand {
                 .iter()
                 .sorted_by_key(|option| option.name)
                 {
-                    let option_value = option.definition.get(&context.shell.options);
+                    let option_value = option.definition.get(context.shell.options());
                     let option_value_str = if option_value { "-o" } else { "+o" };
                     writeln!(context.stdout(), "set {option_value_str} {}", option.name)?;
                 }
@@ -344,7 +350,7 @@ impl builtins::Command for SetCommand {
                 .iter()
                 .sorted_by_key(|option| option.name)
                 {
-                    let option_value = option.definition.get(&context.shell.options);
+                    let option_value = option.definition.get(context.shell.options());
                     let option_value_str = if option_value { "on" } else { "off" };
                     writeln!(context.stdout(), "{:15}\t{option_value_str}", option.name)?;
                 }
@@ -360,7 +366,7 @@ impl builtins::Command for SetCommand {
                 brush_core::namedoptions::options(brush_core::namedoptions::ShellOptionKind::SetO)
                     .get(option_name.as_str())
             {
-                option_def.set(&mut context.shell.options, value);
+                option_def.set(context.shell.options_mut(), value);
             } else {
                 result = ExecutionExitCode::InvalidUsage.into();
             }
@@ -404,7 +410,7 @@ impl builtins::Command for SetCommand {
 
 fn display_all(context: &brush_core::ExecutionContext<'_>) -> Result<(), brush_core::Error> {
     // Display variables.
-    for (name, var) in context.shell.env.iter().sorted_by_key(|v| v.0) {
+    for (name, var) in context.shell.env().iter().sorted_by_key(|v| v.0) {
         if !var.is_enumerable() {
             continue;
         }
@@ -431,7 +437,7 @@ fn display_all(context: &brush_core::ExecutionContext<'_>) -> Result<(), brush_c
     }
 
     // Display functions... unless we're in posix compliance mode.
-    if !context.shell.options.posix_mode {
+    if !context.shell.options().posix_mode {
         for (_name, registration) in context.shell.funcs().iter().sorted_by_key(|v| v.0) {
             writeln!(context.stdout(), "{}", registration.definition())?;
         }

--- a/brush-builtins/src/shopt.rs
+++ b/brush-builtins/src/shopt.rs
@@ -64,7 +64,7 @@ impl builtins::Command for ShoptCommand {
             };
 
             for option in options {
-                let option_value = option.definition.get(&context.shell.options);
+                let option_value = option.definition.get(context.shell.options());
                 if self.set && !option_value {
                     continue;
                 }
@@ -106,11 +106,11 @@ impl builtins::Command for ShoptCommand {
 
                 if let Some(option_definition) = option_definition {
                     if self.set {
-                        option_definition.set(&mut context.shell.options, true);
+                        option_definition.set(context.shell.options_mut(), true);
                     } else if self.unset {
-                        option_definition.set(&mut context.shell.options, false);
+                        option_definition.set(context.shell.options_mut(), false);
                     } else {
-                        let option_value = option_definition.get(&context.shell.options);
+                        let option_value = option_definition.get(context.shell.options());
                         if !option_value {
                             return_value = ExecutionResult::general_error();
                         }

--- a/brush-builtins/src/suspend.rs
+++ b/brush-builtins/src/suspend.rs
@@ -18,7 +18,7 @@ impl builtins::Command for SuspendCommand {
         &self,
         context: brush_core::ExecutionContext<'_>,
     ) -> Result<ExecutionResult, Self::Error> {
-        if context.shell.options.login_shell && !self.force {
+        if context.shell.options().login_shell && !self.force {
             writeln!(context.stderr(), "login shell cannot be suspended")?;
             return Ok(ExecutionExitCode::InvalidUsage.into());
         }

--- a/brush-builtins/src/trap.rs
+++ b/brush-builtins/src/trap.rs
@@ -67,7 +67,7 @@ impl TrapCommand {
     fn display_all_handlers(
         context: &brush_core::ExecutionContext<'_>,
     ) -> Result<(), brush_core::Error> {
-        for (signal, _) in context.shell.traps.iter_handlers() {
+        for (signal, _) in context.shell.traps().iter_handlers() {
             Self::display_handlers_for(context, signal)?;
         }
         Ok(())
@@ -77,7 +77,7 @@ impl TrapCommand {
         context: &brush_core::ExecutionContext<'_>,
         signal_type: TrapSignal,
     ) -> Result<(), brush_core::Error> {
-        if let Some(handler) = context.shell.traps.get_handler(signal_type) {
+        if let Some(handler) = context.shell.traps().get_handler(signal_type) {
             writeln!(
                 context.stdout(),
                 "trap -- '{}' {signal_type}",
@@ -88,7 +88,7 @@ impl TrapCommand {
     }
 
     fn remove_all_handlers(context: &mut brush_core::ExecutionContext<'_>, signal: TrapSignal) {
-        context.shell.traps.remove_handlers(signal);
+        context.shell.traps_mut().remove_handlers(signal);
     }
 
     fn register_handler(
@@ -102,10 +102,11 @@ impl TrapCommand {
         let source_info = context.shell.call_stack().current_pos_as_source_info();
 
         for signal in signals {
-            context
-                .shell
-                .traps
-                .register_handler(signal, handler.to_owned(), source_info.clone());
+            context.shell.traps_mut().register_handler(
+                signal,
+                handler.to_owned(),
+                source_info.clone(),
+            );
         }
     }
 }

--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -145,7 +145,7 @@ impl TypeCommand {
 
         if !self.force_path_search {
             // Check for aliases.
-            if let Some(a) = shell.aliases.get(name) {
+            if let Some(a) = shell.aliases().get(name) {
                 types.push(ResolvedType::Alias(a.clone()));
                 if !self.all_locations {
                     return types;
@@ -192,7 +192,7 @@ impl TypeCommand {
                 }
             }
         } else {
-            if let Some(path) = shell.program_location_cache.get(name) {
+            if let Some(path) = shell.program_location_cache().get(name) {
                 types.push(ResolvedType::File { path, hashed: true });
                 if !self.all_locations {
                     return types;

--- a/brush-builtins/src/unalias.rs
+++ b/brush-builtins/src/unalias.rs
@@ -24,10 +24,10 @@ impl builtins::Command for UnaliasCommand {
         let mut exit_code = ExecutionResult::success();
 
         if self.remove_all {
-            context.shell.aliases.clear();
+            context.shell.aliases_mut().clear();
         } else {
             for alias in &self.aliases {
-                if context.shell.aliases.remove(alias).is_none() {
+                if context.shell.aliases_mut().remove(alias).is_none() {
                     writeln!(
                         context.stderr(),
                         "{}: {}: not found",

--- a/brush-builtins/src/unset.rs
+++ b/brush-builtins/src/unset.rs
@@ -64,7 +64,7 @@ impl builtins::Command for UnsetCommand {
                         brush_parser::word::Parameter::Positional(_) => continue,
                         brush_parser::word::Parameter::Special(_) => continue,
                         brush_parser::word::Parameter::Named(name) => {
-                            context.shell.env.unset(name.as_str())?.is_some()
+                            context.shell.env_mut().unset(name.as_str())?.is_some()
                         }
                         brush_parser::word::Parameter::NamedWithIndex { name, index } => {
                             unset_array_index(context.shell, name.as_str(), index.as_str())?
@@ -99,7 +99,7 @@ fn unset_array_index(
     index: &str,
 ) -> Result<bool, brush_core::Error> {
     // First check to see if it's an associative array.
-    let is_assoc_array = if let Some((_, var)) = shell.env.get(name) {
+    let is_assoc_array = if let Some((_, var)) = shell.env().get(name) {
         matches!(
             var.value(),
             ShellValue::AssociativeArray(_)
@@ -121,5 +121,5 @@ fn unset_array_index(
     };
 
     // Now we can try to unset, and return the result.
-    shell.env.unset_index(name, index_to_use.as_ref())
+    shell.env_mut().unset_index(name, index_to_use.as_ref())
 }

--- a/brush-builtins/src/wait.rs
+++ b/brush-builtins/src/wait.rs
@@ -43,9 +43,9 @@ impl builtins::Command for WaitCommand {
             return error::unimp("wait with job specs");
         }
 
-        let jobs = context.shell.jobs.wait_all().await?;
+        let jobs = context.shell.jobs_mut().wait_all().await?;
 
-        if context.shell.options.enable_job_control {
+        if context.shell.options().enable_job_control {
             for job in jobs {
                 writeln!(context.stdout(), "{job}")?;
             }

--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -99,7 +99,7 @@ pub(crate) async fn expand_and_eval(
         .map_err(|_e| EvalError::ParseError(expanded_self))?;
 
     // Trace if applicable.
-    if trace_if_needed && shell.options.print_commands_and_arguments {
+    if trace_if_needed && shell.options().print_commands_and_arguments {
         shell
             .trace_command(params, std::format!("(( {expr} ))"))
             .await
@@ -161,7 +161,7 @@ fn get_var_value<'a>(shell: &'a Shell, name: &str) -> Result<Cow<'a, str>, EvalE
         }
     }
 
-    if shell.options.treat_unset_variables_as_error {
+    if shell.options().treat_unset_variables_as_error {
         return Err(EvalError::ExpandingUnsetVariable(name.into()));
     }
 
@@ -175,7 +175,7 @@ fn deref_lvalue(shell: &mut Shell, lvalue: &ast::ArithmeticTarget) -> Result<i64
             let index_str = index_expr.eval(shell)?.to_string();
 
             shell
-                .env
+                .env()
                 .get(name)
                 .map_or_else(
                     || Ok(None),
@@ -322,7 +322,7 @@ fn assign(shell: &mut Shell, lvalue: &ast::ArithmeticTarget, value: i64) -> Resu
     match lvalue {
         ast::ArithmeticTarget::Variable(name) => {
             shell
-                .env
+                .env_mut()
                 .update_or_add(
                     name.as_str(),
                     variables::ShellValueLiteral::Scalar(value.to_string()),
@@ -336,7 +336,7 @@ fn assign(shell: &mut Shell, lvalue: &ast::ArithmeticTarget, value: i64) -> Resu
             let index_str = index_expr.eval(shell)?.to_string();
 
             shell
-                .env
+                .env_mut()
                 .update_or_add_array_element(
                     name.as_str(),
                     index_str,

--- a/brush-core/src/env.rs
+++ b/brush-core/src/env.rs
@@ -58,7 +58,7 @@ impl<'a> ScopeGuard<'a> {
     /// * `shell` - The shell whose environment to modify.
     /// * `scope_type` - The type of scope to push.
     pub fn new(shell: &'a mut crate::Shell, scope_type: EnvironmentScope) -> Self {
-        shell.env.push_scope(scope_type);
+        shell.env_mut().push_scope(scope_type);
         Self {
             scope_type,
             shell,
@@ -80,7 +80,7 @@ impl<'a> ScopeGuard<'a> {
 impl Drop for ScopeGuard<'_> {
     fn drop(&mut self) {
         if !self.detached {
-            let _ = self.shell.env.pop_scope(self.scope_type);
+            let _ = self.shell.env_mut().pop_scope(self.scope_type);
         }
     }
 }

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -385,7 +385,7 @@ impl Error {
     ///
     /// * `shell` - The shell instance, used to check interactive mode and script call stack.
     pub const fn to_control_flow(&self, shell: &Shell) -> results::ExecutionControlFlow {
-        if self.is_fatal() && !shell.options.interactive {
+        if self.is_fatal() && !shell.options().interactive {
             results::ExecutionControlFlow::ExitShell
         } else {
             results::ExecutionControlFlow::Normal

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -52,7 +52,7 @@ async fn apply_unary_predicate(
 ) -> Result<bool, error::Error> {
     let expanded_operand = expansion::basic_expand_word(shell, params, operand).await?;
 
-    if shell.options.print_commands_and_arguments {
+    if shell.options().print_commands_and_arguments {
         shell
             .trace_command(
                 params,
@@ -178,13 +178,13 @@ pub(crate) fn apply_unary_predicate_to_str(
             if let Some(option) =
                 namedoptions::options(namedoptions::ShellOptionKind::SetO).get(shopt_name)
             {
-                Ok(option.get(&shell.options))
+                Ok(option.get(shell.options()))
             } else {
                 Ok(false)
             }
         }
-        ast::UnaryPredicate::ShellVariableIsSetAndAssigned => Ok(shell.env.is_set(operand)),
-        ast::UnaryPredicate::ShellVariableIsSetAndNameRef => match shell.env.get(operand) {
+        ast::UnaryPredicate::ShellVariableIsSetAndAssigned => Ok(shell.env().is_set(operand)),
+        ast::UnaryPredicate::ShellVariableIsSetAndNameRef => match shell.env().get(operand) {
             Some((_, reffed)) => Ok(reffed.value().is_set() && reffed.is_treated_as_nameref()),
             None => Ok(false),
         },
@@ -206,7 +206,7 @@ async fn apply_binary_predicate(
                 .await?
                 .set_multiline(true);
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {s} {op} {right} ]]"))
                     .await?;
@@ -231,7 +231,7 @@ async fn apply_binary_predicate(
                     .collect(),
             ));
 
-            shell.env.update_or_add(
+            shell.env_mut().update_or_add(
                 "BASH_REMATCH",
                 captures_value,
                 |_| Ok(()),
@@ -245,7 +245,7 @@ async fn apply_binary_predicate(
             let left = expansion::basic_expand_word(shell, params, left).await?;
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -257,7 +257,7 @@ async fn apply_binary_predicate(
             let left = expansion::basic_expand_word(shell, params, left).await?;
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -269,7 +269,7 @@ async fn apply_binary_predicate(
             let s = expansion::basic_expand_word(shell, params, left).await?;
             let substring = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {s} {op} {substring} ]]"))
                     .await?;
@@ -281,7 +281,7 @@ async fn apply_binary_predicate(
             let left = expansion::basic_expand_word(shell, params, left).await?;
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -293,7 +293,7 @@ async fn apply_binary_predicate(
             let left = expansion::basic_expand_word(shell, params, left).await?;
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -305,7 +305,7 @@ async fn apply_binary_predicate(
             let left = expansion::basic_expand_word(shell, params, left).await?;
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -317,7 +317,7 @@ async fn apply_binary_predicate(
             let left = expansion::basic_expand_word(shell, params, left).await?;
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -330,7 +330,7 @@ async fn apply_binary_predicate(
             let left = expansion::basic_expand_word(shell, params, left).await?;
             let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -345,7 +345,7 @@ async fn apply_binary_predicate(
             let right =
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -359,7 +359,7 @@ async fn apply_binary_predicate(
             let right =
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -373,7 +373,7 @@ async fn apply_binary_predicate(
             let right =
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -387,7 +387,7 @@ async fn apply_binary_predicate(
             let right =
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -401,7 +401,7 @@ async fn apply_binary_predicate(
             let right =
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -415,7 +415,7 @@ async fn apply_binary_predicate(
             let right =
                 arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
                     .await?;
@@ -432,10 +432,10 @@ async fn apply_binary_predicate(
             let s = expansion::basic_expand_word(shell, params, left).await?;
             let pattern = expansion::basic_expand_pattern(shell, params, right)
                 .await?
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+                .set_extended_globbing(shell.options().extended_globbing)
+                .set_case_insensitive(shell.options().case_insensitive_conditionals);
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
                 let escaped_right = escape::quote_if_needed(
                     expanded_right.as_str(),
@@ -452,10 +452,10 @@ async fn apply_binary_predicate(
             let s = expansion::basic_expand_word(shell, params, left).await?;
             let pattern = expansion::basic_expand_pattern(shell, params, right)
                 .await?
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+                .set_extended_globbing(shell.options().extended_globbing)
+                .set_case_insensitive(shell.options().case_insensitive_conditionals);
 
-            if shell.options.print_commands_and_arguments {
+            if shell.options().print_commands_and_arguments {
                 let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
                 let escaped_right = escape::quote_if_needed(
                     expanded_right.as_str(),
@@ -524,15 +524,15 @@ pub(crate) fn apply_binary_predicate_to_strs(
         ),
         ast::BinaryPredicate::StringExactlyMatchesPattern => {
             let pattern = patterns::Pattern::from(right)
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+                .set_extended_globbing(shell.options().extended_globbing)
+                .set_case_insensitive(shell.options().case_insensitive_conditionals);
 
             pattern.exactly_matches(left)
         }
         ast::BinaryPredicate::StringDoesNotExactlyMatchPattern => {
             let pattern = patterns::Pattern::from(right)
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+                .set_extended_globbing(shell.options().extended_globbing)
+                .set_case_insensitive(shell.options().case_insensitive_conditionals);
 
             let eq = pattern.exactly_matches(left)?;
             Ok(!eq)

--- a/brush-core/src/prompt.rs
+++ b/brush-core/src/prompt.rs
@@ -28,14 +28,14 @@ pub(crate) async fn expand_prompt(
 
         let formatted_piece = format_prompt_piece(shell, piece)?;
 
-        if shell.options.expand_prompt_strings && needs_escaping {
+        if shell.options().expand_prompt_strings && needs_escaping {
             formatted_prompt.push('\\');
         }
 
         formatted_prompt.push_str(&formatted_piece);
     }
 
-    if shell.options.expand_prompt_strings {
+    if shell.options().expand_prompt_strings {
         // Now expand any remaining escape sequences, but without tilde-expansion.
         let options = expansion::ExpanderOptions {
             tilde_expand: false,
@@ -107,7 +107,9 @@ fn format_prompt_piece(
             hn
         }
         brush_parser::prompt::PromptPiece::Newline => "\n".to_owned(),
-        brush_parser::prompt::PromptPiece::NumberOfManagedJobs => shell.jobs.jobs.len().to_string(),
+        brush_parser::prompt::PromptPiece::NumberOfManagedJobs => {
+            shell.jobs().jobs.len().to_string()
+        }
         brush_parser::prompt::PromptPiece::ShellBaseName => {
             if let Some(shell_name) = shell.current_shell_name() {
                 Path::new(shell_name.as_ref())

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -72,7 +72,7 @@ impl RcLoadBehavior {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Shell {
     /// Trap handler configuration for the shell.
-    pub traps: traps::TrapHandlerConfig,
+    traps: traps::TrapHandlerConfig,
 
     /// Manages files opened and accessible via redirection operators.
     open_files: openfiles::OpenFiles,
@@ -81,21 +81,21 @@ pub struct Shell {
     working_dir: PathBuf,
 
     /// The shell environment, containing shell variables.
-    pub env: ShellEnvironment,
+    env: ShellEnvironment,
 
     /// Shell function definitions.
     funcs: functions::FunctionEnv,
 
     /// Runtime shell options.
-    pub options: RuntimeOptions,
+    options: RuntimeOptions,
 
     /// State of managed jobs.
     /// TODO(serde): Need to warn somehow that jobs cannot be serialized.
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub jobs: jobs::JobManager,
+    jobs: jobs::JobManager,
 
     /// Shell aliases.
-    pub aliases: HashMap<String, String>,
+    aliases: HashMap<String, String>,
 
     /// The status of the last completed command.
     last_exit_status: u8,
@@ -104,7 +104,7 @@ pub struct Shell {
     last_exit_status_change_count: usize,
 
     /// The status of each of the commands in the last pipeline.
-    pub last_pipeline_statuses: Vec<u8>,
+    last_pipeline_statuses: Vec<u8>,
 
     /// Clone depth from the original ancestor shell.
     depth: usize,
@@ -125,17 +125,17 @@ pub struct Shell {
     call_stack: callstack::CallStack,
 
     /// Directory stack used by pushd et al.
-    pub directory_stack: Vec<PathBuf>,
+    directory_stack: Vec<PathBuf>,
 
     /// Completion configuration.
-    pub completion_config: completion::Config,
+    completion_config: completion::Config,
 
     /// Shell built-in commands.
     #[cfg_attr(feature = "serde", serde(skip))]
     builtins: HashMap<String, builtins::Registration>,
 
     /// Shell program location cache.
-    pub program_location_cache: pathcache::PathCache,
+    program_location_cache: pathcache::PathCache,
 
     /// Last "SECONDS" captured time.
     last_stopwatch_time: std::time::SystemTime,
@@ -689,6 +689,11 @@ impl Shell {
         &self.funcs
     }
 
+    /// Returns a mutable reference to the function definition environment for this shell.
+    pub const fn funcs_mut(&mut self) -> &mut functions::FunctionEnv {
+        &mut self.funcs
+    }
+
     /// Tries to undefine a function in the shell's environment. Returns whether or
     /// not a definition was removed.
     ///
@@ -697,6 +702,106 @@ impl Shell {
     /// * `name` - The name of the function to undefine.
     pub fn undefine_func(&mut self, name: &str) -> bool {
         self.funcs.remove(name).is_some()
+    }
+
+    /// Returns the shell environment containing variables.
+    pub const fn env(&self) -> &ShellEnvironment {
+        &self.env
+    }
+
+    /// Returns a mutable reference to the shell environment.
+    pub const fn env_mut(&mut self) -> &mut ShellEnvironment {
+        &mut self.env
+    }
+
+    /// Returns the shell's runtime options.
+    pub const fn options(&self) -> &RuntimeOptions {
+        &self.options
+    }
+
+    /// Returns a mutable reference to the shell's runtime options.
+    pub const fn options_mut(&mut self) -> &mut RuntimeOptions {
+        &mut self.options
+    }
+
+    /// Returns the shell's aliases.
+    pub const fn aliases(&self) -> &HashMap<String, String> {
+        &self.aliases
+    }
+
+    /// Returns a mutable reference to the shell's aliases.
+    pub const fn aliases_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.aliases
+    }
+
+    /// Returns the shell's job manager.
+    pub const fn jobs(&self) -> &jobs::JobManager {
+        &self.jobs
+    }
+
+    /// Returns a mutable reference to the shell's job manager.
+    pub const fn jobs_mut(&mut self) -> &mut jobs::JobManager {
+        &mut self.jobs
+    }
+
+    /// Returns the shell's trap handler configuration.
+    pub const fn traps(&self) -> &traps::TrapHandlerConfig {
+        &self.traps
+    }
+
+    /// Returns a mutable reference to the shell's trap handler configuration.
+    pub const fn traps_mut(&mut self) -> &mut traps::TrapHandlerConfig {
+        &mut self.traps
+    }
+
+    /// Returns the shell's directory stack.
+    pub fn directory_stack(&self) -> &[PathBuf] {
+        &self.directory_stack
+    }
+
+    /// Returns a mutable reference to the shell's directory stack.
+    pub const fn directory_stack_mut(&mut self) -> &mut Vec<PathBuf> {
+        &mut self.directory_stack
+    }
+
+    /// Returns the statuses of commands in the last pipeline.
+    pub fn last_pipeline_statuses(&self) -> &[u8] {
+        &self.last_pipeline_statuses
+    }
+
+    /// Returns a mutable reference to the statuses of commands in the last pipeline.
+    pub const fn last_pipeline_statuses_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.last_pipeline_statuses
+    }
+
+    /// Returns the shell's program location cache.
+    pub const fn program_location_cache(&self) -> &pathcache::PathCache {
+        &self.program_location_cache
+    }
+
+    /// Returns a mutable reference to the shell's program location cache.
+    pub const fn program_location_cache_mut(&mut self) -> &mut pathcache::PathCache {
+        &mut self.program_location_cache
+    }
+
+    /// Returns the shell's completion configuration.
+    pub const fn completion_config(&self) -> &completion::Config {
+        &self.completion_config
+    }
+
+    /// Returns a mutable reference to the shell's completion configuration.
+    pub const fn completion_config_mut(&mut self) -> &mut completion::Config {
+        &mut self.completion_config
+    }
+
+    /// Returns the shell's open files.
+    pub const fn open_files(&self) -> &openfiles::OpenFiles {
+        &self.open_files
+    }
+
+    /// Returns a mutable reference to the shell's open files.
+    pub const fn open_files_mut(&mut self) -> &mut openfiles::OpenFiles {
+        &mut self.open_files
     }
 
     /// Defines a function in the shell's environment. If a function already exists

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -38,7 +38,7 @@ pub(crate) fn inherit_env_vars(shell: &mut Shell) -> Result<(), error::Error> {
 
         let mut var = ShellVariable::new(ShellValue::String(v));
         var.export();
-        shell.env.set_global(k, var)?;
+        shell.env_mut().set_global(k, var)?;
     }
 
     Ok(())
@@ -47,7 +47,7 @@ pub(crate) fn inherit_env_vars(shell: &mut Shell) -> Result<(), error::Error> {
 #[expect(clippy::too_many_lines)]
 pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error> {
     let shell_version = shell.version().clone();
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BRUSH_VERSION",
         ShellVariable::new(shell_version.unwrap_or_default()),
     )?;
@@ -55,19 +55,19 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     // TODO(#479): implement $_
 
     // BASH
-    if let Some(shell_name) = shell.current_shell_name() {
+    if let Some(shell_name) = shell.current_shell_name().map(|s| s.to_string()) {
         shell
-            .env
-            .set_global("BASH", ShellVariable::new(shell_name.as_ref()))?;
+            .env_mut()
+            .set_global("BASH", ShellVariable::new(shell_name))?;
     }
 
     // BASHOPTS
     let mut bashopts_var = ShellVariable::new(ShellValue::Dynamic {
-        getter: |shell| shell.options.shopt_optstr().into(),
+        getter: |shell| shell.options().shopt_optstr().into(),
         setter: |_| (),
     });
     bashopts_var.set_readonly();
-    shell.env.set_global("BASHOPTS", bashopts_var)?;
+    shell.env_mut().set_global("BASHOPTS", bashopts_var)?;
 
     // BASHPID
     #[cfg(not(target_family = "wasm"))]
@@ -75,17 +75,17 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
         let mut bashpid_var =
             ShellVariable::new(ShellValue::String(std::process::id().to_string()));
         bashpid_var.treat_as_integer();
-        shell.env.set_global("BASHPID", bashpid_var)?;
+        shell.env_mut().set_global("BASHPID", bashpid_var)?;
     }
 
     // BASH_ALIASES
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BASH_ALIASES",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| {
                 let values = variables::ArrayLiteral(
                     shell
-                        .aliases
+                        .aliases()
                         .iter()
                         .map(|(k, v)| (Some(k.to_owned()), v.to_owned()))
                         .collect::<Vec<_>>(),
@@ -102,7 +102,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     // TODO(vars): implement BASH_ARGV
 
     // BASH_ARGV0
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BASH_ARGV0",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| {
@@ -115,10 +115,10 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     )?;
 
     // TODO(vars): implement mutation of BASH_CMDS
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BASH_CMDS",
         ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| shell.program_location_cache.to_value().unwrap(),
+            getter: |shell| shell.program_location_cache().to_value().unwrap(),
             setter: |_| (),
         }),
     )?;
@@ -127,7 +127,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     // TODO(vars): implement BASH_EXECUTION_STRING
 
     // BASH_LINENO
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BASH_LINENO",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| get_bash_lineno_value(shell),
@@ -136,7 +136,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     )?;
 
     // BASH_SOURCE
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BASH_SOURCE",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| get_bash_source_value(shell),
@@ -145,7 +145,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     )?;
 
     // BASH_SUBSHELL
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BASH_SUBSHELL",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| shell.depth().to_string().into(),
@@ -166,11 +166,13 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
         .as_slice(),
     ));
     bash_versinfo_var.set_readonly();
-    shell.env.set_global("BASH_VERSINFO", bash_versinfo_var)?;
+    shell
+        .env_mut()
+        .set_global("BASH_VERSINFO", bash_versinfo_var)?;
 
     // BASH_VERSION
     // This is the Bash interface version. See BRUSH_VERSION for its implementation version.
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "BASH_VERSION",
         ShellVariable::new(std::format!(
             "{BASH_MAJOR}.{BASH_MINOR}.{BASH_PATCH}({BASH_BUILD})-{BASH_RELEASE}"
@@ -179,22 +181,22 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
 
     // COMP_WORDBREAKS
     let mut default_comp_wordbreaks = String::from(" \t\n\"\'><=;|&(:");
-    if shell.options.enable_hostname_completion {
+    if shell.options().enable_hostname_completion {
         default_comp_wordbreaks.push('@');
     }
 
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "COMP_WORDBREAKS",
         ShellVariable::new(default_comp_wordbreaks),
     )?;
 
     // DIRSTACK
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "DIRSTACK",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| {
                 shell
-                    .directory_stack
+                    .directory_stack()
                     .iter()
                     .map(|p| p.to_string_lossy().to_string())
                     .collect::<Vec<_>>()
@@ -205,7 +207,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     )?;
 
     // EPOCHREALTIME
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "EPOCHREALTIME",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |_shell| {
@@ -220,7 +222,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     )?;
 
     // EPOCHSECONDS
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "EPOCHSECONDS",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |_shell| {
@@ -238,11 +240,11 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     if let Ok(euid) = sys::users::get_effective_uid() {
         let mut euid_var = ShellVariable::new(ShellValue::String(format!("{euid}")));
         euid_var.treat_as_integer().set_readonly();
-        shell.env.set_global("EUID", euid_var)?;
+        shell.env_mut().set_global("EUID", euid_var)?;
     }
 
     // FUNCNAME
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "FUNCNAME",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| get_funcname_value(shell),
@@ -253,7 +255,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     // GROUPS
     // N.B. We could compute this up front, but we choose to make it dynamic so that we
     // don't have to make costly system calls if the user never accesses it.
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "GROUPS",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |_shell| {
@@ -276,13 +278,13 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
         setter: |_| (),
     });
     histcmd_var.treat_as_integer();
-    shell.env.set_global("HISTCMD", histcmd_var)?;
+    shell.env_mut().set_global("HISTCMD", histcmd_var)?;
 
     // HISTFILE (if not already set)
-    if !shell.env.is_set("HISTFILE") {
+    if !shell.env().is_set("HISTFILE") {
         if let Some(home_dir) = shell.home_dir() {
             let histfile = home_dir.join(".brush_history");
-            shell.env.set_global(
+            shell.env_mut().set_global(
                 "HISTFILE",
                 ShellVariable::new(ShellValue::String(histfile.to_string_lossy().to_string())),
             )?;
@@ -290,7 +292,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     }
 
     // HOSTNAME
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "HOSTNAME",
         ShellVariable::new(
             sys::network::get_hostname()
@@ -301,16 +303,18 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     )?;
 
     // HOSTTYPE
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "HOSTTYPE",
         ShellVariable::new(std::env::consts::ARCH.to_string()),
     )?;
 
     // IFS
-    shell.env.set_global("IFS", ShellVariable::new(" \t\n"))?;
+    shell
+        .env_mut()
+        .set_global("IFS", ShellVariable::new(" \t\n"))?;
 
     // LINENO
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "LINENO",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| get_lineno(shell).to_string().into(),
@@ -320,24 +324,26 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
 
     // MACHTYPE
     shell
-        .env
+        .env_mut()
         .set_global("MACHTYPE", ShellVariable::new(BASH_MACHINE))?;
 
     // OLDPWD (initialization)
-    if !shell.env.is_set("OLDPWD") {
+    if !shell.env().is_set("OLDPWD") {
         let mut oldpwd_var =
             ShellVariable::new(ShellValue::Unset(variables::ShellValueUnsetType::Untyped));
         oldpwd_var.export();
-        shell.env.set_global("OLDPWD", oldpwd_var)?;
+        shell.env_mut().set_global("OLDPWD", oldpwd_var)?;
     }
 
     // OPTERR
-    shell.env.set_global("OPTERR", ShellVariable::new("1"))?;
+    shell
+        .env_mut()
+        .set_global("OPTERR", ShellVariable::new("1"))?;
 
     // OPTIND
     let mut optind_var = ShellVariable::new("1");
     optind_var.treat_as_integer();
-    shell.env.set_global("OPTIND", optind_var)?;
+    shell.env_mut().set_global("OPTIND", optind_var)?;
 
     // OSTYPE
     let os_type = match std::env::consts::OS {
@@ -346,26 +352,26 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
         _ => "unknown",
     };
     shell
-        .env
+        .env_mut()
         .set_global("OSTYPE", ShellVariable::new(os_type))?;
 
     // PATH (if not already set)
-    if !shell.env.is_set("PATH") {
+    if !shell.env().is_set("PATH") {
         let default_path_str = sys::fs::get_default_executable_search_paths().join(":");
         shell
-            .env
+            .env_mut()
             .set_global("PATH", ShellVariable::new(default_path_str))?;
     }
 
     // PIPESTATUS
     // TODO(well-known-vars): Investigate what happens if this gets unset.
     // TODO(well-known-vars): Investigate if this needs to be saved/preserved across prompt display.
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "PIPESTATUS",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| {
                 ShellValue::indexed_array_from_strings(
-                    shell.last_pipeline_statuses.iter().map(|s| s.to_string()),
+                    shell.last_pipeline_statuses().iter().map(|s| s.to_string()),
                 )
             },
             setter: |_| (),
@@ -376,7 +382,7 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     if let Some(ppid) = sys::terminal::get_parent_process_id() {
         let mut ppid_var = ShellVariable::new(ppid.to_string());
         ppid_var.treat_as_integer().set_readonly();
-        shell.env.set_global("PPID", ppid_var)?;
+        shell.env_mut().set_global("PPID", ppid_var)?;
     }
 
     // RANDOM
@@ -385,10 +391,10 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
         setter: |_| (),
     });
     random_var.treat_as_integer();
-    shell.env.set_global("RANDOM", random_var)?;
+    shell.env_mut().set_global("RANDOM", random_var)?;
 
     // SECONDS
-    shell.env.set_global(
+    shell.env_mut().set_global(
         "SECONDS",
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| {
@@ -405,10 +411,10 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     )?;
 
     // SHELL (if not already set)
-    if !shell.env.is_set("SHELL") {
+    if !shell.env().is_set("SHELL") {
         // Per docs, this should be the user's default login shell -- not the current shell.
         if let Some(default_shell) = sys::users::get_current_user_default_shell() {
-            shell.env.set_global(
+            shell.env_mut().set_global(
                 "SHELL",
                 ShellVariable::new(default_shell.to_string_lossy().to_string()),
             )?;
@@ -417,18 +423,18 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
 
     // SHELLOPTS
     let mut shellopts_var = ShellVariable::new(ShellValue::Dynamic {
-        getter: |shell| shell.options.seto_optstr().into(),
+        getter: |shell| shell.options().seto_optstr().into(),
         setter: |_| (),
     });
     shellopts_var.set_readonly();
-    shell.env.set_global("SHELLOPTS", shellopts_var)?;
+    shell.env_mut().set_global("SHELLOPTS", shellopts_var)?;
 
     // SHLVL
     let input_shlvl = shell.env_str("SHLVL").unwrap_or_else(|| "0".into());
     let updated_shlvl = input_shlvl.as_ref().parse::<u32>().unwrap_or(0) + 1;
     let mut shlvl_var = ShellVariable::new(updated_shlvl.to_string());
     shlvl_var.export();
-    shell.env.set_global("SHLVL", shlvl_var)?;
+    shell.env_mut().set_global("SHLVL", shlvl_var)?;
 
     // SRANDOM
     let mut random_var = ShellVariable::new(ShellValue::Dynamic {
@@ -436,24 +442,28 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
         setter: |_| (),
     });
     random_var.treat_as_integer();
-    shell.env.set_global("SRANDOM", random_var)?;
+    shell.env_mut().set_global("SRANDOM", random_var)?;
 
     // PS1 / PS2
-    if shell.options.interactive {
-        if !shell.env.is_set("PS1") {
+    if shell.options().interactive {
+        if !shell.env().is_set("PS1") {
             shell
-                .env
+                .env_mut()
                 .set_global("PS1", ShellVariable::new(r"\s-\v\$ "))?;
         }
 
-        if !shell.env.is_set("PS2") {
-            shell.env.set_global("PS2", ShellVariable::new("> "))?;
+        if !shell.env().is_set("PS2") {
+            shell
+                .env_mut()
+                .set_global("PS2", ShellVariable::new("> "))?;
         }
     }
 
     // PS4
-    if !shell.env.is_set("PS4") {
-        shell.env.set_global("PS4", ShellVariable::new("+ "))?;
+    if !shell.env().is_set("PS4") {
+        shell
+            .env_mut()
+            .set_global("PS4", ShellVariable::new("+ "))?;
     }
 
     //
@@ -466,13 +476,13 @@ pub(crate) fn init_well_known_vars(shell: &mut Shell) -> Result<(), error::Error
     let pwd = shell.working_dir().to_string_lossy().to_string();
     let mut pwd_var = ShellVariable::new(pwd);
     pwd_var.export();
-    shell.env.set_global("PWD", pwd_var)?;
+    shell.env_mut().set_global("PWD", pwd_var)?;
 
     // UID
     if let Ok(uid) = sys::users::get_current_uid() {
         let mut uid_var = ShellVariable::new(ShellValue::String(format!("{uid}")));
         uid_var.treat_as_integer().set_readonly();
-        shell.env.set_global("UID", uid_var)?;
+        shell.env_mut().set_global("UID", uid_var)?;
     }
 
     Ok(())

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -108,7 +108,7 @@ impl<'a, IB: InputBackend> InteractiveShell<'a, IB> {
     pub async fn run_interactively(&mut self) -> Result<(), ShellError> {
         let mut shell = self.shell.lock().await;
 
-        let mut announce_exit = shell.options.interactive;
+        let mut announce_exit = shell.options().interactive;
 
         shell.start_interactive_session()?;
 
@@ -144,7 +144,7 @@ impl<'a, IB: InputBackend> InteractiveShell<'a, IB> {
                 }
             }
 
-            if self.shell.lock().await.options.exit_after_one_command {
+            if self.shell.lock().await.options().exit_after_one_command {
                 announce_exit = false;
                 break;
             }
@@ -425,7 +425,7 @@ impl<'a, IB: InputBackend> InteractiveShell<'a, IB> {
     ) -> Result<(), ShellError> {
         // Save (and later restore) the last exit status.
         let prev_last_result = shell.last_exit_status();
-        let prev_last_pipeline_statuses = shell.last_pipeline_statuses.clone();
+        let prev_last_pipeline_statuses = shell.last_pipeline_statuses().to_vec();
 
         // Run the command.
         let params = shell.default_exec_params();
@@ -433,7 +433,7 @@ impl<'a, IB: InputBackend> InteractiveShell<'a, IB> {
         shell.run_string(prompt_cmd, &source_info, &params).await?;
 
         // Restore the last exit status.
-        shell.last_pipeline_statuses = prev_last_pipeline_statuses;
+        *shell.last_pipeline_statuses_mut() = prev_last_pipeline_statuses;
         shell.set_last_exit_status(prev_last_result);
 
         Ok(())

--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -303,7 +303,7 @@ impl<'a> StyledInputLine<'a> {
     ) -> CommandType {
         if self.shell.is_keyword(name) {
             return CommandType::Keyword;
-        } else if self.shell.aliases.contains_key(name) {
+        } else if self.shell.aliases().contains_key(name) {
             return CommandType::Alias;
         } else if self.shell.funcs().get(name).is_some() {
             return CommandType::Function;

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -356,7 +356,7 @@ fn instantiate_shell_from_file(
 
     // NOTE: We need to manually register builtins because we can't serialize/deserialize them.
     // TODO(serde): we should consider whether we could/should at least track *which* are enabled.
-    let builtin_set = if shell.options.sh_mode {
+    let builtin_set = if shell.options().sh_mode {
         brush_builtins::BuiltinSet::ShMode
     } else {
         brush_builtins::BuiltinSet::BashMode

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -74,7 +74,7 @@ impl TestShellWithBashCompletion {
 
     pub fn set_var(&mut self, name: &str, value: &str) -> Result<()> {
         self.shell
-            .env
+            .env_mut()
             .set_global(name, brush_core::ShellVariable::new(value))?;
         Ok(())
     }
@@ -101,7 +101,10 @@ async fn complete_relative_file_path() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn complete_relative_file_path_ignoring_case() -> Result<()> {
     let mut test_shell = TestShellWithBashCompletion::new().await?;
-    test_shell.shell.options.case_insensitive_pathname_expansion = true;
+    test_shell
+        .shell
+        .options_mut()
+        .case_insensitive_pathname_expansion = true;
 
     // Create file and dir.
     test_shell.temp_dir.child("ITEM1").touch()?;


### PR DESCRIPTION
This addresses some technical debt with the `Shell` struct -- it makes it fully opaque. This will aid further work to extract some of the functionality of `Shell` into a trait that would allow some consuming code to be made a bit more generic (and more testable with synthetic/fake/test implementations).