### PR TITLE
feat(parser): handle inline comments in PEG command substitution

### DIFF
--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -815,7 +815,8 @@ peg::parser! {
         rule unquoted_literal_text_piece<T>(stop_condition: rule<T>, in_command: bool) =
             is_true(in_command) extglob_pattern() /
             is_true(in_command) subshell_command() /
-            !stop_condition() !normal_escape_sequence() !enabled_tilde_expr_after_colon() [^'\'' | '\"' | '$' | '`'] {}
+            is_true(in_command) !stop_condition() !normal_escape_sequence() !enabled_tilde_expr_after_colon() [^'\'' | '\"' | '$' | '`' | '#'] {} /
+            is_false(in_command) !stop_condition() !normal_escape_sequence() !enabled_tilde_expr_after_colon() [^'\'' | '\"' | '$' | '`'] {}
 
         rule enabled_tilde_expr_after_colon() -> WordPiece =
             tilde_exprs_after_colon_enabled() last_char_is_colon() piece:tilde_expression_piece() { piece }
@@ -835,6 +836,7 @@ peg::parser! {
         }}
 
         rule is_true(value: bool) = &[_] {? if value { Ok(()) } else { Err("not true") } }
+        rule is_false(value: bool) = &[_] {? if !value { Ok(()) } else { Err("not false") } }
 
         rule extglob_pattern() =
             ("@" / "!" / "?" / "+" / "*") "(" extglob_body_piece()* ")" {}
@@ -1075,7 +1077,8 @@ peg::parser! {
 
         pub(crate) rule command_piece() -> () =
             word_piece(<[')']>, true /*in_command*/) {} /
-            ([' ' | '\t'])+ {} /
+            ([' ' | '\t' | '\n'])+ {} /
+            "#" [^'\n']* {} /
             ['\'' | '`'] {}
 
         rule backquoted_command() -> String =

--- a/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
@@ -220,3 +220,16 @@ cases:
 
       $($(:))
       echo "exit code: $?"
+
+  - name: "Comment in command substitution without newline fails"
+    known_failure: true
+    stdin: |
+      x=$(echo # must fail)
+
+  - name: "Comment in command substitution with newline"
+    stdin: |
+      x=$(
+        echo "a" # comment with "quote
+        echo "b"
+      )
+      echo "$x"


### PR DESCRIPTION
Exclude '#' from literal text when inside command context and add comment handling to command_piece() rule. This allows comments within
 command substitutions to be properly parsed.