### PR TITLE
feat(xtask): convenience options for bash-completion test execution

### DIFF
--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -147,12 +147,12 @@ pub struct BashCompletionArgs {
     list: bool,
 
     /// Filter tests by name pattern (passed to pytest -k).
-    /// Supports pytest expression syntax, e.g., "test_alias", "test_alias and test_1".
+    /// Supports pytest expression syntax, e.g., `"test_alias"`, `"test_alias and test_1"`.
     #[clap(long, short = 't')]
     test_filter: Option<String>,
 
     /// Run only specific test file(s). Can be specified multiple times.
-    /// Example: -f test_alias.py -f test_bash.py
+    /// Example: `-f test_alias.py -f test_bash.py`
     #[clap(long, short = 'f')]
     file: Vec<String>,
 


### PR DESCRIPTION
Add new flags for more flexible test execution:

- --list: List available tests without running them
- -t/--test-filter: Filter tests by name pattern (pytest -k)
- -f/--file: Run specific test file(s)
- -x/--stop-on-first: Stop on first failure

Also make JSON reporting and parallel execution optional:
- JSON output now requires explicit --output flag
- Use -j 1 to disable parallel execution (for systems without pytest-xdist)