### PR TITLE
fix(commands): use async pipe reads for command substitution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,6 +3242,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -52,6 +52,7 @@ hostname = "0.4.2"
 tokio = { version = "1.49.0", features = [
     "io-util",
     "macros",
+    "net",
     "process",
     "rt",
     "rt-multi-thread",

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -764,20 +764,11 @@ pub(crate) async fn invoke_command_in_subshell_and_get_output(
     let (reader, writer) = std::io::pipe()?;
     params.set_fd(OpenFiles::STDOUT_FD, writer.into());
 
-    // Start the execution of the command, but don't wait for it to
-    // complete. In case the command generates lots of output, we
-    // need to start reading in parallel so the command doesn't block
-    // when the pipe's buffer fills up. We pass ownership of the
-    // subshell and params to run_substitution_command; we must
-    // ensure that they're both dropped by the time this call
-    // returns (so they're not holding onto the write end of the pipe).
-    let cmd_join_handle = tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Handle::current();
-        rt.block_on(run_substitution_command(subshell, params, s))
-    });
+    let mut async_reader = sys::async_pipe::AsyncPipeReader::new(reader)?;
 
-    // Extract output.
-    let output_str = std::io::read_to_string(reader)?;
+    let cmd_join_handle = tokio::spawn(run_substitution_command(subshell, params, s));
+
+    let output_str = async_reader.read_to_string().await?;
 
     // Now observe the command's completion.
     let run_result = cmd_join_handle.await?;

--- a/brush-core/src/sys.rs
+++ b/brush-core/src/sys.rs
@@ -27,6 +27,7 @@ pub mod tokio_process;
 
 pub mod fs;
 
+pub use platform::async_pipe;
 pub use platform::commands;
 pub use platform::fd;
 pub use platform::input;

--- a/brush-core/src/sys/stubs.rs
+++ b/brush-core/src/sys/stubs.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::unused_async)]
 #![allow(clippy::unused_self)]
 
+pub mod async_pipe;
 pub mod commands;
 pub mod fd;
 pub mod fs;

--- a/brush-core/src/sys/stubs/async_pipe.rs
+++ b/brush-core/src/sys/stubs/async_pipe.rs
@@ -1,0 +1,30 @@
+//! Async pipe reading utilities for non-Unix platforms.
+//!
+//! Uses `spawn_blocking` internally for the I/O operation only,
+//! not for the entire subshell execution.
+
+use std::io::{self, Read};
+
+pub(crate) struct AsyncPipeReader {
+    inner: Option<std::io::PipeReader>,
+}
+
+impl AsyncPipeReader {
+    pub(crate) fn new(fd: std::io::PipeReader) -> io::Result<Self> {
+        Ok(Self { inner: Some(fd) })
+    }
+
+    pub(crate) async fn read_to_string(&mut self) -> io::Result<String> {
+        let Some(reader) = self.inner.take() else {
+            return Ok(String::new());
+        };
+
+        tokio::task::spawn_blocking(move || {
+            let mut s = String::new();
+            { reader }.read_to_string(&mut s)?;
+            Ok(s)
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+}

--- a/brush-core/src/sys/unix.rs
+++ b/brush-core/src/sys/unix.rs
@@ -1,3 +1,4 @@
+pub mod async_pipe;
 pub mod commands;
 pub mod fd;
 pub mod fs;

--- a/brush-core/src/sys/unix/async_pipe.rs
+++ b/brush-core/src/sys/unix/async_pipe.rs
@@ -1,0 +1,23 @@
+//! Async pipe reading utilities for Unix.
+
+use std::io;
+use std::os::unix::io::OwnedFd;
+
+use tokio::net::unix::pipe;
+
+pub(crate) struct AsyncPipeReader(pipe::Receiver);
+
+impl AsyncPipeReader {
+    pub(crate) fn new(reader: std::io::PipeReader) -> io::Result<Self> {
+        Ok(Self(pipe::Receiver::from_file(std::fs::File::from(
+            OwnedFd::from(reader),
+        ))?))
+    }
+
+    pub(crate) async fn read_to_string(&mut self) -> io::Result<String> {
+        use tokio::io::AsyncReadExt;
+        let mut s = String::new();
+        self.0.read_to_string(&mut s).await?;
+        Ok(s)
+    }
+}

--- a/brush-core/src/sys/wasm.rs
+++ b/brush-core/src/sys/wasm.rs
@@ -1,3 +1,4 @@
+pub use crate::sys::stubs::async_pipe;
 pub use crate::sys::stubs::commands;
 pub use crate::sys::stubs::fd;
 pub use crate::sys::stubs::fs;

--- a/brush-core/src/sys/windows.rs
+++ b/brush-core/src/sys/windows.rs
@@ -1,3 +1,4 @@
+pub use crate::sys::stubs::async_pipe;
 pub use crate::sys::stubs::commands;
 pub use crate::sys::stubs::fd;
 pub use crate::sys::stubs::fs;


### PR DESCRIPTION
Replace spawn_blocking-based pipe reading with proper async I/O to avoid blocking tokio worker threads during command substitution ().

On Unix, use tokio's AsyncFd with non-blocking pipes for efficient readiness-based polling. On Windows/WASM, use spawn_blocking only for the I/O operation (not the entire subshell), matching tokio's approach.