### PR TITLE
feat(parser)!: replace ParsingNearToken with ParsingNear

### DIFF
--- a/brush-interactive/src/basic/input_backend.rs
+++ b/brush-interactive/src/basic/input_backend.rs
@@ -83,12 +83,15 @@ impl BasicInputBackend {
 
     fn is_valid_input(shell: &Shell<impl brush_core::ShellExtensions>, input: &str) -> bool {
         match shell.parse_string(input.to_owned()) {
+            // Incomplete tokenizing (unclosed quotes, etc.) - need more input
             Err(brush_parser::ParseError::Tokenizing { inner, position: _ })
                 if inner.is_incomplete() =>
             {
                 false
             }
+            // Parse error at end of input - could be incomplete
             Err(brush_parser::ParseError::ParsingAtEndOfInput) => false,
+            // Parse error at a specific position OR successful parse - complete
             _ => true,
         }
     }


### PR DESCRIPTION
Breaking change: ParseError::ParsingNearToken(Token) is replaced with ParseError::ParsingNear(SourcePosition).

This decouples parse errors from the Token type, making it easier for any parser (Winnow, PEG, etc.) to report error positions without needing a full token object. The position (line/column) is sufficient for error reporting and interactive input validation.

Benefits:
- Simpler error type (no Token dependency)
- Easier for Winnow parser to report errors
- Interactive backends can distinguish incomplete input from parse errors (ParsingNear = complete but erroneous, ParsingAtEndOfInput = incomplete)