### PR TITLE
test: add basic wasm32-wasip2 tests to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,7 @@ jobs:
             artifact_suffix: "linux-x86_64"
             name_suffix: "(linux/x86_64)"
             homebrew_supported: true
+            coverage: true
             coverage_min_percent: 70
 
           - host: "ubuntu-24.04-arm"
@@ -198,6 +199,7 @@ jobs:
             artifact_suffix: "linux-aarch64"
             name_suffix: "(linux/aarch64)"
             homebrew_supported: false
+            coverage: true
             coverage_min_percent: 70
 
           - host: "macos-latest"
@@ -205,6 +207,7 @@ jobs:
             artifact_suffix: "-macos"
             name_suffix: "(macOS)"
             homebrew_supported: true
+            coverage: true
             coverage_min_percent: 70
 
           - host: "windows-2025"
@@ -212,7 +215,18 @@ jobs:
             artifact_suffix: "-windows"
             name_suffix: "(windows)"
             homebrew_supported: false
+            coverage: true
             coverage_min_percent: 20
+
+          - host: "ubuntu-24.04"
+            variant: "wasi"
+            artifact_suffix: "-wasi"
+            name_suffix: "(wasm32/wasi-0.2)"
+            homebrew_supported: false
+            coverage: false
+            extra_rust_targets: "wasm32-wasip2"
+            wasi_runtime: "wasmtime"
+            xtask_test_args: "--wasi"
 
     name: "Test ${{ matrix.name_suffix }}"
     runs-on: ${{ matrix.host }}
@@ -229,6 +243,7 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+          targets: ${{ matrix.extra_rust_targets || '' }}
           components: llvm-tools-preview
 
       - name: Enable cargo cache
@@ -243,9 +258,16 @@ jobs:
           tool: cargo-nextest
 
       - name: Install cargo-llvm-cov
+        if: ${{ matrix.coverage }}
         uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2.65.1
         with:
           tool: cargo-llvm-cov
+
+      - name: Install WASI runtime
+        if: ${{ matrix.wasi_runtime }}
+        uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2.65.1
+        with:
+          tool: ${{ matrix.wasi_runtime }}
 
       - name: Set up Homebrew
         if: ${{ matrix.homebrew_supported }}
@@ -287,7 +309,13 @@ jobs:
       - name: Test
         env:
           VARIANT: ${{ matrix.variant }}
-        run: cargo xtask test integration --coverage --coverage-output ./codecov-${VARIANT}.xml --results-output ./test-results-${VARIANT}.xml
+        run: |
+          args="${{ matrix.xtask_test_args || '' }}"
+          args="${args} --results-output ./test-results-${VARIANT}.xml"
+          if [[ "${{ matrix.coverage }}" == "true" ]]; then
+            args="${args} --coverage --coverage-output ./codecov-${VARIANT}.xml"
+          fi
+          cargo xtask test integration ${args}
 
       - name: "Upload test results"
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -298,7 +326,7 @@ jobs:
 
       - name: "Generate code coverage report"
         uses: clearlyip/code-coverage-report-action@9e2cd22e39153feba8b4477e4fefcc0b5e2727ba # v6.0
-        if: always()
+        if: ${{ always() && matrix.coverage }}
         id: "code_coverage_report"
         with:
           artifact_download_workflow_names: "CI"

--- a/brush-shell/tests/cases/brush/cli.yaml
+++ b/brush-shell/tests/cases/brush/cli.yaml
@@ -8,6 +8,9 @@ cases:
   - name: "Exit code propagates"
     stdin: "exit 42"
     expected_exit_code: 42
+    # WASI 0.2's wasi-cli/exit interface only models success/failure, so any
+    # non-zero exit code is clamped to 1 by the host (e.g., wasmtime).
+    incompatible_platforms: ["wasi"]
 
   - name: "Echo via args"
     args:
@@ -31,7 +34,10 @@ cases:
     args:
       - "--unknown-argument-here"
     expected_exit_code: 2
-    # Exit code 2 for argument parsing errors
+    # Exit code 2 for argument parsing errors.
+    # WASI 0.2's wasi-cli/exit interface only models success/failure, so any
+    # non-zero exit code is clamped to 1 by the host (e.g., wasmtime).
+    incompatible_platforms: ["wasi"]
 
   - name: "Explicit config file not found fails"
     removed_default_args:

