### PR TITLE
fix(env): Return None in the get_str on unset vars

### DIFF
--- a/brush-core/src/env.rs
+++ b/brush-core/src/env.rs
@@ -276,7 +276,7 @@ impl ShellEnvironment {
         shell: &Shell<SE>,
     ) -> Option<Cow<'_, str>> {
         self.get(name.as_ref())
-            .map(|(_, v)| v.value().to_cow_str(shell))
+            .and_then(|(_, v)| v.value().try_get_cow_str(shell))
     }
 
     /// Checks if a variable of the given name is set in the environment.


### PR DESCRIPTION
Fixes IFS handling when unset in local scope and potentially makes the HOME fallback more correct.

The get_str method was incorrectly converting unset variables to empty strings instead of returning None. This caused issues with IFS handling where unset IFS variables should fall back to default behavior but were instead treated as empty IFS.