### PR TITLE
feat: scaffolding for winnow parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "utf8-chars",
+ "winnow",
 ]
 
 [[package]]
@@ -4129,6 +4130,9 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [features]
 default = []
 serde = ["dep:serde", "brush-parser/serde", "rpds/serde", "chrono/serde"]
+experimental-parser = ["brush-parser/winnow-parser"]
 
 [dependencies]
 async-recursion = "1.1.1"

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -45,8 +45,8 @@ mod wellknownvars;
 /// Re-export parser types used in core definitions.
 pub mod parser {
     pub use brush_parser::{
-        BindingParseError, ParseError, SourcePosition, SourcePositionOffset, SourceSpan,
-        TestCommandParseError, WordParseError, ast,
+        BindingParseError, ParseError, ParserImpl, SourcePosition, SourcePositionOffset,
+        SourceSpan, TestCommandParseError, WordParseError, ast,
     };
 }
 

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -134,6 +134,10 @@ pub struct Shell<SE: extensions::ShellExtensions = extensions::DefaultShellExten
     /// Last "SECONDS" offset requested.
     last_stopwatch_offset: u32,
 
+    /// Parser implementation to use.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    parser_impl: crate::parser::ParserImpl,
+
     /// Key bindings for the shell, optionally implemented by an interactive shell.
     #[cfg_attr(feature = "serde", serde(skip))]
     key_bindings: Option<KeyBindingsHelper>,
@@ -168,6 +172,7 @@ impl<SE: extensions::ShellExtensions> Clone for Shell<SE> {
             program_location_cache: self.program_location_cache.clone(),
             last_stopwatch_time: self.last_stopwatch_time,
             last_stopwatch_offset: self.last_stopwatch_offset,
+            parser_impl: self.parser_impl,
             key_bindings: self.key_bindings.clone(),
             history: self.history.clone(),
             depth: self.depth + 1,
@@ -209,6 +214,7 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
             product_display_str: options.shell_product_display_str,
             working_dir: options.working_dir.map_or_else(std::env::current_dir, Ok)?,
             builtins: options.builtins,
+            parser_impl: options.parser,
             key_bindings: options.key_bindings,
             ..Self::default()
         };

--- a/brush-core/src/shell/builder.rs
+++ b/brush-core/src/shell/builder.rs
@@ -212,6 +212,9 @@ pub struct CreateOptions<SE: extensions::ShellExtensions = extensions::DefaultSh
     /// Whether to print verbose output.
     #[builder(default)]
     pub verbose: bool,
+    /// Parser implementation to use.
+    #[builder(default)]
+    pub parser: crate::parser::ParserImpl,
     /// Whether the shell is in command string mode (-c).
     #[builder(default)]
     pub command_string_mode: bool,
@@ -250,6 +253,7 @@ impl<SE: extensions::ShellExtensions> Default for Shell<SE> {
             program_location_cache: pathcache::PathCache::default(),
             last_stopwatch_time: std::time::SystemTime::now(),
             last_stopwatch_offset: 0,
+            parser_impl: crate::parser::ParserImpl::default(),
             key_bindings: None,
             history: None,
         }

--- a/brush-core/src/shell/parsing.rs
+++ b/brush-core/src/shell/parsing.rs
@@ -39,7 +39,7 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
             sh_mode: self.options.sh_mode,
             tilde_expansion_at_word_start: true,
             tilde_expansion_after_colon: false,
-            parser_impl: brush_parser::ParserImpl::Peg,
+            parser_impl: self.parser_impl,
         }
     }
 }

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -22,6 +22,7 @@ arbitrary = ["dep:arbitrary"]
 debug-tracing = ["peg/trace"]
 diagnostics = ["dep:miette"]
 serde = ["dep:serde"]
+winnow-parser = ["dep:winnow"]
 
 [dependencies]
 arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
@@ -37,6 +38,7 @@ serde = { version = "1.0.228", optional = true, features = ["derive", "rc"] }
 thiserror = "2.0.18"
 tracing = "0.1.44"
 utf8-chars = "3.0.6"
