### PR TITLE
fix(*): remove all ref-options

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -510,14 +510,13 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         Ok(String::from(self.basic_expand(word).await?))
     }
 
-    #[expect(clippy::ref_option)]
     async fn basic_expand_opt_pattern(
         &mut self,
-        word: &Option<String>,
+        word: Option<String>,
     ) -> Result<Option<patterns::Pattern>, error::Error> {
         if let Some(word) = word {
             let pattern = self
-                .basic_expand_pattern(word)
+                .basic_expand_pattern(&word)
                 .await?
                 .set_extended_globbing(self.parser_options.enable_extended_globbing);
 
@@ -1106,9 +1105,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
                 transform_expansion(expanded_parameter, async |s| {
-                    patterns::remove_smallest_matching_suffix(s.as_str(), &expanded_pattern)
+                    patterns::remove_smallest_matching_suffix(s.as_str(), expanded_pattern.as_ref())
                         .map(|s| s.to_owned())
                 })
                 .await
@@ -1119,9 +1118,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
                 transform_expansion(expanded_parameter, async |s| {
-                    patterns::remove_largest_matching_suffix(s.as_str(), &expanded_pattern)
+                    patterns::remove_largest_matching_suffix(s.as_str(), expanded_pattern.as_ref())
                         .map(|s| s.to_owned())
                 })
                 .await
@@ -1132,10 +1131,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
 
                 transform_expansion(expanded_parameter, async |s| {
-                    patterns::remove_smallest_matching_prefix(s.as_str(), &expanded_pattern)
+                    patterns::remove_smallest_matching_prefix(s.as_str(), expanded_pattern.as_ref())
                         .map(|s| s.to_owned())
                 })
                 .await
@@ -1146,10 +1145,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
 
                 transform_expansion(expanded_parameter, async |s| {
-                    patterns::remove_largest_matching_prefix(s.as_str(), &expanded_pattern)
+                    patterns::remove_largest_matching_prefix(s.as_str(), expanded_pattern.as_ref())
                         .map(|s| s.to_owned())
                 })
                 .await
@@ -1308,10 +1307,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
 
                 transform_expansion(expanded_parameter, async |s| {
-                    Self::uppercase_first_char(s, &expanded_pattern)
+                    Self::uppercase_first_char(s, expanded_pattern.as_ref())
                 })
                 .await
             }
@@ -1321,10 +1320,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
 
                 transform_expansion(expanded_parameter, async |s| {
-                    Self::uppercase_pattern(s.as_str(), &expanded_pattern)
+                    Self::uppercase_pattern(s.as_str(), expanded_pattern.as_ref())
                 })
                 .await
             }
@@ -1334,10 +1333,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
 
                 transform_expansion(expanded_parameter, async |s| {
-                    Self::lowercase_first_char(s, &expanded_pattern)
+                    Self::lowercase_first_char(s, expanded_pattern.as_ref())
                 })
                 .await
             }
@@ -1347,10 +1346,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 pattern,
             } => {
                 let expanded_parameter = self.expand_parameter(&parameter, indirect).await?;
-                let expanded_pattern = self.basic_expand_opt_pattern(&pattern).await?;
+                let expanded_pattern = self.basic_expand_opt_pattern(pattern).await?;
 
                 transform_expansion(expanded_parameter, async |s| {
-                    Self::lowercase_pattern(s.as_str(), &expanded_pattern)
+                    Self::lowercase_pattern(s.as_str(), expanded_pattern.as_ref())
                 })
                 .await
             }
@@ -1747,10 +1746,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         Ok(value.to_string())
     }
 
