### PR TITLE
fix: compat fixes for \[ and \] in prompt expansion

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -1378,7 +1378,12 @@ impl Shell {
         self.last_pipeline_statuses = prev_last_pipeline_statuses;
         self.set_last_exit_status(prev_last_result);
 
-        result
+        // Strip out special characters that readline would typically drop:
+        // \001 and \002 (start and end of non-printing sequences).
+        let mut expanded = result?;
+        expanded.retain(|c| c != '\x01' && c != '\x02');
+
+        Ok(expanded)
     }
 
     fn parameter_or_default<'a>(&'a self, name: &str, default: &'a str) -> Cow<'a, str> {

--- a/brush-shell/tests/cases/prompt.yaml
+++ b/brush-shell/tests/cases/prompt.yaml
@@ -186,3 +186,15 @@ cases:
       PS1='$(echo Hello)> '
       false
       echo $?
+
+  - name: "Brackets and var"
+    stdin: |
+      prompt='\[$var\]\u > '
+      echo "Prompt: ${prompt@P}"
+
+  - name: "Brackets and var (interactive mode)"
+    args: ["-i"]
+    ignore_stderr: true
+    stdin: |
+      prompt='\[$var\]\u > '
+      echo "Prompt: ${prompt@P}"


### PR DESCRIPTION
Resolves #906