### PR TITLE
fix(tokenizer): prioritize heredoc body over terminating char in `next_token_until`

### DIFF
--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -751,14 +751,6 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
                 result = state
                     .delimit_current_token(TokenEndReason::EndOfInput, &mut self.cross_state)?;
             //
-            // Look for the specially specified terminating char.
-            //
-            } else if state.unquoted() && terminating_char == Some(c) {
-                result = state.delimit_current_token(
-                    TokenEndReason::SpecifiedTerminatingChar,
-                    &mut self.cross_state,
-                )?;
-            //
             // Handle being in a here document.
             //
             } else if matches!(self.cross_state.here_state, HereState::InHereDocs) {
@@ -782,6 +774,14 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
                         self.remove_here_end_tag(&mut state, &mut result, true)?;
                     }
                 }
+            //
+            // Look for the specially specified terminating char.
+            //
+            } else if state.unquoted() && terminating_char == Some(c) {
+                result = state.delimit_current_token(
+                    TokenEndReason::SpecifiedTerminatingChar,
+                    &mut self.cross_state,
+                )?;
             } else if state.in_operator() {
                 //
                 // We're in an operator. See if this character continues an operator, or if it

--- a/brush-shell/tests/cases/compat/here.yaml
+++ b/brush-shell/tests/cases/compat/here.yaml
@@ -189,7 +189,6 @@ cases:
       EOF
 
   - name: "Here doc in a command substitution with parentheses"
-    known_failure: true # Issue #419
     stdin: |
       test1=$(cat <<EOF
       (something)


### PR DESCRIPTION
Fixes #419

The test case for #419 provides a minimal reproduction:

https://github.com/reubeno/brush/blob/4dbd00362db42fb36bf438d5b118f935e31217a1/brush-shell/tests/cases/compat/here.yaml#L191-L199

The issue is specifically a `)` appearing inside a command substitution causes a premature termination.

The issue is that the **terminating char match** 

https://github.com/reubeno/brush/blob/4dbd00362db42fb36bf438d5b118f935e31217a1/brush-parser/src/tokenizer.rs#L753-L760

Comes before the **HereState::InHereDocs match**

https://github.com/reubeno/brush/blob/4dbd00362db42fb36bf438d5b118f935e31217a1/brush-parser/src/tokenizer.rs#L761-L785

Reversing the order resolves it.

All tests pass when run inside the devcontainer.

---
RE: Contributor Policy

> Please be transparent about your use of AI.


- To be transparent, Claude Code was used to diagnose my issue and it identified this test case as being relevant. 
- It then wrote an incredibly verbose fix which I dismissed and manually reduced to the minimal solution that is included in this PR.

> It also remains your responsibility to review, test, understand, and vouch for all code and content that you submit. Accordingly, you must fully understand all code and other content in your contributions and be able to explain their behavior and purpose.

- I have reviewed, tested and understood the parts of the brush code base I have touched.
- However, I only have a understanding of these narrow areas, not the wider project. I'm therefore trusting that the extensive tests - and maintainer review - ensures that I'm not introducing other issues.
