### PR TITLE
fix(login): correctly reflect login option via shopt

### DIFF
--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -229,6 +229,7 @@ impl RuntimeOptions {
             treat_unset_variables_as_error: create_options.treat_unset_variables_as_error,
             exit_on_nonzero_command_exit: create_options.exit_on_nonzero_command_exit,
             external_cmd_leads_session: create_options.external_cmd_leads_session,
+            login_shell: create_options.login,
             remember_command_locations: true,
             check_window_size_after_external_commands: true,
             save_multiline_cmds_in_history: true,

--- a/brush-shell/tests/cases/compat/options/shopt-login_shell.yaml
+++ b/brush-shell/tests/cases/compat/options/shopt-login_shell.yaml
@@ -1,0 +1,12 @@
+name: "shopt login_shell"
+cases:
+  - name: "login_shell is on for login shells"
+    args:
+      - "--login"
+      - "-c"
+      - "shopt -q login_shell"
+
+  - name: "login_shell is off for non-login shells"
+    args:
+      - "-c"
+      - "shopt -q login_shell"


### PR DESCRIPTION
`brush` appears to correctly identify when it's running as a login shell, but it had been missing the (single line of) logic required to initialize the `login_shell` `shopt` option accordingly.

Note that OSes may count on this option to be correctly set. For example, I found my system's `/etc/bashrc` file has this logic:

```bash
if ! shopt -q login_shell ; then # We're not a login shell
    # ...
fi
```