### PR TITLE
fix: correctly handle pipe errors in builtins

### DIFF
--- a/brush-builtins/src/printf.rs
+++ b/brush-builtins/src/printf.rs
@@ -104,10 +104,13 @@ fn format_via_uucore(
         for item in &format_items {
             let control_flow = item
                 .write(&mut writer, &mut format_args_wrapper)
-                .map_err(|e| {
-                    Error::from(ErrorKind::PrintfInvalidUsage(std::format!(
-                        "printf formatting error: {e}"
-                    )))
+                .map_err(|e| match e {
+                    // Propagate I/O errors directly so they can be handled appropriately
+                    format::FormatError::IoError(io_err) => Error::from(io_err),
+                    // Wrap other format errors
+                    other => Error::from(ErrorKind::PrintfInvalidUsage(std::format!(
+                        "printf formatting error: {other}"
+                    ))),
                 })?;
 
             if control_flow == ControlFlow::Break(()) {

--- a/brush-core/src/results.rs
+++ b/brush-core/src/results.rs
@@ -143,6 +143,8 @@ pub enum ExecutionExitCode {
     NotFound,
     /// Indicates execution was interrupted.
     Interrupted,
+    /// Indicates a broken pipe (SIGPIPE) was encountered.
+    BrokenPipe,
     /// Indicates unimplemented functionality was encountered.
     Unimplemented,
     /// A custom exit code.
@@ -166,6 +168,7 @@ impl From<u8> for ExecutionExitCode {
             126 => Self::CannotExecute,
             127 => Self::NotFound,
             130 => Self::Interrupted,
+            141 => Self::BrokenPipe,
             code => Self::Custom(code),
         }
     }
@@ -187,6 +190,7 @@ impl From<&ExecutionExitCode> for u8 {
             ExecutionExitCode::CannotExecute => 126,
             ExecutionExitCode::NotFound => 127,
             ExecutionExitCode::Interrupted => 130,
+            ExecutionExitCode::BrokenPipe => 141,
             ExecutionExitCode::Custom(code) => *code,
         }
     }

--- a/brush-shell/tests/cases/compat/pipeline.yaml
+++ b/brush-shell/tests/cases/compat/pipeline.yaml
@@ -51,6 +51,10 @@ cases:
       foo() { cat dfgdfg; } |& wc -l
 
   - name: "Possible broken pipe case"
-    skip: true # TODO(pipeline): look into suppressing error?
     stdin: |
       echo hello | var=value
+
+  - name: "printf broken pipe returns 141 in PIPESTATUS"
+    stdin: |
+      printf '%s\n' {0..10000} | x=1
+      echo "Last: $?, PIPESTATUS: ${PIPESTATUS[*]}"


### PR DESCRIPTION
This should, among other things, resolve some of the flaky tests we've seen very recently. Those were cases where a pipe error was *sometimes* getting returned by the `printf` builtin.