### PR TITLE
feat: add convenience cmd line option to set up xtrace

### DIFF
--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -303,6 +303,10 @@ pub enum ErrorKind {
     /// History file is too large to import.
     #[error("history file is too large to import")]
     HistoryFileTooLargeToImport,
+
+    /// Too many open files.
+    #[error("too many open files")]
+    TooManyOpenFiles,
 }
 
 impl BuiltinError for Error {}

--- a/brush-interactive/src/error.rs
+++ b/brush-interactive/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 /// Represents an error encountered while running or otherwise managing an interactive shell.
 #[derive(thiserror::Error, Debug)]
 pub enum ShellError {
@@ -8,6 +10,10 @@ pub enum ShellError {
     /// A generic I/O error occurred.
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
+
+    /// Failed to create xtrace file.
+    #[error("failed to create xtrace file '{0}': {1}")]
+    FailedToCreateXtraceFile(PathBuf, std::io::Error),
 
     /// An error occurred while reading input.
     #[error("input error occurred: {0}")]

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -166,6 +166,10 @@ pub struct CommandLineArgs {
     #[clap(short = 'x', help_heading = HEADING_STANDARD_OPTIONS)]
     pub print_commands_and_arguments: bool,
 
+    /// Enable xtrace and configure for the given output file.
+    #[clap(long = "xtrace-file", value_name = "FILE", help_heading = HEADING_UI_OPTIONS)]
+    pub xtrace_file_path: Option<PathBuf>,
+
     /// Disable bracketed paste.
     #[clap(long = "disable-bracketed-paste", help_heading = HEADING_UI_OPTIONS)]
     pub disable_bracketed_paste: bool,


### PR DESCRIPTION
This adds a command-line option `--xtrace-file` to `brush` that automates setting up `set -x` style tracing to an output file, including:

* Opening the file for writing (always truncating if existing)
* Injecting the file into the shell's file descriptor table
* Initializing `BASH_XTRACEFD` to the file descriptor (before any init/rc scripts run in the shell)