### PR TITLE
fix: shadowing special builtins with funcs

### DIFF
--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -307,6 +307,13 @@ pub enum ErrorKind {
     /// Too many open files.
     #[error("too many open files")]
     TooManyOpenFiles,
+
+    /// The function name shadows a special built-in command.
+    #[error("function name '{}' shadows a special built-in command", .name)]
+    FunctionNameShadowsSpecialBuiltin {
+        /// Name of the function.
+        name: String,
+    },
 }
 
 impl BuiltinError for Error {}
@@ -340,6 +347,7 @@ impl From<&ErrorKind> for results::ExecutionExitCode {
             ErrorKind::FunctionParseError(..) => Self::InvalidUsage,
             ErrorKind::TestCommandParseError(..) => Self::InvalidUsage,
             ErrorKind::FailedToExecuteCommand(..) => Self::CannotExecute,
+            ErrorKind::FunctionNameShadowsSpecialBuiltin { .. } => Self::InvalidUsage,
             ErrorKind::BuiltinError(inner, ..) => inner.as_exit_code(),
             _ => Self::GeneralError,
         }

--- a/brush-shell/tests/cases/compat/errors.yaml
+++ b/brush-shell/tests/cases/compat/errors.yaml
@@ -347,6 +347,34 @@ cases:
       exec 0<&-
       echo "after closing stdin"
 
+  - name: "Failing special built-in (non-POSIX mode, non-interactive)"
+    ignore_stderr: true
+    stdin: |
+      . ./non-existent-file
+      echo "after builtin call (status $?)"
+
+  - name: "Failing special built-in (non-POSIX mode, interactive)"
+    args: ["-i"]
+    ignore_stderr: true
+    stdin: |
+      . ./non-existent-file
+      echo "after builtin call (status $?)"
+
+  - name: "Failing special built-in (POSIX mode, non-interactive)"
+    ignore_stderr: true
+    stdin: |
+      set -o posix
+      . ./non-existent-file
+      echo "after builtin call (status $?)"
+
+  - name: "Failing special built-in (POSIX mode, interactive)"
+    args: ["-i"]
+    ignore_stderr: true
+    stdin: |
+      set -o posix
+      . ./non-existent-file
+      echo "after builtin call (status $?)"
+
   - name: "errexit with failing command (non-interactive)"
     stdin: |
       set -e

--- a/brush-shell/tests/cases/compat/functions.yaml
+++ b/brush-shell/tests/cases/compat/functions.yaml
@@ -108,3 +108,28 @@ cases:
       }
 
       my/func
+
+  - name: "Functions shadowing builtins"
+    stdin: |
+      .() {
+          echo "In custom dot function"
+      }
+
+      echo "Func result: $?"
+
+      .
+      echo "Call result: $?"
+
+  - name: "Functions shadowing builtins (POSIX mode)"
+    ignore_stderr: true
+    stdin: |
+      set -o posix
+
+      .() {
+          echo "In custom dot function"
+      }
+
+      echo "Func result: $?"
+
+      .
+      echo "Call result: $?"


### PR DESCRIPTION
Fixes related to special builtins:

* Correctly honor POSIX mode for disallowing shadowing a builtin.
* Update our command execution logic to allow functions to shadow special builtins in non-POSIX mode.
* Ensure that, in POSIX mode, errors in special builtins are considered fatal for the shell.

Fixes #920 