-    #[expect(clippy::ref_option)]
     fn uppercase_first_char(
         s: String,
-        pattern: &Option<patterns::Pattern>,
+        pattern: Option<&patterns::Pattern>,
     ) -> Result<String, error::Error> {
         if let Some(first_char) = s.chars().next() {
             let applicable = if let Some(pattern) = pattern {
@@ -1772,10 +1770,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         Ok(s)
     }
 
-    #[expect(clippy::ref_option)]
     fn lowercase_first_char(
         s: String,
-        pattern: &Option<patterns::Pattern>,
+        pattern: Option<&patterns::Pattern>,
     ) -> Result<String, error::Error> {
         if let Some(first_char) = s.chars().next() {
             let applicable = if let Some(pattern) = pattern {
@@ -1797,10 +1794,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         Ok(s)
     }
 
-    #[expect(clippy::ref_option)]
     fn uppercase_pattern(
         s: &str,
-        pattern: &Option<patterns::Pattern>,
+        pattern: Option<&patterns::Pattern>,
     ) -> Result<String, error::Error> {
         if let Some(pattern) = pattern {
             if !pattern.is_empty() {
@@ -1817,10 +1813,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         }
     }
 
-    #[expect(clippy::ref_option)]
     fn lowercase_pattern(
         s: &str,
-        pattern: &Option<patterns::Pattern>,
+        pattern: Option<&patterns::Pattern>,
     ) -> Result<String, error::Error> {
         if let Some(pattern) = pattern {
             if !pattern.is_empty() {

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -404,10 +404,9 @@ fn pattern_to_regex_str(
 ///
 /// * `s` - The string to remove the prefix from.
 /// * `pattern` - The pattern to match.
-#[expect(clippy::ref_option)]
 pub(crate) fn remove_largest_matching_prefix<'a>(
     s: &'a str,
-    pattern: &Option<Pattern>,
+    pattern: Option<&Pattern>,
 ) -> Result<&'a str, error::Error> {
     if let Some(pattern) = pattern {
         let indices = s.char_indices().rev();
@@ -435,10 +434,9 @@ pub(crate) fn remove_largest_matching_prefix<'a>(
 ///
 /// * `s` - The string to remove the prefix from.
 /// * `pattern` - The pattern to match.
-#[expect(clippy::ref_option)]
 pub(crate) fn remove_smallest_matching_prefix<'a>(
     s: &'a str,
-    pattern: &Option<Pattern>,
+    pattern: Option<&Pattern>,
 ) -> Result<&'a str, error::Error> {
     if let Some(pattern) = pattern {
         let mut indices = s.char_indices();
@@ -464,10 +462,9 @@ pub(crate) fn remove_smallest_matching_prefix<'a>(
 ///
 /// * `s` - The string to remove the suffix from.
 /// * `pattern` - The pattern to match.
-#[expect(clippy::ref_option)]
 pub(crate) fn remove_largest_matching_suffix<'a>(
     s: &'a str,
-    pattern: &Option<Pattern>,
+    pattern: Option<&Pattern>,
 ) -> Result<&'a str, error::Error> {
     if let Some(pattern) = pattern {
         #[allow(
@@ -490,10 +487,9 @@ pub(crate) fn remove_largest_matching_suffix<'a>(
 ///
 /// * `s` - The string to remove the suffix from.
 /// * `pattern` - The pattern to match.
-#[expect(clippy::ref_option)]
 pub(crate) fn remove_smallest_matching_suffix<'a>(
     s: &'a str,
-    pattern: &Option<Pattern>,
+    pattern: Option<&Pattern>,
 ) -> Result<&'a str, error::Error> {
     if let Some(pattern) = pattern {
         #[allow(
@@ -584,27 +580,27 @@ mod tests {
     #[test]
     fn test_remove_largest_matching_prefix() -> Result<()> {
         assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("")))?,
+            remove_largest_matching_prefix("ooof", Some(&Pattern::from("")))?,
             "ooof"
         );
         assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("x")))?,
+            remove_largest_matching_prefix("ooof", Some(&Pattern::from("x")))?,
             "ooof"
         );
         assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("o")))?,
+            remove_largest_matching_prefix("ooof", Some(&Pattern::from("o")))?,
             "oof"
         );
         assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("o*o")))?,
+            remove_largest_matching_prefix("ooof", Some(&Pattern::from("o*o")))?,
             "f"
         );
         assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("o*")))?,
+            remove_largest_matching_prefix("ooof", Some(&Pattern::from("o*")))?,
             ""
         );
         assert_eq!(
-            remove_largest_matching_prefix("🚀🚀🚀rocket", &Some(Pattern::from("🚀")))?,
+            remove_largest_matching_prefix("🚀🚀🚀rocket", Some(&Pattern::from("🚀")))?,
             "🚀🚀rocket"
         );
         Ok(())
@@ -613,31 +609,31 @@ mod tests {
     #[test]
     fn test_remove_smallest_matching_prefix() -> Result<()> {
         assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("")))?,
+            remove_smallest_matching_prefix("ooof", Some(&Pattern::from("")))?,
             "ooof"
         );
         assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("x")))?,
+            remove_smallest_matching_prefix("ooof", Some(&Pattern::from("x")))?,
             "ooof"
         );
         assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o")))?,
+            remove_smallest_matching_prefix("ooof", Some(&Pattern::from("o")))?,
             "oof"
         );
         assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o*o")))?,
+            remove_smallest_matching_prefix("ooof", Some(&Pattern::from("o*o")))?,
             "of"
         );
         assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o*")))?,
+            remove_smallest_matching_prefix("ooof", Some(&Pattern::from("o*")))?,
             "oof"
         );
         assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("ooof")))?,
+            remove_smallest_matching_prefix("ooof", Some(&Pattern::from("ooof")))?,
             ""
         );
         assert_eq!(
-            remove_smallest_matching_prefix("🚀🚀🚀rocket", &Some(Pattern::from("🚀")))?,
+            remove_smallest_matching_prefix("🚀🚀🚀rocket", Some(&Pattern::from("🚀")))?,
             "🚀🚀rocket"
         );
         Ok(())
@@ -646,27 +642,27 @@ mod tests {
     #[test]
     fn test_remove_largest_matching_suffix() -> Result<()> {
         assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("")))?,
+            remove_largest_matching_suffix("foo", Some(&Pattern::from("")))?,
             "foo"
         );
         assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("x")))?,
+            remove_largest_matching_suffix("foo", Some(&Pattern::from("x")))?,
             "foo"
         );
         assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("o")))?,