--- a/brush-shell/tests/cases/brush/tracing.yaml
+++ b/brush-shell/tests/cases/brush/tracing.yaml
@@ -7,3 +7,8 @@ cases:
         true
     expected_exit_code: 0
     snapshot: true
+    # std::fs::File::try_clone() returns "operation not supported" on
+    # wasm32-wasip2, so brush's OpenFile::clone() falls back to a failing
+    # writer and the trace file ends up empty. Affects all output redirection
+    # under wasi, not just xtrace.
+    incompatible_platforms: ["wasi"]

--- a/brush-shell/tests/cases/compat/builtins/trap.yaml
+++ b/brush-shell/tests/cases/compat/builtins/trap.yaml
@@ -376,6 +376,7 @@ cases:
       echo "main continues"
 
   - name: "coproc - DEBUG trap inheritance"
+    skip: true # TODO: this test is too inconsistent
     min_oracle_version: "5.3.0"
     incompatible_os:
       - fedora

--- a/brush-shell/tests/compat_tests.rs
+++ b/brush-shell/tests/compat_tests.rs
@@ -31,6 +31,7 @@ fn create_bash_oracle(options: &TestOptions) -> Result<OracleConfig> {
             which: WhichShell::NamedShell(options.bash_path.clone()),
             default_args: vec![String::from("--norc"), String::from("--noprofile")],
             default_path_var: options.test_path_var.clone(),
+            launcher: None,
         },
         version_str: Some(bash_version_str),
     })
@@ -43,36 +44,21 @@ fn create_sh_oracle(options: &TestOptions) -> OracleConfig {
             which: WhichShell::NamedShell(PathBuf::from("sh")),
             default_args: vec![],
             default_path_var: options.test_path_var.clone(),
+            launcher: None,
         },
         version_str: None,
     }
 }
 
