### PR TITLE
fix(windows): fix /dev/null handling

### DIFF
--- a/brush-core/src/sys/windows/fs.rs
+++ b/brush-core/src/sys/windows/fs.rs
@@ -148,7 +148,7 @@ pub fn open_null_file() -> Result<std::fs::File, error::Error> {
 
 /// Gives the platform an opportunity to handle a special file path (e.g. `/dev/null`).
 pub fn try_open_special_file(path: &Path) -> Option<Result<std::fs::File, std::io::Error>> {
-    if path == Path::new("/dev/null") {
+    if path.ends_with("dev/null") && path.is_absolute() {
         Some(open_null_file().map_err(std::io::Error::other))
     } else {
         None


### PR DESCRIPTION
This makes brush closer to behaving correctly with starship on Windows.

Before:
```
PS D:\wfs> brush
error: command not found:
error: failed to redirect to D:/dev/null: The system cannot find the path specified. (os error 3)

D:wfs
❯ ls
brush  portage	redbox
error: failed to redirect to D:/dev/null: The system cannot find the path specified. (os error 3)
```

After:
```
PS D:\wfs> .\brush\target\debug\brush
error: command not found:

D:wfs
❯ ls
brush  portage	redbox
```