### PR TITLE
fix(command_subst): strip NULL bytes from command substitutions

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::cmp::min;
+use std::io::Write as _;
 
 use brush_parser::word::{ParameterTransformOp, SubstringMatchKind};
 use itertools::Itertools;
@@ -912,6 +913,15 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 } else {
                     String::new()
                 };
+
+                // Strips null bytes from command substitution output for compatibility.
+                if cmd_output.contains('\0') {
+                    writeln!(
+                        self.params.stderr(self.shell),
+                        "warning: command substitution: ignored null byte in input",
+                    )?;
+                    cmd_output.retain(|c| c != '\0');
+                }
 
                 // We trim trailing newlines, per spec.
                 let trimmed_len = cmd_output.trim_end_matches('\n').len();

--- a/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
@@ -175,6 +175,44 @@ cases:
       $(exec false)
       echo "exit code: $?"
 
+  - name: "Command substitution strips null bytes"
+    ignore_stderr: true
+    stdin: |
+      echo "$(echo -e 'a\x00b')" | hexdump -C
+
+  - name: "Backtick substitution strips null bytes"
+    ignore_stderr: true
+    stdin: |
+      echo "`echo -e 'a\x00b'`" | hexdump -C
+
+  - name: "Command substitution strips multiple null bytes"
+    ignore_stderr: true
+    stdin: |
+      echo "$(echo -e 'hello\x00world\x00end')" | hexdump -C
+
+  - name: "Command substitution with only null bytes produces empty string"
+    ignore_stderr: true
+    stdin: |
+      echo "$(echo -e '\x00\x00\x00')" | hexdump -C
+
+  - name: "Variable assignment from command substitution strips null bytes"
+    ignore_stderr: true
+    stdin: |
+      x=$(echo -e 'a\x00b')
+      echo "$x" | hexdump -C
+
+  - name: "Input redirection substitution strips null bytes"
+    ignore_stderr: true
+    stdin: |
+      printf 'a\x00b' > file.txt
+      x=$(<file.txt)
+      echo "$x" | hexdump -C
+
+  - name: "Nested command substitution strips null bytes"
+    ignore_stderr: true
+    stdin: |
+      echo "$(echo "$(echo -e 'a\x00b')")" | hexdump -C
+
   - name: "Nested command substitution exit code"
     stdin: |
       $($(false))


### PR DESCRIPTION
`bash` strips NULL bytes from the output of a command substitution before including it in the containing command. (It also emits a warning to stderr.)

Resolves #1046.