### PR TITLE
fix(wasm): avoid panic in split_paths on wasm

### DIFF
--- a/brush-core/src/shell/fs.rs
+++ b/brush-core/src/shell/fs.rs
@@ -91,7 +91,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         filename: &'a str,
     ) -> impl Iterator<Item = PathBuf> + 'a {
         let path_var = self.env.get_str("PATH", self).unwrap_or_default();
-        let paths = std::env::split_paths(path_var.as_ref());
+        let paths = crate::sys::fs::split_paths(path_var.as_ref());
 
         pathsearch::search_for_executable(paths, filename)
     }
@@ -108,7 +108,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         case_insensitive: bool,
     ) -> impl Iterator<Item = PathBuf> {
         let path_var = self.env.get_str("PATH", self).unwrap_or_default();
-        let paths = std::env::split_paths(path_var.as_ref());
+        let paths = crate::sys::fs::split_paths(path_var.as_ref());
 
         pathsearch::search_for_executable_with_prefix(paths, filename_prefix, case_insensitive)
     }
@@ -124,7 +124,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         candidate_name: S,
     ) -> Option<PathBuf> {
         let path = self.env_str("PATH").unwrap_or_default();
-        for one_dir in std::env::split_paths(path.as_ref()) {
+        for one_dir in crate::sys::fs::split_paths(path.as_ref()) {
             let candidate_path = one_dir.join(candidate_name.as_ref());
             if candidate_path.executable() {
                 return Some(candidate_path);

--- a/brush-core/src/sys/unix/fs.rs
+++ b/brush-core/src/sys/unix/fs.rs
@@ -69,6 +69,13 @@ fn try_get_file_mode(path: &Path) -> Option<u32> {
     path.metadata().map(|metadata| metadata.mode()).ok()
 }
 
+/// Splits a platform-specific PATH-like value into individual paths.
+///
+/// On Unix, this delegates to [`std::env::split_paths`].
+pub fn split_paths<T: AsRef<std::ffi::OsStr> + ?Sized>(s: &T) -> std::env::SplitPaths<'_> {
+    std::env::split_paths(s)
+}
+
 pub(crate) fn get_default_executable_search_paths() -> Vec<PathBuf> {
     // standard hard-coded defaults for executable search path
     vec![
@@ -92,7 +99,7 @@ pub fn get_default_standard_utils_paths() -> Vec<PathBuf> {
     if let Ok(Some(cs_path)) = confstr_cs_path()
         && !cs_path.as_os_str().is_empty()
     {
-        return std::env::split_paths(&cs_path).collect();
+        return split_paths(&cs_path).collect();
     }
     // standard hard-coded defaults
     vec![

--- a/brush-core/src/sys/wasm/fs.rs
+++ b/brush-core/src/sys/wasm/fs.rs
@@ -1,0 +1,19 @@
+//! Filesystem utilities for WASM.
+
+pub use crate::sys::stubs::fs::*;
+
+/// Splits a PATH-like value into individual paths.
+///
+/// On WASM, `std::env::split_paths` is not available, so this
+/// implementation splits by the `:` separator.
+pub fn split_paths<T: AsRef<std::ffi::OsStr> + ?Sized>(
+    s: &T,
+) -> impl Iterator<Item = std::path::PathBuf> {
+    s.as_ref()
+        .to_str()
+        .unwrap_or_default()
+        .split(':')
+        .map(std::path::PathBuf::from)
+        .collect::<Vec<_>>()
+        .into_iter()
+}

--- a/brush-core/src/sys/wasm/mod.rs
+++ b/brush-core/src/sys/wasm/mod.rs
@@ -1,7 +1,7 @@
 pub use crate::sys::stubs::async_pipe;
 pub use crate::sys::stubs::commands;
 pub use crate::sys::stubs::fd;
-pub use crate::sys::stubs::fs;
+pub(crate) mod fs;
 pub use crate::sys::stubs::input;
 pub(crate) use crate::sys::stubs::network;
 pub(crate) use crate::sys::stubs::pipes;

--- a/brush-core/src/sys/windows.rs
+++ b/brush-core/src/sys/windows.rs
@@ -1,7 +1,7 @@
 pub use crate::sys::stubs::async_pipe;
 pub use crate::sys::stubs::commands;
 pub use crate::sys::stubs::fd;
-pub use crate::sys::stubs::fs;
+pub(crate) mod fs;
 pub use crate::sys::stubs::input;
 pub(crate) mod network;
 pub use crate::sys::stubs::poll;

--- a/brush-core/src/sys/windows/fs.rs
+++ b/brush-core/src/sys/windows/fs.rs
@@ -1,0 +1,10 @@
+//! Filesystem utilities for Windows.
+
+pub use crate::sys::stubs::fs::*;
+
+/// Splits a platform-specific PATH-like value into individual paths.
+///
+/// On Windows, this delegates to [`std::env::split_paths`].
+pub fn split_paths<T: AsRef<std::ffi::OsStr> + ?Sized>(s: &T) -> std::env::SplitPaths<'_> {
+    std::env::split_paths(s)
+}


### PR DESCRIPTION
`std::env::split_paths` panics on some WASM platforms. For now, let's route calls to it through the `sys` module and provide an alternate implementation for some targets.