-fn create_test_shell_config(options: &TestOptions, oracle_name: &str) -> ShellConfig {
-    let mut default_args = vec![
-        "--norc".into(),
-        "--noprofile".into(),
-        "--no-config".into(),
-        "--input-backend=basic".into(),
-        "--disable-bracketed-paste".into(),
-        "--disable-color".into(),
-    ];
+fn create_test_shell_config(options: &TestOptions, oracle_name: &str) -> Result<ShellConfig> {
+    let mut config = options.create_test_shell_config()?;
 
-    // Add --sh flag when testing against sh oracle
+    // Add --sh flag when testing against sh oracle.
     if oracle_name == SH_CONFIG_NAME {
-        default_args.insert(0, "--sh".into());
+        config.default_args.insert(0, "--sh".into());
     }
 
-    // Add any additional brush args specified.
-    options.brush_args.split_whitespace().for_each(|arg| {
-        default_args.push(arg.into());
-    });
-
-    ShellConfig {
-        which: WhichShell::ShellUnderTest(PathBuf::from(&options.brush_path)),
-        default_args,
-        default_path_var: options.test_path_var.clone(),
-    }
+    Ok(config)
 }
 
 async fn run_compat_tests(mut options: TestOptions) -> Result<bool> {
@@ -107,11 +93,12 @@ async fn run_compat_tests(mut options: TestOptions) -> Result<bool> {
     // Run tests for each enabled config
     if options.should_enable_config(BASH_CONFIG_NAME, &[BASH_CONFIG_NAME]) {
         let oracle = create_bash_oracle(&options)?;
-        let test_shell = create_test_shell_config(&options, &oracle.name);
+        let test_shell = create_test_shell_config(&options, &oracle.name)?;
 
         let config = RunnerConfig::new(PathBuf::from(&options.brush_path), test_cases_dir.clone())
             .with_oracle(oracle)
-            .with_mode(TestMode::Oracle);
+            .with_mode(TestMode::Oracle)
+            .with_platform_tags(options.platform_tags());
 
         let config = RunnerConfig {
             test_shell,
@@ -126,11 +113,12 @@ async fn run_compat_tests(mut options: TestOptions) -> Result<bool> {
 
     if options.should_enable_config(SH_CONFIG_NAME, &[BASH_CONFIG_NAME]) {
         let oracle = create_sh_oracle(&options);
-        let test_shell = create_test_shell_config(&options, &oracle.name);
+        let test_shell = create_test_shell_config(&options, &oracle.name)?;
 
         let config = RunnerConfig::new(PathBuf::from(&options.brush_path), test_cases_dir.clone())
             .with_oracle(oracle)
-            .with_mode(TestMode::Oracle);
+            .with_mode(TestMode::Oracle)
+            .with_platform_tags(options.platform_tags());
 
         let config = RunnerConfig {
             test_shell,

--- a/brush-shell/tests/integration_tests.rs
+++ b/brush-shell/tests/integration_tests.rs
@@ -6,33 +6,9 @@
 #![cfg(any(unix, windows))]
 
 use anyhow::Result;
-use brush_test_harness::{
-    RunnerConfig, ShellConfig, TestMode, TestOptions, TestRunner, WhichShell,
-};
+use brush_test_harness::{RunnerConfig, TestMode, TestOptions, TestRunner};
 use clap::Parser;
 use std::path::{Path, PathBuf};
-
-fn create_test_shell_config(options: &TestOptions) -> ShellConfig {
-    let mut default_args = vec![
-        "--norc".into(),
-        "--noprofile".into(),
-        "--no-config".into(),
-        "--input-backend=basic".into(),
-        "--disable-bracketed-paste".into(),
-        "--disable-color".into(),
-    ];
-
-    // Add any additional brush args specified.
-    options.brush_args.split_whitespace().for_each(|arg| {
-        default_args.push(arg.into());
-    });
-
-    ShellConfig {
-        which: WhichShell::ShellUnderTest(PathBuf::from(&options.brush_path)),
-        default_args,
-        default_path_var: options.test_path_var.clone(),
-    }
-}
 
 async fn run_brush_tests(mut options: TestOptions) -> Result<bool> {
     // Resolve path to the shell-under-test.
@@ -54,10 +30,11 @@ async fn run_brush_tests(mut options: TestOptions) -> Result<bool> {
         |p| p.to_owned(),
     );
 
-    let test_shell = create_test_shell_config(&options);
+    let test_shell = options.create_test_shell_config()?;
 
     let config = RunnerConfig::new(PathBuf::from(&options.brush_path), test_cases_dir)
-        .with_mode(TestMode::Expectation);
+        .with_mode(TestMode::Expectation)
+        .with_platform_tags(options.platform_tags());
 
     let config = RunnerConfig {
         test_shell,

--- a/brush-test-harness/src/config.rs
+++ b/brush-test-harness/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration types for the test harness.
 
 use clap::Parser;
-use std::{ffi::OsString, path::PathBuf};
+use std::{collections::HashSet, ffi::OsString, path::PathBuf};
 
 /// Which shell to use for a test.
 #[derive(Clone, Debug)]
@@ -21,6 +21,10 @@ pub struct ShellConfig {
     pub default_args: Vec<String>,
     /// Default PATH variable for this shell.
     pub default_path_var: Option<String>,
+    /// Optional launcher command to prepend (e.g., `["wasmtime", "run", "--"]` for wasm
+    /// targets). The first element is the program to execute; the rest are leading arguments
+    /// inserted before the shell binary path.
+    pub launcher: Option<Vec<String>>,
 }
 
 impl ShellConfig {
@@ -95,10 +99,17 @@ pub struct RunnerConfig {
     pub snapshot_dir_name: String,
     /// Host OS ID (for filtering incompatible tests).
     pub host_os_id: Option<String>,
+    /// Active runtime platform tags (e.g., "wasi", "wasm"). Tests that
+    /// declare any of these in `incompatible_platforms` will be skipped.
+    pub platform_tags: HashSet<String>,
 }
 
 impl RunnerConfig {
-    /// Creates a new runner config with default values.
+    /// Creates a new runner config with minimal safe defaults.
+    ///
+    /// N.B. Callers typically override `test_shell` via
+    /// `TestOptions::create_test_shell_config()`, which adds
+    /// platform-appropriate flags like `--input-backend=basic`.
     pub fn new(test_shell_path: PathBuf, test_cases_dir: PathBuf) -> Self {
         Self {
             mode: TestMode::Expectation,
@@ -109,16 +120,24 @@ impl RunnerConfig {
                     "--norc".into(),
                     "--noprofile".into(),
                     "--no-config".into(),
-                    "--input-backend=basic".into(),
                     "--disable-bracketed-paste".into(),
                     "--disable-color".into(),
                 ],
                 default_path_var: None,
+                launcher: None,
             },
             test_cases_dir,
             snapshot_dir_name: String::from("snaps"),
             host_os_id: crate::util::get_host_os_id(),
+            platform_tags: HashSet::new(),
         }
+    }
+
+    /// Sets the active runtime platform tags.
+    #[must_use]
+    pub fn with_platform_tags(mut self, tags: HashSet<String>) -> Self {
+        self.platform_tags = tags;
+        self
     }
 
     /// Sets the oracle configuration, enabling oracle comparison mode.
@@ -207,6 +226,26 @@ pub struct TestOptions {
     #[clap(long = "brush-args", default_value = "", env = "BRUSH_ARGS")]
     pub brush_args: String,
 
+    /// Optionally specify a launcher command to prepend when invoking brush
+    /// (e.g., "wasmtime run --" to execute a wasm build under wasmtime).
+    /// The string is split on whitespace; the first token becomes the program
+    /// to execute and the remainder are passed as leading arguments before
+    /// the brush binary path.
+    #[clap(long = "brush-launcher", default_value = "", env = "BRUSH_LAUNCHER")]
+    pub brush_launcher: String,
+
+    /// Runtime platform tags (e.g., "wasi", "wasm") describing the
+    /// environment in which brush is being executed. Test cases that
+    /// declare any of these tags in `incompatible_platforms` will be
+    /// skipped. May be specified multiple times on the CLI or as a
+    /// space-separated value in the environment variable.
+    #[clap(
+        long = "brush-platform-tags",
+        value_delimiter = ' ',
+        env = "BRUSH_PLATFORM_TAGS"
+    )]
+    pub brush_platform_tags: Vec<String>,
+
     /// Optionally specify path to test cases.
     #[clap(long = "test-cases-path", env = "BRUSH_TEST_CASES")]
     pub test_cases_path: Option<PathBuf>,
@@ -244,6 +283,59 @@ pub struct TestOptions {
 }
 
 impl TestOptions {
+    /// Returns the configured platform tags as a set.
+    pub fn platform_tags(&self) -> HashSet<String> {
+        self.brush_platform_tags.iter().cloned().collect()
+    }
+
+    /// Builds the default `ShellConfig` for the shell under test based on
+    /// the common options (path, launcher, platform tags, extra args).
+    ///
+    /// Resolves the launcher binary to an absolute path (if one is
+    /// configured) because the test harness clears env vars — including
+    /// `PATH` — before spawning child processes.
+    pub fn create_test_shell_config(&self) -> anyhow::Result<ShellConfig> {
+        let mut default_args: Vec<String> = vec![
+            "--norc".into(),
+            "--noprofile".into(),
+            "--no-config".into(),
+            "--disable-bracketed-paste".into(),
+            "--disable-color".into(),
+        ];
+
+        // Use the basic input backend for native builds. WASI builds are
+        // compiled with `--features minimal` which doesn't include the basic
+        // backend, so passing this flag would cause a startup error. Omitting
+        // it lets brush pick its own default (Minimal on wasm targets).
+        if !self.platform_tags().contains("wasi") {
+            default_args.push("--input-backend=basic".into());
+        }
+
+        // Append any additional brush args specified by the caller.
+        self.brush_args.split_whitespace().for_each(|arg| {
+            default_args.push(arg.into());
+        });
+
+        let launcher = if self.brush_launcher.is_empty() {
+            None
+        } else {
+            let mut tokens: Vec<String> = self
+                .brush_launcher
+                .split_whitespace()
+                .map(Into::into)
+                .collect();
+            crate::util::resolve_launcher_path(&mut tokens)?;
+            Some(tokens)
+        };
+
+        Ok(ShellConfig {
+            which: WhichShell::ShellUnderTest(PathBuf::from(&self.brush_path)),
+            default_args,
+            default_path_var: self.test_path_var.clone(),
+            launcher,
+        })
+    }
+
     /// Returns whether the given config name should be enabled.
     pub fn should_enable_config(&self, config: &str, default_configs: &[&str]) -> bool {
         let enabled_configs = if self.enabled_configs.is_empty() {

--- a/brush-test-harness/src/execution.rs
+++ b/brush-test-harness/src/execution.rs
@@ -102,6 +102,24 @@ impl TestCase {
         Ok(())
     }
 
+    /// Constructs a `Command` to invoke the given shell binary, optionally
+    /// prepending a launcher (e.g., `["wasmtime", "run", "--"]`). When a
+    /// launcher is provided, the first element becomes the program to execute
+    /// and the rest are passed as leading arguments before the shell binary path.
+    fn new_shell_command(
+        shell_path: &std::path::Path,
+        launcher: Option<&[String]>,
+    ) -> std::process::Command {
+        if let Some([program, leading_args @ ..]) = launcher {
+            let mut cmd = std::process::Command::new(program);
+            cmd.args(leading_args);
+            cmd.arg(shell_path);
+            cmd
+        } else {
+            std::process::Command::new(shell_path)
+        }
+    }
+
     fn create_command_for_shell(
         &self,
         shell_config: &ShellConfig,
@@ -115,9 +133,13 @@ impl TestCase {
                     let target_dir = std::env::var("CARGO_TARGET_DIR")
                         .ok()
                         .map_or_else(default_target_dir, PathBuf::from);
-                    (std::process::Command::new(name), Some(target_dir))
+                    (
+                        Self::new_shell_command(name, shell_config.launcher.as_deref()),
+                        Some(target_dir),
+                    )
                 }
-                WhichShell::NamedShell(name) => (std::process::Command::new(name), None),
+                // Launcher only applies to the shell under test; the oracle is invoked directly.
+                WhichShell::NamedShell(name) => (Self::new_shell_command(name, None), None),
             },
             ShellInvocation::ExecScript(_) => unimplemented!("exec script test"),
         };

--- a/brush-test-harness/src/runner.rs
+++ b/brush-test-harness/src/runner.rs
@@ -136,9 +136,11 @@ impl TestRunner {
     }
 
     fn should_skip_test(&self, test_case_set: &TestCaseSet, test_case: &TestCase) -> Result<bool> {
-        // Check incompatible configs
+        // Check incompatible configs (set-level and per-case).
         if let Some(oracle) = &self.config.oracle {
-            if test_case.incompatible_configs.contains(&oracle.name) {
+            if test_case_set.incompatible_configs.contains(&oracle.name)
+                || test_case.incompatible_configs.contains(&oracle.name)
+            {
                 return Ok(true);
             }
         }
@@ -148,6 +150,16 @@ impl TestRunner {
             if test_case.incompatible_os.contains(host_os_id) {
                 return Ok(true);
             }
+        }
+
+        // Check incompatible runtime platforms (set-level and per-case).
+        if test_case_set
+            .incompatible_platforms
+            .iter()
+            .chain(test_case.incompatible_platforms.iter())
+            .any(|p| self.config.platform_tags.contains(p))
+        {
+            return Ok(true);
         }
 
         // Check oracle version constraints
@@ -217,23 +229,6 @@ async fn run_test_case_set(
     let mut fail_count = 0;
     let mut success_duration = std::time::Duration::default();
     let mut test_case_results = vec![];
-
-    // Check if the entire test case set is incompatible
-    if let Some(oracle) = &config.oracle {
-        if test_case_set.incompatible_configs.contains(&oracle.name) {
-            return Ok(TestCaseSetResults {
-                name: test_case_set.name.clone(),
-                config_name: oracle.name.clone(),
-                test_case_results: vec![],
-                success_count: 0,
-                #[expect(clippy::cast_possible_truncation)]
-                skip_count: test_case_set.cases.len() as u32,
-                known_failure_count: 0,
-                fail_count: 0,
-                success_duration: std::time::Duration::default(),
-            });
-        }
-    }
 
     for test_case in &test_case_set.cases {
         let runner = TestRunner::new(config.clone(), options.clone());

--- a/brush-test-harness/src/testcase.rs
+++ b/brush-test-harness/src/testcase.rs
@@ -110,6 +110,12 @@ pub struct TestCase {
     #[serde(default)]
     pub incompatible_os: HashSet<String>,
 
+    /// Runtime platform tags (e.g., "wasi", "wasm") that are incompatible
+    /// with this test. The test is skipped when any of these tags is present
+    /// in the runner's active platform tag set.
+    #[serde(default)]
+    pub incompatible_platforms: HashSet<String>,
+
     /// Minimum oracle version required for this test.
     #[serde(default)]
     pub min_oracle_version: Option<String>,
@@ -179,6 +185,11 @@ pub struct TestCaseSet {
     /// Configurations that are incompatible with this entire test set.
     #[serde(default)]
     pub incompatible_configs: HashSet<String>,
+
+    /// Runtime platform tags (e.g., "wasi", "wasm") that are incompatible
+    /// with this entire test set.
+    #[serde(default)]
+    pub incompatible_platforms: HashSet<String>,
 
     /// Directory containing the YAML file (computed at runtime).
     #[serde(skip)]

--- a/brush-test-harness/src/util.rs
+++ b/brush-test-harness/src/util.rs
@@ -68,6 +68,28 @@ pub fn write_diff(
     Ok(())
 }
 
+/// Resolves the first element of the given launcher token list to an absolute
+/// path by walking the current `PATH`. This is needed because the test harness
+/// clears env vars (including `PATH`) before spawning child processes, so a
+/// launcher binary referenced by name (e.g., `wasmtime`) would fail to resolve
+/// at exec time.
+pub fn resolve_launcher_path(tokens: &mut Vec<String>) -> Result<()> {
+    let Some(first) = tokens.first() else {
+        return Ok(());
+    };
+    if std::path::Path::new(first.as_str()).is_absolute() {
+        return Ok(());
+    }
+    let resolved = std::env::var_os("PATH")
+        .into_iter()
+        .flat_map(|p| std::env::split_paths(&p).collect::<Vec<_>>())
+        .map(|d| d.join(first.as_str()))
+        .find(|p| p.is_file())
+        .ok_or_else(|| anyhow::anyhow!("could not resolve launcher binary '{first}' in PATH"))?;
+    tokens[0] = resolved.to_string_lossy().into_owned();
+    Ok(())
+}
+
 /// Gets the bash version string from the given bash path.
 pub fn get_bash_version_str(bash_path: &std::path::Path) -> Result<String> {
     use anyhow::Context;

--- a/brush-test-harness/src/util.rs
+++ b/brush-test-harness/src/util.rs
@@ -68,12 +68,12 @@ pub fn write_diff(
     Ok(())
 }
 
-/// Resolves the first element of the given launcher token list to an absolute
-/// path by walking the current `PATH`. This is needed because the test harness
-/// clears env vars (including `PATH`) before spawning child processes, so a
-/// launcher binary referenced by name (e.g., `wasmtime`) would fail to resolve
-/// at exec time.
-pub fn resolve_launcher_path(tokens: &mut Vec<String>) -> Result<()> {
+/// Resolves the first element of the given launcher token list to an absolute path.
+///
+/// This is needed because the test harness clears env vars (including `PATH`)
+/// before spawning child processes, so a launcher binary referenced by name
+/// (e.g., `wasmtime`) would fail to resolve at exec time.
+pub fn resolve_launcher_path(tokens: &mut [String]) -> Result<()> {
     let Some(first) = tokens.first() else {
         return Ok(());
     };

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -131,7 +131,7 @@ pub struct IntegrationTestArgs {
     /// Launcher command for the WASI runtime (only used with --wasi).
     /// The first token is resolved against `PATH`; subsequent tokens are
     /// passed as leading arguments before the brush binary path.
-    /// Defaults to "wasmtime run --dir=.::/ --".
+    /// Defaults to `wasmtime run --dir=.::/ --allow-precompiled --`.
     #[clap(long)]
     pub wasi_launcher: Option<String>,
 
@@ -369,17 +369,33 @@ fn run_integration_tests_wasi(
     // sandbox. This is intentionally permissive for testing — tests create
     // temp dirs and need access to fixtures across the filesystem. This is
     // NOT a recommended default for production use of brush under WASI.
+    // Pre-compile the wasm module to avoid JIT compilation overhead during
+    // parallel test execution. Without this, multiple concurrent wasmtime
+    // processes each try to JIT-compile brush.wasm simultaneously, which
+    // can exceed test timeouts on CI.
+    eprintln!("Pre-compiling brush.wasm...");
+    let cwasm_path = wasm_path.with_extension("cwasm");
+    {
+        let wasm_arg = wasm_path.display().to_string();
+        let cwasm_arg = cwasm_path.display().to_string();
+        cmd!(sh, "wasmtime compile {wasm_arg} -o {cwasm_arg}")
+            .run()
+            .context("failed to pre-compile brush.wasm with wasmtime")?;
+    }
+
+    // The default launcher includes --allow-precompiled so wasmtime accepts
+    // the AOT-compiled .cwasm module without re-compilation.
     let launcher = args
         .wasi_launcher
         .as_deref()
-        .unwrap_or("wasmtime run --dir=.::/ --");
+        .unwrap_or("wasmtime run --dir=.::/ --allow-precompiled --");
 
     eprintln!("Running brush integration tests under WASI...");
-    eprintln!("  wasm:     {}", wasm_path.display());
+    eprintln!("  wasm:     {}", cwasm_path.display());
     eprintln!("  launcher: {launcher}");
 
-    let wasm_path_str = wasm_path.display().to_string();
-    let _brush_path = sh.push_env("BRUSH_PATH", &wasm_path_str);
+    let brush_path_str = cwasm_path.display().to_string();
+    let _brush_path = sh.push_env("BRUSH_PATH", &brush_path_str);
     let _brush_launcher = sh.push_env("BRUSH_LAUNCHER", launcher);
     let _brush_platform_tags = sh.push_env("BRUSH_PLATFORM_TAGS", "wasi wasm");
 

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -121,6 +121,24 @@ pub struct IntegrationTestArgs {
     /// The copy is performed even if tests fail, so CI can always upload results.
     #[clap(long)]
     pub results_output: Option<PathBuf>,
+
+    /// Build and test against a wasm32-wasip2 target under a WASI runtime
+    /// (wasmtime by default). Builds brush for wasm32-wasip2 with minimal
+    /// features, then runs the integration tests under the WASI launcher.
+    #[clap(long)]
+    pub wasi: bool,
+
+    /// Launcher command for the WASI runtime (only used with --wasi).
+    /// The first token is resolved against `PATH`; subsequent tokens are
+    /// passed as leading arguments before the brush binary path.
+    /// Defaults to "wasmtime run --dir=.::/ --".
+    #[clap(long)]
+    pub wasi_launcher: Option<String>,
+
+    /// Skip the WASI wasm build step and assume brush.wasm is already
+    /// present at the expected path (only used with --wasi).
+    #[clap(long)]
+    pub skip_wasi_build: bool,
 }
 
 /// Arguments for coverage collection.
@@ -250,7 +268,8 @@ pub fn run_unit_tests(
 /// Run all workspace tests (unit + integration).
 ///
 /// This runs all tests in the workspace, including integration tests
-/// that execute the brush binary.
+/// that execute the brush binary. With `--wasi`, builds brush for
+/// wasm32-wasip2 and runs the integration tests under a WASI runtime.
 pub fn run_integration_tests(
     sh: &Shell,
     binary_args: &BinaryArgs,
@@ -258,6 +277,11 @@ pub fn run_integration_tests(
     verbose: bool,
 ) -> Result<()> {
     let profile = binary_args.effective_profile();
+
+    if args.wasi {
+        return run_integration_tests_wasi(sh, profile, args, verbose);
+    }
+
     eprintln!("Running integration tests ({profile:?} profile)...");
 
     #[cfg(windows)]
@@ -280,6 +304,88 @@ pub fn run_integration_tests(
             eprintln!("Integration tests passed.");
         })
     };
+
+    // Copy nextest results if requested (even on test failure, so CI can upload them).
+    if let Some(ref output) = args.results_output {
+        copy_nextest_results(output)?;
+    }
+
+    test_result
+}
+
+/// Run the brush integration tests against a wasm32-wasip2 build of brush,
+/// executed under a WASI runtime. Builds the wasm module first unless
+/// `--skip-wasi-build` is given, then runs the integration tests via nextest
+/// with the appropriate environment variables populated for the test harness.
+fn run_integration_tests_wasi(
+    sh: &Shell,
+    profile: BuildProfile,
+    args: &IntegrationTestArgs,
+    verbose: bool,
+) -> Result<()> {
+    let is_release = profile == BuildProfile::Release;
+
+    // Build the wasm module unless the caller opts out.
+    if !args.skip_wasi_build {
+        eprintln!("Building brush for wasm32-wasip2...");
+        let mut build_args = vec![
+            "build",
+            "--target",
+            "wasm32-wasip2",
+            "-p",
+            "brush-shell",
+            "--bin",
+            "brush",
+            "--no-default-features",
+            "--features",
+            "minimal",
+        ];
+        if is_release {
+            build_args.push("--release");
+        }
+        if verbose {
+            eprintln!("Running: cargo {}", build_args.join(" "));
+        }
+        cmd!(sh, "cargo {build_args...}")
+            .run()
+            .context("failed to build brush for wasm32-wasip2")?;
+    }
+
+    // Locate the wasm module that was (or should have been) produced.
+    let workspace_root = find_workspace_root()?;
+    let profile_dir = if is_release { "release" } else { "debug" };
+    let wasm_path = workspace_root
+        .join("target/wasm32-wasip2")
+        .join(profile_dir)
+        .join("brush.wasm");
+    let wasm_path = wasm_path.canonicalize().with_context(|| {
+        format!(
+            "brush.wasm not found at {} — did the build step succeed?",
+            wasm_path.display()
+        )
+    })?;
+
+    // The `--dir=.::/` flag maps the host root filesystem into the WASI
+    // sandbox. This is intentionally permissive for testing — tests create
+    // temp dirs and need access to fixtures across the filesystem. This is
+    // NOT a recommended default for production use of brush under WASI.
+    let launcher = args
+        .wasi_launcher
+        .as_deref()
+        .unwrap_or("wasmtime run --dir=.::/ --");
+
+    eprintln!("Running brush integration tests under WASI...");
+    eprintln!("  wasm:     {}", wasm_path.display());
+    eprintln!("  launcher: {launcher}");
+
+    let wasm_path_str = wasm_path.display().to_string();
+    let _brush_path = sh.push_env("BRUSH_PATH", &wasm_path_str);
+    let _brush_launcher = sh.push_env("BRUSH_LAUNCHER", launcher);
+    let _brush_platform_tags = sh.push_env("BRUSH_PLATFORM_TAGS", "wasi wasm");
+
+    // Only run the brush integration tests; compat tests require a native binary.
+    let filter = "binary(brush-integration-tests)";
+    let test_result = run_nextest(sh, profile, Some(filter), verbose);
 
     // Copy nextest results if requested (even on test failure, so CI can upload them).
     if let Some(ref output) = args.results_output {

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -124,7 +124,8 @@ pub struct IntegrationTestArgs {
 
     /// Build and test against a wasm32-wasip2 target under a WASI runtime
     /// (wasmtime by default). Builds brush for wasm32-wasip2 with minimal
-    /// features, then runs the integration tests under the WASI launcher.
+    /// features, then runs a subset of integration tests (excluding compat,
+    /// interactive, and completion suites) under the WASI launcher.
     #[clap(long)]
     pub wasi: bool,
 
@@ -279,6 +280,9 @@ pub fn run_integration_tests(
     let profile = binary_args.effective_profile();
 
     if args.wasi {
+        if args.coverage.coverage {
+            eprintln!("Warning: --coverage is not supported with --wasi and will be ignored.");
+        }
         return run_integration_tests_wasi(sh, profile, args, verbose);
     }
 


### PR DESCRIPTION
Enables *extremely* basic tests to run against wasm32-wasip2 target in CI via `wasmtime`.