### PR TITLE
fix: readonly should operate on global scope

### DIFF
--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -244,7 +244,9 @@ impl DeclareCommand {
         verb: DeclareVerb,
     ) -> Result<bool, brush_core::Error> {
         let create_var_local = matches!(verb, DeclareVerb::Local)
-            || (context.shell.in_function() && !self.create_global);
+            || (matches!(verb, DeclareVerb::Declare)
+                && context.shell.in_function()
+                && !self.create_global);
 
         if self.function_names_or_defs_only || self.function_names_only {
             return self.try_display_declaration(context, declaration, verb);

--- a/brush-shell/tests/cases/compat/builtins/readonly.yaml
+++ b/brush-shell/tests/cases/compat/builtins/readonly.yaml
@@ -14,3 +14,13 @@ cases:
 
       echo "Invoking declare -p..."
       declare -p my_var
+
+  - name: "readonly array after append"
+    stdin: |
+      ARR=()
+      f() {
+          ARR+=("a" "b")
+          readonly ARR
+          echo "${#ARR[@]}"
+      }
+      f


### PR DESCRIPTION
In bash, 'readonly VAR' always operates on the global scope, even when called inside a function. Previously, brush was treating 'readonly' like 'declare -r', which creates a local variable.

This fixes the issue where 'readonly ARR' inside a function would create an empty local variable instead of marking the existing global array as readonly.