### PR TITLE
fix(expansion): correct descending brace sequence expansion with step

### DIFF
--- a/brush-core/src/braceexpansion.rs
+++ b/brush-core/src/braceexpansion.rs
@@ -35,18 +35,23 @@ fn expand_brace_expr_member(bem: word::BraceExpressionMember) -> Box<dyn Iterato
             end,
             increment,
         } => {
-            let increment = increment.unsigned_abs() as usize;
+            let mut increment = increment.unsigned_abs() as usize;
+            if increment == 0 {
+                increment = 1;
+            }
 
             if start <= end {
                 Box::new((start..=end).step_by(increment).map(|n| n.to_string()))
             } else {
+                // Iterate from start down to end by decrementing.
+                #[allow(clippy::cast_possible_wrap)]
+                let increment = increment as i64;
                 Box::new(
-                    (end..=start)
-                        .step_by(increment)
-                        .map(|n| n.to_string())
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .rev(),
+                    std::iter::successors(Some(start), move |&n| {
+                        let next = n - increment;
+                        (next >= end).then_some(next)
+                    })
+                    .map(|n| n.to_string()),
                 )
             }
         }
@@ -56,18 +61,22 @@ fn expand_brace_expr_member(bem: word::BraceExpressionMember) -> Box<dyn Iterato
             end,
             increment,
         } => {
-            let increment = increment.unsigned_abs() as usize;
+            let mut increment = increment.unsigned_abs() as usize;
+            if increment == 0 {
+                increment = 1;
+            }
 
             if start <= end {
                 Box::new((start..=end).step_by(increment).map(|c| c.to_string()))
             } else {
+                // Iterate from start down to end by decrementing.
+                let increment = increment as u32;
                 Box::new(
-                    (end..=start)
-                        .step_by(increment)
-                        .map(|c| c.to_string())
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .rev(),
+                    std::iter::successors(Some(start), move |&c| {
+                        let next = char::from_u32(c as u32 - increment)?;
+                        (next >= end).then_some(next)
+                    })
+                    .map(|c| c.to_string()),
                 )
             }
         }

--- a/brush-shell/tests/cases/compat/word_expansion/braces.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/braces.yaml
@@ -66,6 +66,14 @@ cases:
       echo {a..f..2}
       echo
 
+      echo "{a..f..0} =>"
+      echo {a..f..0}
+      echo
+
+      echo "{m..f} =>"
+      echo {m..f}
+      echo
+
   - name: "Expansion with curly braces: numeric ranges"
     stdin: |
       echo "{2..9} =>"
@@ -84,6 +92,10 @@ cases:
       echo {2..1}
       echo
 
+      echo "{10..2..0} =>"
+      echo {10..2..0}
+      echo
+
       echo "{10..2..2} =>"
       echo {10..2..2}
       echo
@@ -96,12 +108,20 @@ cases:
       echo {2..9..2}
       echo
 
+      echo "{2..9..0} =>"
+      echo {2..9..0}
+      echo
+
       echo "{-1..-10} =>"
       echo {-1..-10}
       echo
 
       echo "{-10..-1} =>"
       echo {-10..-1}
+      echo
+
+      echo "{-1..-10..2} =>"
+      echo {-1..-10..2}
       echo
 
   - name: "Expansion with curly braces: nested"


### PR DESCRIPTION
Descending sequences like {-1..-10..2} and {z..a..2} started from the wrong end, producing {-2,-4,-6,...} instead of {-1,-3,-5,...}.