+            remove_largest_matching_suffix("foo", Some(&Pattern::from("o")))?,
             "fo"
         );
         assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("o*")))?,
+            remove_largest_matching_suffix("foo", Some(&Pattern::from("o*")))?,
             "f"
         );
         assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("foo")))?,
+            remove_largest_matching_suffix("foo", Some(&Pattern::from("foo")))?,
             ""
         );
         assert_eq!(
-            remove_largest_matching_suffix("rocket🚀🚀🚀", &Some(Pattern::from("🚀")))?,
+            remove_largest_matching_suffix("rocket🚀🚀🚀", Some(&Pattern::from("🚀")))?,
             "rocket🚀🚀"
         );
         Ok(())
@@ -675,31 +671,31 @@ mod tests {
     #[test]
     fn test_remove_smallest_matching_suffix() -> Result<()> {
         assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("")))?,
+            remove_smallest_matching_suffix("fooo", Some(&Pattern::from("")))?,
             "fooo"
         );
         assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("x")))?,
+            remove_smallest_matching_suffix("fooo", Some(&Pattern::from("x")))?,
             "fooo"
         );
         assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o")))?,
+            remove_smallest_matching_suffix("fooo", Some(&Pattern::from("o")))?,
             "foo"
         );
         assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o*o")))?,
+            remove_smallest_matching_suffix("fooo", Some(&Pattern::from("o*o")))?,
             "fo"
         );
         assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o*")))?,
+            remove_smallest_matching_suffix("fooo", Some(&Pattern::from("o*")))?,
             "foo"
         );
         assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("fooo")))?,
+            remove_smallest_matching_suffix("fooo", Some(&Pattern::from("fooo")))?,
             ""
         );
         assert_eq!(
-            remove_smallest_matching_suffix("rocket🚀🚀🚀", &Some(Pattern::from("🚀")))?,
+            remove_smallest_matching_suffix("rocket🚀🚀🚀", Some(&Pattern::from("🚀")))?,
             "rocket🚀🚀"
         );
         Ok(())

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -457,8 +457,8 @@ impl<SE: extensions::ShellExtensions> ShellState for Shell<SE> {
     }
 
     /// Returns the shell's official version string (if available).
-    pub fn version(&self) -> &Option<String> {
-        &self.version
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
     }
 
     /// Returns the exit status of the last command executed in this shell.
@@ -473,8 +473,8 @@ impl<SE: extensions::ShellExtensions> ShellState for Shell<SE> {
     }
 
     /// Returns the key bindings helper for the shell.
-    pub fn key_bindings(&self) -> &Option<KeyBindingsHelper> {
-        &self.key_bindings
+    pub fn key_bindings(&self) -> Option<&KeyBindingsHelper> {
+        self.key_bindings.as_ref()
     }
 
     /// Sets the key bindings helper for the shell.
@@ -494,8 +494,8 @@ impl<SE: extensions::ShellExtensions> ShellState for Shell<SE> {
     }
 
     /// Returns the product display name for this shell.
-    pub fn product_display_str(&self) -> &Option<String> {
-        &self.product_display_str
+    pub fn product_display_str(&self) -> Option<&str> {
+        self.product_display_str.as_deref()
     }
 }
 

--- a/brush-core/src/shell/state.rs
+++ b/brush-core/src/shell/state.rs
@@ -98,7 +98,7 @@ pub trait ShellState {
     fn history_mut(&mut self) -> Option<&mut crate::history::History>;
 
     /// Returns the shell's official version string (if available).
-    fn version(&self) -> &Option<String>;
+    fn version(&self) -> Option<&str>;
 
     /// Returns the exit status of the last command executed in this shell.
     fn last_exit_status(&self) -> u8;
@@ -107,7 +107,7 @@ pub trait ShellState {
     fn set_last_exit_status(&mut self, status: u8);
 
     /// Returns the key bindings helper for the shell.
-    fn key_bindings(&self) -> &Option<KeyBindingsHelper>;
+    fn key_bindings(&self) -> Option<&KeyBindingsHelper>;
 
     /// Sets the key bindings helper for the shell.
     fn set_key_bindings(&mut self, key_bindings: Option<KeyBindingsHelper>);
@@ -120,5 +120,5 @@ pub trait ShellState {
     fn working_dir_mut(&mut self) -> &mut PathBuf;
 
     /// Returns the product display name for this shell.
-    fn product_display_str(&self) -> &Option<String>;
+    fn product_display_str(&self) -> Option<&str>;
 }

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -55,7 +55,7 @@ pub(crate) fn inherit_env_vars(
 pub(crate) fn init_well_known_vars(
     shell: &mut Shell<impl extensions::ShellExtensions>,
 ) -> Result<(), error::Error> {
-    let shell_version = shell.version().clone();
+    let shell_version = shell.version().map(ToString::to_string);
     shell.env_mut().set_global(
         "BRUSH_VERSION",
         ShellVariable::new(shell_version.unwrap_or_default()),


### PR DESCRIPTION
This should be more optimized for memory layouts and is just general practice.