### PR TITLE
fix(test): resolve bash to absolute path before running compat tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "uuid",
  "version-compare",
  "walkdir",
+ "which",
 ]
 
 [[package]]

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -133,6 +133,7 @@ test-with = { version = "0.15.7", default-features = false, features = [
 ] }
 version-compare = "0.2.1"
 walkdir = "2.5.0"
+which = "8.0.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.31.1" }

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -89,6 +89,13 @@ async fn run_compat_tests(mut options: TestOptions) -> Result<bool> {
         ));
     }
 
+    // Resolve bash path to absolute path to avoid issues when env is cleared.
+    if options.bash_path.is_relative() || options.bash_path.as_path() == Path::new("bash") {
+        if let Ok(resolved) = which::which(&options.bash_path) {
+            options.bash_path = resolved;
+        }
+    }
+
     // Resolve test cases directory (now under compat/).
     let test_cases_dir = options.test_cases_path.as_deref().map_or_else(
         || PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/cases/compat"),


### PR DESCRIPTION
When the test harness clears the environment with env_clear(), PATH gets reset which can cause 'bash' to resolve to /bin/bash (macOS system bash 3.2) instead of the expected modern bash from Homebrew.

This fixes many false test failures related to features unsupported in old bash versions (e.g., declare -A for associative arrays).