### PR TITLE
fix(heredoc): handle unbalanced single quotes and backticks in heredoc bodies inside `$(…)`  (#420)

### DIFF
--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_balanced_backticks.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_balanced_backticks.snap
@@ -1,0 +1,20 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"\\\"$(cat <<'EOF'\\n`hello`\\nEOF\\n)\\\"\")?"
+---
+ParseTestResults(
+  input: "\"$(cat <<\'EOF\'\n`hello`\nEOF\n)\"",
+  result: [
+    WordPieceWithSource(
+      piece: DoubleQuotedSequence([
+        WordPieceWithSource(
+          piece: CommandSubstitution("cat <<\'EOF\'\n`hello`\nEOF\n"),
+          start_index: 1,
+          end_index: 28,
+        ),
+      ]),
+      start_index: 0,
+      end_index: 29,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_balanced_double_quotes.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_balanced_double_quotes.snap
@@ -1,0 +1,20 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"\\\"$(cat <<'EOF'\\n\\\"hello\\\"\\nEOF\\n)\\\"\")?"
+---
+ParseTestResults(
+  input: "\"$(cat <<\'EOF\'\n\"hello\"\nEOF\n)\"",
+  result: [
+    WordPieceWithSource(
+      piece: DoubleQuotedSequence([
+        WordPieceWithSource(
+          piece: CommandSubstitution("cat <<\'EOF\'\n\"hello\"\nEOF\n"),
+          start_index: 1,
+          end_index: 28,
+        ),
+      ]),
+      start_index: 0,
+      end_index: 29,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_balanced_single_quotes.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_balanced_single_quotes.snap
@@ -1,0 +1,20 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"\\\"$(cat <<'EOF'\\n'hello'\\nEOF\\n)\\\"\")?"
+---
+ParseTestResults(
+  input: "\"$(cat <<\'EOF\'\n\'hello\'\nEOF\n)\"",
+  result: [
+    WordPieceWithSource(
+      piece: DoubleQuotedSequence([
+        WordPieceWithSource(
+          piece: CommandSubstitution("cat <<\'EOF\'\n\'hello\'\nEOF\n"),
+          start_index: 1,
+          end_index: 28,
+        ),
+      ]),
+      start_index: 0,
+      end_index: 29,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_unbalanced_backtick.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_unbalanced_backtick.snap
@@ -1,0 +1,20 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"\\\"$(cat <<'EOF'\\na ` b\\nEOF\\n)\\\"\")?"
+---
+ParseTestResults(
+  input: "\"$(cat <<\'EOF\'\na ` b\nEOF\n)\"",
+  result: [
+    WordPieceWithSource(
+      piece: DoubleQuotedSequence([
+        WordPieceWithSource(
+          piece: CommandSubstitution("cat <<\'EOF\'\na ` b\nEOF\n"),
+          start_index: 1,
+          end_index: 26,
+        ),
+      ]),
+      start_index: 0,
+      end_index: 27,
+    ),
+  ],
+)

--- a/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_unbalanced_single_quote.snap
+++ b/brush-parser/src/snapshots/brush_parser__word__tests__parse_command_sub_with_unbalanced_single_quote.snap
@@ -1,0 +1,20 @@
+---
+source: brush-parser/src/word.rs
+expression: "test_parse(\"\\\"$(cat <<'EOF'\\nit's here\\nEOF\\n)\\\"\")?"
+---
+ParseTestResults(
+  input: "\"$(cat <<\'EOF\'\nit\'s here\nEOF\n)\"",
+  result: [
+    WordPieceWithSource(
+      piece: DoubleQuotedSequence([
+        WordPieceWithSource(
+          piece: CommandSubstitution("cat <<\'EOF\'\nit\'s here\nEOF\n"),
+          start_index: 1,
+          end_index: 30,
+        ),
+      ]),
+      start_index: 0,
+      end_index: 31,
+    ),
+  ],
+)

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -1075,7 +1075,8 @@ peg::parser! {
 
         pub(crate) rule command_piece() -> () =
             word_piece(<[')']>, true /*in_command*/) {} /
-            ([' ' | '\t'])+ {}
+            ([' ' | '\t'])+ {} /
+            ['\'' | '`'] {}
 
         rule backquoted_command() -> String =
             chars:(backquoted_char()*) { chars.into_iter().collect() }
@@ -1260,6 +1261,36 @@ mod tests {
     #[test]
     fn parse_command_substitution_with_embedded_extglob() -> Result<()> {
         assert_ron_snapshot!(test_parse("$(echo !(x))")?);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_command_sub_with_unbalanced_single_quote() -> Result<()> {
+        assert_ron_snapshot!(test_parse("\"$(cat <<'EOF'\nit's here\nEOF\n)\"")?);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_command_sub_with_unbalanced_backtick() -> Result<()> {
+        assert_ron_snapshot!(test_parse("\"$(cat <<'EOF'\na ` b\nEOF\n)\"")?);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_command_sub_with_balanced_double_quotes() -> Result<()> {
+        assert_ron_snapshot!(test_parse("\"$(cat <<'EOF'\n\"hello\"\nEOF\n)\"")?);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_command_sub_with_balanced_single_quotes() -> Result<()> {
+        assert_ron_snapshot!(test_parse("\"$(cat <<'EOF'\n'hello'\nEOF\n)\"")?);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_command_sub_with_balanced_backticks() -> Result<()> {
+        assert_ron_snapshot!(test_parse("\"$(cat <<'EOF'\n`hello`\nEOF\n)\"")?);
         Ok(())
     }
 

--- a/brush-shell/tests/cases/compat/here.yaml
+++ b/brush-shell/tests/cases/compat/here.yaml
@@ -250,3 +250,34 @@ cases:
       true
       EOF
       )
+
+  - name: "Here doc with unpaired single quote in command substitution"
+    stdin: |
+      echo "$(cat <<'EOF'
+      it's here
+      EOF
+      )"
+
+  - name: "Here doc with unpaired backtick in command substitution"
+    stdin: |
+      echo "$(cat <<'EOF'
+      a ` b
+      EOF
+      )"
+
+  - name: "Here doc with three single quotes in command substitution"
+    stdin: |
+      echo "$(cat <<'EOF'
+      it's Bob's it's
+      EOF
+      )"
+
+  - name: "Here doc with unpaired single quote in command substitution (#420)"
+    stdin: |
+      var=$(
+        sed 's/nice/cool/' - <<-EOF
+        that's
+        "nice"
+      EOF
+      )
+      echo $var


### PR DESCRIPTION
Fixes #420

## Test results *without* fix
    
```yaml
---
source: brush-parser/src/word.rs
expression: "test_parse(\"\\\"$(cat <<'EOF'\\na ` b\\nEOF\\n)\\\"\")?"
---
ParseTestResults(
  input: "\"$(cat <<\'EOF\'\na ` b\nEOF\n)\"",
  result: [
    WordPieceWithSource(
      piece: DoubleQuotedSequence([
        WordPieceWithSource(
          piece: Text("$"),
          start_index: 1,
          end_index: 2,
        ),
        WordPieceWithSource(
          piece: Text("(cat <<\'EOF\'\na ` b\nEOF\n)"),
          start_index: 2,
          end_index: 26,
        ),
      ]),
      start_index: 0,
      end_index: 27,
    ),
  ],
)
```

```yaml
---
source: brush-parser/src/word.rs
expression: "test_parse(\"\\\"$(cat <<'EOF'\\nit's here\\nEOF\\n)\\\"\")?"
---
ParseTestResults(
  input: "\"$(cat <<\'EOF\'\nit\'s here\nEOF\n)\"",
  result: [
    WordPieceWithSource(
      piece: DoubleQuotedSequence([
        WordPieceWithSource(
          piece: Text("$"),
          start_index: 1,
          end_index: 2,
        ),
        WordPieceWithSource(
          piece: Text("(cat <<\'EOF\'\nit\'s here\nEOF\n)"),
          start_index: 2,
          end_index: 30,
        ),
      ]),
      start_index: 0,
      end_index: 31,
    ),
  ],
)
```

```
* Test case: [Here doc with unpaired single quote in command substitution]... 
    Oracle comparison:
      status matches (exit status: 0) ✔️
      stdout DIFFERS:
          ------ Oracle <> Test: stdout ---------------------------------
          + $(cat <<'EOF'
            it's here
          + EOF
          + )
            
          ---------------------------------------------------------------
      stderr matches ✔️
      temp dir matches ✔️
    FAILED.
* Test case: [Here doc with unpaired backtick in command substitution]... 
    Oracle comparison:
      status matches (exit status: 0) ✔️
      stdout DIFFERS:
          ------ Oracle <> Test: stdout ---------------------------------
          + $(cat <<'EOF'
            a ` b
          + EOF
          + )
            
          ---------------------------------------------------------------
      stderr matches ✔️
      temp dir matches ✔️
    FAILED.
* Test case: [Here doc with three single quotes in command substitution]... 
    Oracle comparison:
      status matches (exit status: 0) ✔️
      stdout DIFFERS:
          ------ Oracle <> Test: stdout ---------------------------------
          + $(cat <<'EOF'
            it's Bob's it's
          + EOF
          + )
            
          ---------------------------------------------------------------
      stderr matches ✔️
      temp dir matches ✔️
    FAILED.
* Test case: [Here doc with unpaired single quote in command substitution (#420)]... 
    Oracle comparison:
      status matches (exit status: 0) ✔️
      stdout DIFFERS:
          ------ Oracle <> Test: stdout ---------------------------------
          - that's "cool"
          + 
            
          ---------------------------------------------------------------
      stderr DIFFERS:
          ------ Oracle <> Test: stderr ---------------------------------
          + error: failed to parse word '$(
          +   sed 's/nice/cool/' - <<-EOF
          +   that's
          +   "nice"
          + EOF
          + )'
          + 
          ---------------------------------------------------------------
      temp dir matches ✔️
    FAILED.
```


## Context

The tokenizer flattens heredoc bodies into `$(...)` token text. When the body contains unbalanced single quotes or backticks, the word parser's quote-matching rules fail to consume them, causing the entire command substitution parse to fail.

If you compare the snapshots of `parse_command_sub_with_unbalanced_single_quote` and `parse_command_sub_with_unbalanced_backtick` prior to the fix with the snapshot of `brush_parser__word__tests__parse_command_sub_with_balanced_backticks` you can clearly see the parser is failing to match the `CommandSubstitution`.

## Solution

The solution is to add a fallback in [`command_piece`](https://github.com/reubeno/brush/blob/main/brush-parser/src/word.rs#L1076) so orphan `'` and `` ` `` are consumed as literal characters when `word_piece` cannot match them. 

> [!CAUTION]
> I **believe** this is safe because of PEG's ordered choice semantics: properly paired quotes are consumed by `word_piece` first; the fallback only fires for characters no other rule can handle.
>
> **However, it would be worth a maintainer validating this**

## Note

Unbalanced `"` inside heredoc bodies within `"$(…)"` is a separate issue tracked in #1066. The `"` is consumed by the outer `double_quoted_sequence` rule before `command_piece` is reached, so this fix does not address it.

---
RE: Contributor Policy

> Please be transparent about your use of AI.

- Claude Code was used to diagnose an issue I was facing.
- It was then used to explore possible solutions
- #1066 was identified as a separate case
- After a LOT of back and forth we narrowed it down to a simple one line fix

> It also remains your responsibility to review, test, understand, and vouch for all code and content that you submit. Accordingly, you must fully understand all code and other content in your contributions and be able to explain their behavior and purpose.

- I have reviewed, tested and understand WHY the fix works. 
>[!CAUTION]
> - However, the fix is inside [`peg::parser!` macro](https://github.com/reubeno/brush/blob/191651668a40c7a1e17131185fa472f63358b3b7/brush-parser/src/word.rs#L628) and I definitely do not have knowledge of how the macro works. Therefore I'm heavily relying on existing tests to identify if this causes regressions. 