### PR TITLE
fix(parser): preserve whitespace in regex operands of extended tests

### DIFF
--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -782,26 +782,34 @@ impl<'a> peg::ParseElem<'a> for Tokens<'a> {
 impl<'a> peg::ParseSlice<'a> for Tokens<'a> {
     type Slice = String;
 
+    /// Reconstructs a source string from a slice of tokens.
+    ///
+    /// Uses each token's source position to detect whether whitespace existed
+    /// between adjacent tokens in the original source, preserving it as a
+    /// single space. This matters for constructs like `[[ x =~ (a| *) ]]`
+    /// where the space inside the regex group is significant.
+    ///
+    /// N.B. This relies on tokens having accurate, contiguous source
+    /// positions. All tokens produced by the normal tokenizer path satisfy
+    /// this. If positions are missing or non-monotonic (as can happen with
+    /// synthetic here-document end-tag tokens), the gap check evaluates
+    /// false and no space is inserted — a safe degradation to the previous
+    /// behavior, which also omitted spaces between non-word tokens.
     fn parse_slice(&'a self, start: usize, end: usize) -> Self::Slice {
         let mut result = String::new();
-        let mut last_token_was_word = false;
+        let mut prev_end_index: Option<usize> = None;
 
         for token in &self.tokens[start..end] {
-            match token {
-                Token::Operator(s, _) => {
-                    result.push_str(s);
-                    last_token_was_word = false;
-                }
-                Token::Word(s, _) => {
-                    // Place spaces between adjacent words.
-                    if last_token_was_word {
-                        result.push(' ');
-                    }
+            let loc = token.location();
 
-                    result.push_str(s);
-                    last_token_was_word = true;
+            if let Some(prev_end) = prev_end_index {
+                if loc.start.index > prev_end {
+                    result.push(' ');
                 }
             }
+
+            result.push_str(token.to_str());
+            prev_end_index = Some(loc.end.index);
         }
 
         result

--- a/brush-parser/src/parser/tests/extended_test.rs
+++ b/brush-parser/src/parser/tests/extended_test.rs
@@ -129,6 +129,17 @@ fn parse_extended_test_regex() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn parse_extended_test_regex_with_spaces() -> Result<()> {
+    let input = r#"[[ "x" =~ (a| *) ]]"#;
+    let result = test_with_snapshot(input)?;
+    assert_snapshot_redacted!(ParseResult {
+        input,
+        result: &result
+    });
+    Ok(())
+}
+
 // Logical operators
 
 #[test]

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__complex__parse_arithmetic_in_condition.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__complex__parse_arithmetic_in_condition.snap
@@ -17,7 +17,7 @@ ParseResult(
                       seq: [
                         Compound(Arithmetic(ArithmeticCommand(
                           expr: UnexpandedArithmeticExpr(
-                            value: "x>5",
+                            value: "x > 5",
                           ),
                           loc: "[location]",
                         )), None),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_arithmetic_for.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_arithmetic_for.snap
@@ -15,7 +15,7 @@ ParseResult(
                   value: "i = 0",
                 )),
                 condition: Some(UnexpandedArithmeticExpr(
-                  value: "i<10",
+                  value: "i < 10",
                 )),
                 updater: Some(UnexpandedArithmeticExpr(
                   value: "i++",

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_regex_with_spaces.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_regex_with_spaces.snap
@@ -1,0 +1,29 @@
+---
+source: brush-parser/src/parser/tests/extended_test.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "[[ \"x\" =~ (a| *) ]]",
+  result: Program(
+    complete_commands: [
+      CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            seq: [
+              ExtendedTest(ExtendedTestExprCommand(
+                expr: BinaryTest(StringMatchesRegex, Word(
+                  value: "\"x\"",
+                  loc: "[location]",
+                ), Word(
+                  value: "(a| *)",
+                  loc: "[location]",
+                )),
+                loc: "[location]",
+              ), None),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-shell/tests/cases/compat/extended_tests.yaml
+++ b/brush-shell/tests/cases/compat/extended_tests.yaml
@@ -290,6 +290,13 @@ cases:
       [[ "<" =~ (<) ]] && echo "1. Matched"
       [[ ">" =~ (<) ]] && echo "2. Matched"
 
+  - name: "Regex with spaces inside parens"
+    stdin: |
+      [[ "x" =~ (a| *) ]]   && echo "1. Matched"
+      [[ "a b" =~ ^(a |b) ]] && echo "2. Matched: [${BASH_REMATCH[0]}]"
+      [[ "a b" =~ ^(a |b)$ ]] || echo "3. No match"
+      [[ " " =~ ^( )$ ]]    && echo "4. Matched: [${BASH_REMATCH[1]}]"
+
   - name: "Regex with unescaped open bracket in character class"
     stdin: |
       [[ "[" =~ ^([x[]) ]] && echo "Matched"


### PR DESCRIPTION
`[[ "x" =~ (a| *) ]]` was failing because the space between `|` and `*` was dropped when reconstructing the =~ operand from tokens, producing the invalid regex `(a|*)`.

The root cause was in `Tokens::parse_slice`, the PEG `$()` capture mechanism used by `regex_word()` and `arithmetic_expression()` to reconstitute a string from matched tokens. It only inserted spaces between adjacent `Word` tokens, never between `Word`-`Operator` or `Operator`-Word pairs. So the token sequence `(`, `a`, `|`, `*`, `)` was joined without the original inter-token whitespace.

Fix by using each token's source position to detect gaps: if a token's start index is past the previous token's end index, there was whitespace in the original source and a space is inserted. This is correct for all tokens produced by the normal tokenizer path. For tokens with synthetic positions (e.g. here-doc end-tags), the gap check safely evaluates false — matching the previous behavior.