### PR TITLE
fix(expansion): preserve quoted empty strings with nullglob enabled

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -2130,6 +2130,30 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test: a quoted empty string `""` must survive word expansion
+    /// even when `nullglob` is enabled.  Previously, `Pattern::expand()` would
+    /// return `NoGlob` for an all-empty pattern, which with nullglob set caused
+    /// `expand_pathnames_in_field` to silently discard the empty-string field.
+    #[tokio::test]
+    async fn test_quoted_empty_string_with_nullglob() -> Result<()> {
+        let mut shell = crate::shell::Shell::builder().build().await?;
+        shell.options_mut().expand_non_matching_patterns_to_null = true; // shopt -s nullglob
+        let params = shell.default_exec_params();
+
+        // Quoted empty string must always produce exactly one empty-string field.
+        assert_eq!(
+            full_expand_and_split_word(&mut shell, &params, "\"\"").await?,
+            vec![""]
+        );
+        // Unquoted empty string (no characters at all) should still produce no fields.
+        assert_eq!(
+            full_expand_and_split_word(&mut shell, &params, "").await?,
+            Vec::<String>::new()
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_brace_expansion() -> Result<()> {
         let mut shell = crate::shell::Shell::builder().build().await?;

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -174,9 +174,12 @@ impl Pattern {
     where
         PF: Fn(&Path) -> bool,
     {
-        // If the pattern is completely empty, then short-circuit the function; there's
-        // no reason to proceed onward when we know there's no expansions.
-        if self.is_empty() {
+        // If the pattern has no pieces at all, short-circuit; there's nothing to expand.
+        // Note: we intentionally do NOT short-circuit when pieces are present but empty
+        // (e.g. from a quoted empty string ""); those fall through to the literal branch
+        // below which correctly returns Expanded([""]) instead of NoGlob, preserving
+        // the argument even when nullglob is enabled.
+        if self.pieces.is_empty() {
             return Ok(PatternExpansionResult::NoGlob);
 
         // Similarly, if we're *confident* the pattern doesn't require expansion, then we

--- a/brush-shell/tests/cases/compat/functions.yaml
+++ b/brush-shell/tests/cases/compat/functions.yaml
@@ -150,3 +150,28 @@ cases:
 
       .
       echo "Call result: $?"
+
+  - name: "Empty string arguments preserved with nullglob"
+    stdin: |
+      shopt -s nullglob
+      
+      myfunc() {
+          echo "arg count: $#"
+          for arg in "$@"; do
+              echo "arg: '$arg'"
+          done
+      }
+      
+      myfunc 3 - 2 "" 1.2.3b_alpha4
+
+  - name: "Multiple empty string arguments"
+    stdin: |
+      myfunc() {
+          echo "count: $#"
+          echo "1: '$1'"
+          echo "2: '$2'"
+          echo "3: '$3'"
+          echo "4: '$4'"
+      }
+      
+      myfunc "" "non-empty" "" "last"


### PR DESCRIPTION
When nullglob (expand_non_matching_patterns_to_null) is enabled, quoted empty strings like "" were incorrectly being dropped during pathname expansion. The Pattern::expand method was short-circuiting on self.is_empty() which returned true for patterns with empty pieces (like a quoted empty string), returning NoGlob instead of Expanded([""]).

Fix by checking self.pieces.is_empty() instead, which only short-circuits when there are truly no pattern pieces, not when pieces exist but are empty strings. This ensures quoted empty strings survive word expansion even with nullglob enabled, matching bash behavior.

Adds regression test and YAML tests for empty string arguments passed to shell functions.