### PR TITLE
Fix minimal input backend to handle multi-line continuation

### DIFF
--- a/brush-interactive/src/minimal/input_backend.rs
+++ b/brush-interactive/src/minimal/input_backend.rs
@@ -87,7 +87,7 @@ impl MinimalInputBackend {
 
     fn display_prompt(&self, prompt: &str) -> Result<(), ShellError> {
         if self.should_display_prompt() {
-            eprint!("{}", prompt);
+            eprint!("{prompt}");
             std::io::stderr().flush()?;
         }
 

--- a/brush-interactive/src/minimal/input_backend.rs
+++ b/brush-interactive/src/minimal/input_backend.rs
@@ -12,35 +12,82 @@ pub struct MinimalInputBackend;
 impl InputBackend for MinimalInputBackend {
     fn read_line(
         &mut self,
-        _shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
+        shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
         prompt: InteractivePrompt,
     ) -> Result<ReadResult, ShellError> {
-        self.display_prompt(&prompt)?;
+        self.display_prompt(&prompt.prompt)?;
 
-        let result = match Self::read_input_line()? {
-            ReadResult::Input(s) => s,
-            ReadResult::BoundCommand(s) => s,
-            ReadResult::Eof => return Ok(ReadResult::Eof),
-            ReadResult::Interrupted => return Ok(ReadResult::Interrupted),
-        };
+        let mut input = String::new();
 
-        if result.is_empty() {
+        loop {
+            let line = match Self::read_input_line()? {
+                ReadResult::Input(s) => s,
+                ReadResult::BoundCommand(s) => s,
+                ReadResult::Eof => {
+                    // If we have accumulated input, return it; otherwise EOF
+                    if input.is_empty() {
+                        return Ok(ReadResult::Eof);
+                    }
+                    break;
+                }
+                ReadResult::Interrupted => return Ok(ReadResult::Interrupted),
+            };
+
+            if line.is_empty() {
+                if input.is_empty() {
+                    return Ok(ReadResult::Eof);
+                }
+                break;
+            }
+
+            input.push_str(&line);
+
+            // Check if the input is complete by trying to parse it
+            if Self::is_input_complete(shell_ref, &input) {
+                break;
+            }
+
+            // Input is incomplete, show continuation prompt and read more
+            self.display_prompt(&prompt.continuation_prompt)?;
+        }
+
+        if input.is_empty() {
             Ok(ReadResult::Eof)
         } else {
-            Ok(ReadResult::Input(result))
+            Ok(ReadResult::Input(input))
         }
     }
 }
 
 impl MinimalInputBackend {
+    /// Check if the input is syntactically complete (not waiting for more input)
+    fn is_input_complete(
+        shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
+        input: &str,
+    ) -> bool {
+        let shell = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(shell_ref.lock())
+        });
+
+        match shell.parse_string(input.to_owned()) {
+            Err(brush_parser::ParseError::Tokenizing { inner, position: _ })
+                if inner.is_incomplete() =>
+            {
+                false
+            }
+            Err(brush_parser::ParseError::ParsingAtEndOfInput) => false,
+            _ => true,
+        }
+    }
+
     #[expect(clippy::unused_self)]
     fn should_display_prompt(&self) -> bool {
         std::io::stdin().is_terminal()
     }
 
-    fn display_prompt(&self, prompt: &InteractivePrompt) -> Result<(), ShellError> {
+    fn display_prompt(&self, prompt: &str) -> Result<(), ShellError> {
         if self.should_display_prompt() {
-            eprint!("{}", prompt.prompt);
+            eprint!("{}", prompt);
             std::io::stderr().flush()?;
         }
 

--- a/brush-interactive/src/minimal/input_backend.rs
+++ b/brush-interactive/src/minimal/input_backend.rs
@@ -84,6 +84,7 @@ impl MinimalInputBackend {
     }
 
     /// Check if the input is syntactically complete (not waiting for more input)
+    #[cfg(not(target_family = "wasm"))]
     fn is_input_complete(
         shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
         input: &str,
@@ -101,6 +102,16 @@ impl MinimalInputBackend {
             Err(brush_parser::ParseError::ParsingAtEndOfInput) => false,
             _ => true,
         }
+    }
+
+    /// On WASM, block_in_place is not available (no multi-thread runtime),
+    /// so we treat every line as complete (no multi-line continuation).
+    #[cfg(target_family = "wasm")]
+    fn is_input_complete(
+        _shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
+        _input: &str,
+    ) -> bool {
+        true
     }
 
     fn display_prompt(prompt: &str) -> Result<(), ShellError> {

--- a/brush-shell/tests/stdin_tests.rs
+++ b/brush-shell/tests/stdin_tests.rs
@@ -1,0 +1,118 @@
+//! Tests for stdin input handling
+//!
+//! Tests that verify the shell correctly handles multi-line input when
+//! reading from stdin (non-interactive mode).
+
+#![cfg(unix)]
+#![cfg(test)]
+#![allow(clippy::panic_in_result_fn)]
+
+use anyhow::Context;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Test that multi-line input with continuation (e.g., && at end of line) works correctly
+/// when piped to the shell. This tests the minimal input backend's handling of incomplete
+/// commands that span multiple lines.
+#[test]
+fn multiline_continuation_via_stdin() -> anyhow::Result<()> {
+    let shell_path = assert_cmd::cargo::cargo_bin!("brush");
+
+    // Test case: && at end of line requires continuation
+    let mut child = Command::new(&shell_path)
+        .args(["--norc", "--noprofile", "--no-config"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("Failed to spawn brush")?;
+
+    let stdin = child.stdin.as_mut().context("Failed to open stdin")?;
+    stdin.write_all(b"echo one &&\necho two\n")?;
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().context("Failed to wait for brush")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "brush should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("one") && stdout.contains("two"),
+        "Expected 'one' and 'two' in output, got: {}",
+        stdout
+    );
+
+    Ok(())
+}
+
+/// Test that more complex multi-line patterns work correctly via stdin
+#[test]
+fn complex_multiline_via_stdin() -> anyhow::Result<()> {
+    let shell_path = assert_cmd::cargo::cargo_bin!("brush");
+
+    let mut child = Command::new(&shell_path)
+        .args(["--norc", "--noprofile", "--no-config"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("Failed to spawn brush")?;
+
+    // Test: pipe followed by newline, then another command with && and newline
+    let stdin = child.stdin.as_mut().context("Failed to open stdin")?;
+    stdin.write_all(b"echo one | cat\necho two | cat &&\necho three\n")?;
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().context("Failed to wait for brush")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "brush should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("one") && stdout.contains("two") && stdout.contains("three"),
+        "Expected 'one', 'two', and 'three' in output, got: {}",
+        stdout
+    );
+
+    Ok(())
+}
+
+/// Test || continuation works correctly
+#[test]
+fn or_continuation_via_stdin() -> anyhow::Result<()> {
+    let shell_path = assert_cmd::cargo::cargo_bin!("brush");
+
+    let mut child = Command::new(&shell_path)
+        .args(["--norc", "--noprofile", "--no-config"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("Failed to spawn brush")?;
+
+    let stdin = child.stdin.as_mut().context("Failed to open stdin")?;
+    stdin.write_all(b"false ||\necho fallback\n")?;
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().context("Failed to wait for brush")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "brush should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("fallback"),
+        "Expected 'fallback' in output, got: {}",
+        stdout
+    );
+
+    Ok(())
+}

--- a/brush-shell/tests/stdin_tests.rs
+++ b/brush-shell/tests/stdin_tests.rs
@@ -1,7 +1,8 @@
-//! Tests for stdin input handling
+//! Tests for stdin input handling with the minimal input backend.
 //!
-//! Tests that verify the shell correctly handles multi-line input when
-//! reading from stdin (non-interactive mode).
+//! These tests verify multi-line continuation works when reading from stdin.
+//! They explicitly use `--input-backend=minimal` to test the minimal backend's
+//! handling of incomplete commands that span multiple lines.
 
 #![cfg(unix)]
 #![cfg(test)]
@@ -11,108 +12,76 @@ use anyhow::Context;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-/// Test that multi-line input with continuation (e.g., && at end of line) works correctly
-/// when piped to the shell. This tests the minimal input backend's handling of incomplete
-/// commands that span multiple lines.
+struct TestCase {
+    name: &'static str,
+    input: &'static str,
+    expected_words: &'static [&'static str],
+}
+
+const CONTINUATION_TESTS: &[TestCase] = &[
+    TestCase {
+        name: "and_continuation",
+        input: "echo one &&\necho two\n",
+        expected_words: &["one", "two"],
+    },
+    TestCase {
+        name: "or_continuation",
+        input: "false ||\necho fallback\n",
+        expected_words: &["fallback"],
+    },
+    TestCase {
+        name: "pipe_then_and_continuation",
+        input: "echo one | cat\necho two | cat &&\necho three\n",
+        expected_words: &["one", "two", "three"],
+    },
+];
+
+/// Tests that the minimal input backend correctly handles multi-line continuation.
 #[test]
 fn multiline_continuation_via_stdin() -> anyhow::Result<()> {
     let shell_path = assert_cmd::cargo::cargo_bin!("brush");
 
-    // Test case: && at end of line requires continuation
-    let mut child = Command::new(&shell_path)
-        .args(["--norc", "--noprofile", "--no-config"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("Failed to spawn brush")?;
+    for test in CONTINUATION_TESTS {
+        let mut child = Command::new(shell_path)
+            .args([
+                "--norc",
+                "--noprofile",
+                "--no-config",
+                "--input-backend=minimal",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("Failed to spawn brush")?;
 
-    let stdin = child.stdin.as_mut().context("Failed to open stdin")?;
-    stdin.write_all(b"echo one &&\necho two\n")?;
-    drop(child.stdin.take());
+        let stdin = child.stdin.as_mut().context("Failed to open stdin")?;
+        stdin.write_all(test.input.as_bytes())?;
+        drop(child.stdin.take());
 
-    let output = child.wait_with_output().context("Failed to wait for brush")?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
+        let output = child
+            .wait_with_output()
+            .context("Failed to wait for brush")?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
 
-    assert!(
-        output.status.success(),
-        "brush should succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        stdout.contains("one") && stdout.contains("two"),
-        "Expected 'one' and 'two' in output, got: {}",
-        stdout
-    );
+        assert!(
+            output.status.success(),
+            "{}: brush should succeed, stderr: {}",
+            test.name,
+            stderr
+        );
 
-    Ok(())
-}
-
-/// Test that more complex multi-line patterns work correctly via stdin
-#[test]
-fn complex_multiline_via_stdin() -> anyhow::Result<()> {
-    let shell_path = assert_cmd::cargo::cargo_bin!("brush");
-
-    let mut child = Command::new(&shell_path)
-        .args(["--norc", "--noprofile", "--no-config"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("Failed to spawn brush")?;
-
-    // Test: pipe followed by newline, then another command with && and newline
-    let stdin = child.stdin.as_mut().context("Failed to open stdin")?;
-    stdin.write_all(b"echo one | cat\necho two | cat &&\necho three\n")?;
-    drop(child.stdin.take());
-
-    let output = child.wait_with_output().context("Failed to wait for brush")?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    assert!(
-        output.status.success(),
-        "brush should succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        stdout.contains("one") && stdout.contains("two") && stdout.contains("three"),
-        "Expected 'one', 'two', and 'three' in output, got: {}",
-        stdout
-    );
-
-    Ok(())
-}
-
-/// Test || continuation works correctly
-#[test]
-fn or_continuation_via_stdin() -> anyhow::Result<()> {
-    let shell_path = assert_cmd::cargo::cargo_bin!("brush");
-
-    let mut child = Command::new(&shell_path)
-        .args(["--norc", "--noprofile", "--no-config"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("Failed to spawn brush")?;
-
-    let stdin = child.stdin.as_mut().context("Failed to open stdin")?;
-    stdin.write_all(b"false ||\necho fallback\n")?;
-    drop(child.stdin.take());
-
-    let output = child.wait_with_output().context("Failed to wait for brush")?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    assert!(
-        output.status.success(),
-        "brush should succeed, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        stdout.contains("fallback"),
-        "Expected 'fallback' in output, got: {}",
-        stdout
-    );
+        for word in test.expected_words {
+            assert!(
+                stdout.contains(word),
+                "{}: expected '{}' in output, got: {}",
+                test.name,
+                word,
+                stdout
+            );
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
When reading from a non-terminal stdin, the minimal input backend now properly handles incomplete commands that span multiple lines (e.g., commands ending with `&&` or `||`).

Previously, the backend read a single line and passed it directly to the parser, which failed with "syntax error at end of input" for incomplete commands like `echo a &&` followed by `echo b` on the next line.

Now the backend:
1. Reads lines in a loop
2. Checks if the accumulated input parses completely
3. If incomplete (ParsingAtEndOfInput), reads more lines
4. Shows continuation prompt when in terminal mode

Added tests for `&&` continuation, `||` continuation, and complex multi-line patterns with pipes via stdin.