### PR TITLE
fix: bang formatted without space leads to invalid command

### DIFF
--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -346,7 +346,7 @@ impl Display for Pipeline {
         }
 
         if self.bang {
-            write!(f, "!")?;
+            write!(f, "! ")?;
         }
         for (i, command) in self.seq.iter().enumerate() {
             if i > 0 {


### PR DESCRIPTION
When formatting a negated command like:

```
! $0
```

`Pipeline::fmt` results in:

```
!$0
```

which is incorrect.