### PR TITLE
fix: ignore errors in tracing

### DIFF
--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -36,10 +36,6 @@ pub enum EvalError {
     #[error("failed to parse expression: {0}")]
     ParseError(String),
 
-    /// Failed to trace an arithmetic expression.
-    #[error("failed tracing expression")]
-    TraceError,
-
     /// Error expanding an unset variable.
     #[error("expanding unset variable: {0}")]
     ExpandingUnsetVariable(String),
@@ -102,8 +98,7 @@ pub(crate) async fn expand_and_eval(
     if trace_if_needed && shell.options().print_commands_and_arguments {
         shell
             .trace_command(params, std::format!("(( {expr} ))"))
-            .await
-            .map_err(|_err| EvalError::TraceError)?;
+            .await;
     }
 
     // Now evaluate.

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -61,7 +61,7 @@ async fn apply_unary_predicate(
                     escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
                 ),
             )
-            .await?;
+            .await;
     }
 
     apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell, params)
@@ -209,7 +209,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {s} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             let (matches, captures) = match regex.matches(s.as_str()) {
@@ -248,7 +248,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left == right)
@@ -260,7 +260,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left != right)
@@ -272,7 +272,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {s} {op} {substring} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(s.contains(substring.as_str()))
@@ -284,7 +284,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             files_refer_to_same_device_and_inode_numbers(shell, left, right)
@@ -296,7 +296,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             left_file_is_newer_or_exists_when_right_does_not(shell, left, right)
@@ -308,7 +308,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             left_file_is_older_or_does_not_exist_when_right_does(shell, left, right)
@@ -320,7 +320,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             // TODO(test): According to docs, should be lexicographical order of the current locale.
@@ -333,7 +333,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             // TODO(test): According to docs, should be lexicographical order of the current locale.
@@ -348,7 +348,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left == right)
@@ -362,7 +362,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left != right)
@@ -376,7 +376,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left < right)
@@ -390,7 +390,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left <= right)
@@ -404,7 +404,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left > right)
@@ -418,7 +418,7 @@ async fn apply_binary_predicate(
             if shell.options().print_commands_and_arguments {
                 shell
                     .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
+                    .await;
             }
 
             Ok(left >= right)
@@ -443,7 +443,7 @@ async fn apply_binary_predicate(
                 );
                 shell
                     .trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
-                    .await?;
+                    .await;
             }
 
             pattern.exactly_matches(s.as_str())
@@ -463,7 +463,7 @@ async fn apply_binary_predicate(
                 );
                 shell
                     .trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
-                    .await?;
+                    .await;
             }
 
             let eq = pattern.exactly_matches(s.as_str())?;

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -714,11 +714,11 @@ impl Execute for ast::ForClauseCommand {
                                 unexpanded_values.iter().join(" ")
                             ),
                         )
-                        .await?;
+                        .await;
                 } else {
                     shell
                         .trace_command(params, std::format!("for {}", self.variable_name,))
-                        .await?;
+                        .await;
                 }
             }
 
@@ -762,7 +762,7 @@ impl Execute for ast::CaseClauseCommand {
         if shell.options().print_commands_and_arguments {
             shell
                 .trace_command(params, std::format!("case {} in", &self.value))
-                .await?;
+                .await;
         }
 
         let expanded_value = expansion::basic_expand_word(shell, params, &self.value).await?;
@@ -1248,7 +1248,7 @@ async fn execute_command(
                 &params,
                 args.iter().map(|arg| arg.quote_for_tracing()).join(" "),
             )
-            .await?;
+            .await;
     }
 
     guard.detach();
@@ -1408,7 +1408,7 @@ async fn apply_assignment(
         let op = if assignment.append { "+=" } else { "=" };
         shell
             .trace_command(params, std::format!("{}{op}{new_value}", assignment.name))
-            .await?;
+            .await;
     }
 
     // See if we need to eval an array index.

--- a/brush-shell/tests/cases/compat/options/bash_xtracefd.yaml
+++ b/brush-shell/tests/cases/compat/options/bash_xtracefd.yaml
@@ -69,3 +69,16 @@ cases:
 
       set -x
       echo "should go to stderr"
+
+  - name: "redirect to file that fails writes"
+    stdin: |
+      # This test relies on /dev/full being present. We degrade gracefully
+      # if it doesn't.
+      [[ -e /dev/full ]] || exit
+
+      exec 3>/dev/full
+      BASH_XTRACEFD=3
+
+      set -x
+      echo "first echo"
+      echo "first echo result: $?"


### PR DESCRIPTION
Updates `brush-core` to silently ignore `-x` style tracing errors, matching `bash`'s behavior.

Resolves #927 