+winnow = { version = "0.7.14", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.3.4", features = ["wasm_js"] }
@@ -45,7 +47,7 @@ uuid = { version = "1.20.0", features = ["js"] }
 [dev-dependencies]
 anyhow = "1.0.100"
 criterion = { version = "0.8.1", features = ["html_reports"] }
-insta = { version = "1.46.2", features = ["glob", "ron", "yaml"] }
+insta = { version = "1.46.2", features = ["glob", "ron", "yaml", "redactions"] }
 miette = { version = "7.6.0", features = ["fancy"] }
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/brush-parser/benches/parser.rs
+++ b/brush-parser/benches/parser.rs
@@ -1,11 +1,15 @@
 //! Benchmarks for the brush-parser crate.
+//!
+//! Compares parsing approaches:
+//! 1. PEG parser (tokenize + peg parse)
+//! 2. `Winnow_str` parser (direct string parse) - when winnow-parser feature enabled
 
 #![allow(missing_docs)]
 #![allow(clippy::unwrap_used)]
 
 #[cfg(unix)]
 mod unix {
-    use brush_parser::{Token, parse_tokens};
+    use brush_parser::Token;
     use criterion::Criterion;
 
     fn uncached_tokenize(content: &str) -> Vec<brush_parser::Token> {
@@ -18,8 +22,21 @@ mod unix {
             .unwrap()
     }
 
-    fn parse(tokens: &[Token]) -> brush_parser::ast::Program {
-        parse_tokens(tokens, &brush_parser::ParserOptions::default()).unwrap()
+    fn parse_peg(tokens: &[Token]) -> brush_parser::ast::Program {
+        brush_parser::parse_tokens(tokens, &brush_parser::ParserOptions::default()).unwrap()
+    }
+
+    #[cfg(feature = "winnow-parser")]
+    fn parse_winnow_str(content: &str) -> brush_parser::ast::Program {
+        use brush_parser::{ParserOptions, SourceInfo, winnow_str};
+        winnow_str::parse_program(content, &ParserOptions::default(), &SourceInfo::default())
+            .unwrap()
+    }
+
+    // Combined tokenize + parse functions for full pipeline comparison
+    fn tokenize_and_parse_peg(content: &str) -> brush_parser::ast::Program {
+        let tokens = uncached_tokenize(content);
+        parse_peg(&tokens)
     }
 
     const SAMPLE_SCRIPT: &str = r#"
@@ -28,35 +45,223 @@ for f in A B C; do
 done
 "#;
 
+    const SIMPLE_SCRIPT: &str = "echo hello world";
+
+    const PIPELINE_SCRIPT: &str = "cat file.txt | grep pattern | wc -l";
+
+    const COMPLEX_SCRIPT: &str = r#"
+#!/bin/bash
+# Complex script with multiple constructs
+
+function process_file() {
+    local file="$1"
+    if [[ -f "$file" ]]; then
+        while read -r line; do
+            case "$line" in
+                start*)
+                    echo "Starting: $line"
+                    ;;
+                end*)
+                    echo "Ending: $line"
+                    ;;
+                *)
+                    echo "Processing: $line"
+                    ;;
+            esac
+        done < "$file"
+    fi
+}
+
+for i in {1..10}; do
+    if (( i % 2 == 0 )); then
+        echo "$i is even" | tee -a output.txt
+    else
+        echo "$i is odd" >> output.txt
+    fi
+done
+
+process_file "input.txt" && echo "Success" || echo "Failed"
+"#;
+
+    const NESTED_EXPANSIONS_SCRIPT: &str = r"
+# Script with deeply nested expansions (tests balanced delimiter parsing)
+result=$(echo $(echo $((1 + (2 * (3 - 4))))))
+fallback=${foo:-${bar:-${baz}}}
+arithmetic=$((1 + (2 * (3 + (4 - 5)))))
+command_subst=$(ls $(pwd))
+mixed=$(echo $((1 + 2)) | cat)
+backtick=`echo (nested parens)`
+";
+
+    // Extended test expression benchmarks - various patterns
+    #[allow(dead_code)]
+    const EXTENDED_TEST_SIMPLE: &str = "[[ -f file.txt ]]";
+    #[allow(dead_code)]
+    const EXTENDED_TEST_BINARY: &str = "[[ $a == $b ]]";
+    #[allow(dead_code)]
+    const EXTENDED_TEST_REGEX: &str = "[[ $str =~ ^[0-9]+$ ]]";
+    #[allow(dead_code)]
+    const EXTENDED_TEST_COMPLEX_REGEX: &str = "[[ $input =~ ^(foo|bar)[0-9]+(baz|qux)$ ]]";
+    #[allow(dead_code)]
+    const EXTENDED_TEST_LOGICAL: &str = "[[ -f file.txt && -r file.txt || -w other.txt ]]";
+    #[allow(dead_code)]
+    const EXTENDED_TEST_NESTED: &str = "[[ ( -f $file && -r $file ) || ( -d $dir && -x $dir ) ]]";
+    #[allow(dead_code)]
+    const EXTENDED_TEST_COMPLEX: &str =
+        "[[ ! ( $a -eq 5 && $b -gt 10 ) || ( $c =~ pattern && -f $file ) ]]";
+
     fn benchmark_parsing_script_using_caches(c: &mut Criterion, script_path: &std::path::Path) {
         let contents = std::fs::read_to_string(script_path).unwrap();
+        let filename = script_path.file_name().unwrap().to_string_lossy();
 
-        c.bench_function(
-            std::format!(
-                "parse_{}",
-                script_path.file_name().unwrap().to_string_lossy()
-            )
-            .as_str(),
-            |b| b.iter(|| parse(&cacheable_tokenize(contents.as_str()))),
-        );
+        c.bench_function(std::format!("parse_peg_{filename}").as_str(), |b| {
+            b.iter(|| parse_peg(&cacheable_tokenize(contents.as_str())));
+        });
     }
 
     pub(crate) fn criterion_benchmark(c: &mut Criterion) {
         const POSSIBLE_BASH_COMPLETION_SCRIPT_PATH: &str =
             "/usr/share/bash-completion/bash_completion";
 
+        // Tokenization benchmark (applies to both parsers)
         c.bench_function("tokenize_sample_script", |b| {
             b.iter(|| uncached_tokenize(SAMPLE_SCRIPT));
         });
 
-        let tokens = uncached_tokenize(SAMPLE_SCRIPT);
-        c.bench_function("parse_sample_script", |b| b.iter(|| parse(&tokens)));
+        // Simple script benchmarks
+        let simple_tokens = uncached_tokenize(SIMPLE_SCRIPT);
+        c.bench_function("parse_peg_simple", |b| b.iter(|| parse_peg(&simple_tokens)));
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("parse_winnow_str_simple", |b| {
+            b.iter(|| parse_winnow_str(SIMPLE_SCRIPT));
+        });
 
+        // Pipeline script benchmarks
+        let pipeline_tokens = uncached_tokenize(PIPELINE_SCRIPT);
+        c.bench_function("parse_peg_pipeline", |b| {
+            b.iter(|| parse_peg(&pipeline_tokens));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("parse_winnow_str_pipeline", |b| {
+            b.iter(|| parse_winnow_str(PIPELINE_SCRIPT));
+        });
+
+        // Sample script (for loop) benchmarks
+        let sample_tokens = uncached_tokenize(SAMPLE_SCRIPT);
+        c.bench_function("parse_peg_for_loop", |b| {
+            b.iter(|| parse_peg(&sample_tokens));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("parse_winnow_str_for_loop", |b| {
+            b.iter(|| parse_winnow_str(SAMPLE_SCRIPT));
+        });
+
+        // Complex script benchmarks
+        let complex_tokens = uncached_tokenize(COMPLEX_SCRIPT);
+        c.bench_function("parse_peg_complex", |b| {
+            b.iter(|| parse_peg(&complex_tokens));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("parse_winnow_str_complex", |b| {
+            b.iter(|| parse_winnow_str(COMPLEX_SCRIPT));
+        });
+
+        // Real-world bash completion script (if available)
         let well_known_complicated_script =
             std::path::PathBuf::from(POSSIBLE_BASH_COMPLETION_SCRIPT_PATH);
 
         if well_known_complicated_script.exists() {
             benchmark_parsing_script_using_caches(c, &well_known_complicated_script);
+        }
+
+        // ========================================================================
+        // FULL PIPELINE BENCHMARKS (tokenize + parse)
+        // ========================================================================
+        // These benchmarks measure the complete parsing pipeline from string to AST,
+        // allowing fair comparison between different approaches:
+        // - tokenize_and_parse_peg: Legacy tokenizer + PEG parser
+        // - parse_winnow_str: Direct string parsing (no separate tokenization)
+
+        // Simple script full pipeline
+        c.bench_function("full_peg_simple", |b| {
+            b.iter(|| tokenize_and_parse_peg(SIMPLE_SCRIPT));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("full_winnow_str_simple", |b| {
+            b.iter(|| parse_winnow_str(SIMPLE_SCRIPT));
+        });
+
+        // Pipeline script full pipeline
+        c.bench_function("full_peg_pipeline", |b| {
+            b.iter(|| tokenize_and_parse_peg(PIPELINE_SCRIPT));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("full_winnow_str_pipeline", |b| {
+            b.iter(|| parse_winnow_str(PIPELINE_SCRIPT));
+        });
+
+        // For loop full pipeline
+        c.bench_function("full_peg_for_loop", |b| {
+            b.iter(|| tokenize_and_parse_peg(SAMPLE_SCRIPT));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("full_winnow_str_for_loop", |b| {
+            b.iter(|| parse_winnow_str(SAMPLE_SCRIPT));
+        });
+
+        // Complex script full pipeline
+        c.bench_function("full_peg_complex", |b| {
+            b.iter(|| tokenize_and_parse_peg(COMPLEX_SCRIPT));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("full_winnow_str_complex", |b| {
+            b.iter(|| parse_winnow_str(COMPLEX_SCRIPT));
+        });
+
+        // Nested expansions (balanced delimiter parsing stress test)
+        c.bench_function("full_peg_nested_expansions", |b| {
+            b.iter(|| tokenize_and_parse_peg(NESTED_EXPANSIONS_SCRIPT));
+        });
+        #[cfg(feature = "winnow-parser")]
+        c.bench_function("full_winnow_str_nested_expansions", |b| {
+            b.iter(|| parse_winnow_str(NESTED_EXPANSIONS_SCRIPT));
+        });
+
+        // ========================================================================
+        // EXTENDED TEST EXPRESSION BENCHMARKS
+        // ========================================================================
+        // Benchmarks for the refactored extended test ([[ ]]) parser
+        // Tests various patterns: simple, binary, regex, logical operators, nesting
+
+        #[cfg(feature = "winnow-parser")]
+        {
+            c.bench_function("extended_test_simple", |b| {
+                b.iter(|| parse_winnow_str(EXTENDED_TEST_SIMPLE));
+            });
+
+            c.bench_function("extended_test_binary", |b| {
+                b.iter(|| parse_winnow_str(EXTENDED_TEST_BINARY));
+            });
+
+            c.bench_function("extended_test_regex", |b| {
+                b.iter(|| parse_winnow_str(EXTENDED_TEST_REGEX));
+            });
+
+            c.bench_function("extended_test_complex_regex", |b| {
+                b.iter(|| parse_winnow_str(EXTENDED_TEST_COMPLEX_REGEX));
+            });
+
+            c.bench_function("extended_test_logical", |b| {
+                b.iter(|| parse_winnow_str(EXTENDED_TEST_LOGICAL));
+            });
+
+            c.bench_function("extended_test_nested", |b| {
+                b.iter(|| parse_winnow_str(EXTENDED_TEST_NESTED));
+            });
+
+            c.bench_function("extended_test_complex", |b| {
+                b.iter(|| parse_winnow_str(EXTENDED_TEST_COMPLEX));
+            });
         }
     }
 }

--- a/brush-parser/src/lib.rs
+++ b/brush-parser/src/lib.rs
@@ -26,7 +26,10 @@ pub use error::{
 #[cfg(feature = "diagnostics")]
 pub use error::miette::PrettyError;
 
-pub use parser::{Parser, ParserBuilder, ParserImpl, ParserOptions, parse_tokens};
+#[cfg(feature = "winnow-parser")]
+pub use parser::winnow_str;
+pub use parser::{Parser, ParserBuilder, ParserImpl, ParserOptions, SourceInfo, parse_tokens};
+
 pub use source::{SourcePosition, SourcePositionOffset, SourceSpan};
 pub use tokenizer::{
     Token, TokenLocation, TokenizerError, TokenizerOptions, tokenize_str,

--- a/brush-parser/src/parser/tests/mod.rs
+++ b/brush-parser/src/parser/tests/mod.rs
@@ -18,11 +18,14 @@ use crate::ast::Program;
 use crate::error::ParseError;
 use crate::parser::{Parser, ParserImpl, ParserOptions};
 use anyhow::Result;
+#[cfg(feature = "winnow-parser")]
+use serde_json::Value;
 
+/// Wrapper struct for serializing parse results with input context
 #[derive(serde::Serialize)]
-struct ParseResult<'a, T> {
-    input: &'a str,
-    result: &'a T,
+pub struct ParseResult<'a, T> {
+    pub input: &'a str,
+    pub result: &'a T,
 }
 
 /// Macro to assert snapshots with location information redacted.
@@ -36,6 +39,79 @@ macro_rules! assert_snapshot_redacted {
             insta::assert_ron_snapshot!($value);
         });
     }};
+}
+
+/// Recursively redact location fields from a JSON value.
+/// This normalizes AST representations for comparison by removing source location info.
+#[cfg(feature = "winnow-parser")]
+fn redact_locations(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            // Remove location-related fields
+            map.remove("loc");
+            // Also handle tuple structs that store SourceSpan as positional element
+            // These appear as arrays with SourceSpan objects
+
+            // Recursively process remaining fields
+            for (_, v) in map.iter_mut() {
+                // If this value is a SourceSpan object, normalize it
+                if is_source_span(v) {
+                    normalize_source_span(v);
+                } else {
+                    redact_locations(v);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            // Check if this array looks like a tuple struct containing SourceSpan at the end
+            // SourceSpan has: start: SourcePosition, end: SourcePosition
+            // SourcePosition has: index, line, column
+            if let Some(last) = arr.last() {
+                if is_source_span(last) {
+                    arr.pop();
+                }
+            }
+
+            for item in arr.iter_mut() {
+                redact_locations(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Check if a value looks like a `SourceSpan` object
+#[cfg(feature = "winnow-parser")]
+fn is_source_span(value: &Value) -> bool {
+    if let Value::Object(map) = value {
+        map.contains_key("start") && map.contains_key("end") && map.len() == 2
+    } else {
+        false
+    }
+}
+
+/// Normalize a `SourceSpan` object by replacing its positions with placeholder values.
+/// This allows comparing ASTs without position differences.
+#[cfg(feature = "winnow-parser")]
+fn normalize_source_span(value: &mut Value) {
+    if let Value::Object(map) = value {
+        let placeholder_pos = serde_json::json!({
+            "index": 0,
+            "line": 0,
+            "column": 0
+        });
+        map.insert("start".to_string(), placeholder_pos.clone());
+        map.insert("end".to_string(), placeholder_pos);
+    }
+}
+
+/// Convert a Program to a normalized JSON value with locations redacted
+#[cfg(feature = "winnow-parser")]
+#[allow(clippy::expect_used)]
+fn normalize_ast(program: &Program) -> Value {
+    let mut value = serde_json::to_value(program).expect("Failed to serialize Program to JSON");
+    redact_locations(&mut value);
+    value
 }
 
 /// A named parser configuration for test output clarity
@@ -55,18 +131,70 @@ pub fn parser_configs() -> Vec<ParserConfig> {
         parser_impl: ParserImpl::Peg,
     }];
 
+    #[cfg(feature = "winnow-parser")]
+    configs.push(ParserConfig {
+        name: "winnow",
+        parser_impl: ParserImpl::Winnow,
+    });
+
     configs
 }
 
 /// Helper to parse input with a specific parser configuration
 pub fn parse_with_config(input: &str, config: &ParserConfig) -> Result<Program, ParseError> {
     let options = ParserOptions {
-        parser_impl: config.parser_impl.clone(),
+        parser_impl: config.parser_impl,
         ..Default::default()
     };
 
     let mut parser = Parser::new(std::io::Cursor::new(input), &options);
     parser.parse_program()
+}
+
+/// Verify all parser implementations produce the same result.
+///
+/// This function parses the input with each available parser and verifies
+/// they all produce structurally equivalent ASTs. Returns an error if
+/// parsing fails or if the results differ.
+#[cfg(feature = "winnow-parser")]
+#[allow(dead_code)]
+pub fn test_all_parsers_match(input: &str) -> Result<()> {
+    let configs = parser_configs();
+
+    // Parse with each configuration
+    let mut results: Vec<(&str, Program)> = Vec::new();
+
+    for config in &configs {
+        let result = parse_with_config(input, config).map_err(|e| {
+            anyhow::anyhow!(
+                "Parser '{}' failed to parse input: {}\nInput: {}",
+                config.name,
+                e,
+                input
+            )
+        })?;
+        results.push((config.name, result));
+    }
+
+    // Compare all results against the first (peg) implementation
+    // Normalize ASTs by redacting location info before comparison
+    if results.len() > 1 {
+        let (base_name, base_result) = &results[0];
+        let base_normalized = normalize_ast(base_result);
+        for (name, result) in results.iter().skip(1) {
+            let result_normalized = normalize_ast(result);
+            pretty_assertions::assert_eq!(
+                base_normalized,
+                result_normalized,
+                "Parser outputs differ between '{}' and '{}'.\nInput: {}",
+                base_name,
+                name,
+                input
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// Run a test and create snapshot for peg parser (canonical implementation).
@@ -83,9 +211,32 @@ pub fn test_with_snapshot(input: &str) -> Result<Program> {
     let peg_result = parse_with_config(input, &peg_config)
         .map_err(|e| anyhow::anyhow!("Peg parser failed: {e}\nInput: {input}"))?;
 
+    // When winnow is enabled, verify it matches (ignoring location differences)
+    #[cfg(feature = "winnow-parser")]
+    {
+        let winnow_config = ParserConfig {
+            name: "winnow",
+            parser_impl: ParserImpl::Winnow,
+        };
+        let winnow_result = parse_with_config(input, &winnow_config)
+            .map_err(|e| anyhow::anyhow!("Winnow parser failed: {e}\nInput: {input}"))?;
+
+        // Normalize both ASTs by redacting location info before comparison
+        let peg_normalized = normalize_ast(&peg_result);
+        let winnow_normalized = normalize_ast(&winnow_result);
+
+        pretty_assertions::assert_eq!(
+            peg_normalized,
+            winnow_normalized,
+            "Parser outputs differ between 'peg' and 'winnow'.\nInput: {}",
+            input
+        );
+    }
+
     Ok(peg_result)
 }
 
+#[cfg(test)]
 mod harness_tests {
     use super::*;
 
@@ -94,6 +245,14 @@ mod harness_tests {
         let configs = parser_configs();
         assert!(!configs.is_empty());
         assert_eq!(configs[0].name, "peg");
+    }
+
+    #[test]
+    #[cfg(feature = "winnow-parser")]
+    fn test_parser_configs_includes_winnow() {
+        let configs = parser_configs();
+        assert!(configs.len() >= 2);
+        assert!(configs.iter().any(|c| c.name == "winnow"));
     }
 
     #[test]

--- a/brush-parser/src/parser/winnow_str.rs
+++ b/brush-parser/src/parser/winnow_str.rs
@@ -1,0 +1,20 @@
+//! String-based winnow parser
+
+use winnow::error::ContextError;
+
+use crate::ast;
+use crate::parser::{ParserOptions, SourceInfo};
+
+/// Type alias for parser error
+type PError = winnow::error::ErrMode<ContextError>;
+
+/// Parse a shell program from a string with full source location tracking
+///
+/// This is not yet implemented.
+pub fn parse_program(
+    _input: &str,
+    _options: &ParserOptions,
+    _source_info: &SourceInfo,
+) -> Result<ast::Program, PError> {
+    unimplemented!("winnow string parser is not yet implemented")
+}

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -54,9 +54,17 @@ default = ["basic", "reedline", "minimal"]
 basic = ["brush-interactive/basic"]
 minimal = ["brush-interactive/minimal"]
 reedline = ["brush-interactive/reedline"]
-experimental = ["experimental-builtins", "experimental-load"]
+experimental = [
+    "experimental-builtins",
+    "experimental-load",
+    "experimental-parser",
+]
 experimental-builtins = ["dep:brush-experimental-builtins"]
 experimental-load = ["dep:serde_json", "brush-core/serde"]
+experimental-parser = [
+    "brush-core/experimental-parser",
+    "brush-parser/winnow-parser",
+]
 schema = ["dep:schemars"]
 
 [lints]

--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -182,6 +182,11 @@ pub struct CommandLineArgs {
     #[clap(long = "enable-highlighting", help_heading = HEADING_UI_OPTIONS, default_value_t = crate::entry::DEFAULT_ENABLE_HIGHLIGHTING)]
     pub enable_highlighting: bool,
 
+    /// Enable experimental parser (not ready for use).
+    #[cfg(feature = "experimental-parser")]
+    #[clap(long = "experimental-parser", help_heading = HEADING_EXPERIMENTAL_OPTIONS)]
+    pub experimental_parser: bool,
+
     /// Enable terminal integration (**experimental**).
     #[clap(long = "enable-terminal-integration", help_heading = HEADING_EXPERIMENTAL_OPTIONS)]
     pub terminal_shell_integration: bool,

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -63,6 +63,11 @@ fn create_test_shell_config(options: &TestOptions, oracle_name: &str) -> ShellCo
         default_args.insert(0, "--sh".into());
     }
 
+    // Add any additional brush args specified.
+    options.brush_args.split_whitespace().for_each(|arg| {
+        default_args.push(arg.into());
+    });
+
     ShellConfig {
         which: WhichShell::ShellUnderTest(PathBuf::from(&options.brush_path)),
         default_args,

--- a/brush-shell/tests/integration_tests.rs
+++ b/brush-shell/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use std::path::{Path, PathBuf};
 
 fn create_test_shell_config(options: &TestOptions) -> ShellConfig {
-    let default_args = vec![
+    let mut default_args = vec![
         "--norc".into(),
         "--noprofile".into(),
         "--no-config".into(),
@@ -21,6 +21,11 @@ fn create_test_shell_config(options: &TestOptions) -> ShellConfig {
         "--disable-bracketed-paste".into(),
         "--disable-color".into(),
     ];
+
+    // Add any additional brush args specified.
+    options.brush_args.split_whitespace().for_each(|arg| {
+        default_args.push(arg.into());
+    });
 
     ShellConfig {
         which: WhichShell::ShellUnderTest(PathBuf::from(&options.brush_path)),

--- a/brush-test-harness/src/config.rs
+++ b/brush-test-harness/src/config.rs
@@ -203,6 +203,10 @@ pub struct TestOptions {
     #[clap(long = "brush-path", default_value = "", env = "BRUSH_PATH")]
     pub brush_path: String,
 
+    /// Optionally specify additional arguments for brush.
+    #[clap(long = "brush-args", default_value = "", env = "BRUSH_ARGS")]
+    pub brush_args: String,
+
     /// Optionally specify path to test cases.
     #[clap(long = "test-cases-path", env = "BRUSH_TEST_CASES")]
     pub test_cases_path: Option<PathBuf>,

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -114,7 +114,7 @@ fn check_unused_deps(sh: &Shell, verbose: bool) -> Result<()> {
 
 fn check_build(sh: &Shell, verbose: bool) -> Result<()> {
     eprintln!("Checking that code compiles...");
-    let mut args = vec!["check", "--all-features", "--all-targets"];
+    let mut args = vec!["check", "--all-features", "--all-targets", "--workspace"];
     if verbose {
         args.push("--verbose");
         eprintln!("Running: cargo {}", args.join(" "));


### PR DESCRIPTION
Scaffolding for the winnow parser without an implementation body (yet).

@lu-zero I took your latest changes, stripped out the actual parser implementation, leaving just the scaffolding. I also added a runtime command-line option all the way up through `brush-shell` and some new options that would allow us to run our full suite of compat tests against either implementation, e.g.:

```
$ # Run brush shell with the winnow parser
$ cargo run --features=experimental -- --experimental-parser

$ # Run all tests and enable the winnow parser for tests run through our YAML-based test harness
$ BRUSH_ARGS="--experimental-parser" cargo nextest run --features=experimental
```

What do you think about this?

What I'm looking for is to get enough of the scaffolding in first that we can immediately start with an implementation that is 0% compatible and incrementally improve it. With each improvement that's made, we can track progress. Ideally I'd like to update PR CI workflows to run tests with the winnow parser too, but not gate; we can include in the report which percentage of tests are succeeding vs. failing on the winnow parser to track its progress and ensure we're monotonically moving forward.

Once the parser is working well *enough* to use a lot more, but not still not ready to be the *default* we can individually opt into using it by default in an interactive shell via the `--experimental-parser` option (included when compiling with the right features).