### PR TITLE
test: add mkosi config

### DIFF
--- a/brush-shell/tests/images/.gitignore
+++ b/brush-shell/tests/images/.gitignore
@@ -1,0 +1,17 @@
+# mkosi build outputs
+mkosi.output/
+mkosi.builddir/
+mkosi.cache/
+mkosi.pkgcache/
+
+# mkosi local overrides and secrets
+mkosi.local.conf
+mkosi.local/
+mkosi.rootpw
+mkosi.passphrase
+mkosi.key
+mkosi.crt
+mkosi.nspawn
+
+# stale top-level image from before OutputDirectory was configured
+*.raw

--- a/brush-shell/tests/images/README.md
+++ b/brush-shell/tests/images/README.md
@@ -1,0 +1,39 @@
+# Brush Test Images
+
+mkosi configs for building minimal Fedora images with brush as `/bin/sh` and the default login shell.
+
+## Prerequisites
+
+Build brush first:
+
+```bash
+cargo build --release
+```
+
+## Container (systemd-nspawn)
+
+```bash
+mkosi --profile=container build
+sudo mkosi --profile=container boot
+```
+
+## VM (KVM-accelerated)
+
+```bash
+mkosi --profile=vm build
+mkosi --profile=vm vm
+```
+
+## Options
+
+Use a debug build:
+
+```bash
+mkosi --environment=BRUSH_PROFILE=debug --profile=container build
+```
+
+Force rebuild:
+
+```bash
+mkosi -f --profile=container build
+```

--- a/brush-shell/tests/images/mkosi.conf
+++ b/brush-shell/tests/images/mkosi.conf
@@ -1,0 +1,26 @@
+[Distribution]
+Distribution=fedora
+Release=43
+
+[Output]
+OutputDirectory=mkosi.output
+CompressOutput=no
+
+[Content]
+Packages=systemd
+         util-linux
+	 dnf5
+Autologin=yes
+RootPassword=hashed:
+RootShell=/usr/bin/brush
+WithDocs=no
+CleanPackageMetadata=no
+RemoveFiles=/usr/share/locale
+
+[Build]
+BuildSources=.:,
+             ../../../target:brush-target
+Environment=BRUSH_PROFILE=release
+
+[Validation]
+SecureBoot=no

--- a/brush-shell/tests/images/mkosi.postinst
+++ b/brush-shell/tests/images/mkosi.postinst
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+BRUSH_BINARY="${SRCDIR}/brush-target/${BRUSH_PROFILE}/brush"
+
+if [[ ! -f "${BRUSH_BINARY}" ]]; then
+    echo "error: brush binary not found at: ${BRUSH_BINARY}" >&2
+    echo "hint: run 'cargo build --${BRUSH_PROFILE}' first, or override with:" >&2
+    echo "  mkosi --environment=BRUSH_PROFILE=debug build" >&2
+    exit 1
+fi
+
+# Install the pre-built brush binary
+install -Dm755 "${BRUSH_BINARY}" "${BUILDROOT}/usr/bin/brush"
+
+# Register brush as a valid login shell
+grep -qxF /usr/bin/brush "${BUILDROOT}/etc/shells" 2>/dev/null \
+    || echo /usr/bin/brush >> "${BUILDROOT}/etc/shells"
+
+# Make brush available as /bin/sh and as /bin/bash
+ln -sf brush "${BUILDROOT}/usr/bin/sh"
+ln -sf brush "${BUILDROOT}/usr/bin/bash"

--- a/brush-shell/tests/images/mkosi.profiles/container/mkosi.conf
+++ b/brush-shell/tests/images/mkosi.profiles/container/mkosi.conf
@@ -1,0 +1,6 @@
+[Output]
+Format=directory
+ImageId=brush-container
+
+[Content]
+Bootable=no

--- a/brush-shell/tests/images/mkosi.profiles/vm/mkosi.conf
+++ b/brush-shell/tests/images/mkosi.profiles/vm/mkosi.conf
@@ -1,0 +1,21 @@
+[Output]
+Format=disk
+ImageId=brush-vm
+
+[Content]
+Bootable=yes
+Bootloader=systemd-boot
+Packages=systemd-udev
+         systemd-boot
+         kernel-core
+
+KernelCommandLine=console=hvc0
+                  quiet
+                  systemd.show_status=error
+
+[Runtime]
+Firmware=linux
+KVM=auto
+CPUs=2
+RAM=1G
+Console=interactive


### PR DESCRIPTION
Nothing automated, but this provides a simple way to boot a container or VM with `brush` as the login process (and as `/bin/sh`).