### PR TITLE
feat: use bstr::BString for shell values to fix UTF-8 lossy conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "async-trait",
  "bon",
  "brush-parser",
+ "bstr",
  "cached",
  "cfg-if",
  "check_elevation",

--- a/ISSUE_DRAFT.md
+++ b/ISSUE_DRAFT.md
@@ -1,0 +1,58 @@
+# `declare -a`/plain array assignment on a dynamic well-known variable (e.g. `PIPESTATUS`) permanently freezes it
+
+## Summary
+
+Once a script `declare -a`s or plain-array-assigns a dynamic well-known variable such as `PIPESTATUS`, brush **never updates it again** on later pipelines in that shell — it stays frozen at whatever was last assigned. Real bash keeps the variable live and refreshes it on every pipeline.
+
+## Minimal repro
+
+```bash
+declare -a PIPESTATUS=([0]="1")
+true | true | true
+echo "${PIPESTATUS[@]}"
+```
+
+- **bash**: `0 0 0`
+- **brush** (current `origin/main`): `1`
+
+The same freeze happens with a plain array assignment (no `declare`):
+
+```bash
+PIPESTATUS=([0]="9")
+true | false | true
+echo "${PIPESTATUS[@]}"
+```
+
+- **bash**: `0 1 0`
+- **brush**: `9`
+
+## Root cause
+
+`PIPESTATUS` is implemented as a dynamic well-known variable backed by a `ShellValue::Dynamic { getter, setter }` (`brush-core/src/wellknownvars.rs`). Reads go through `getter` (which calls `shell.last_pipeline_statuses()` live), and every write is supposed to be a no-op via `setter: |_| ()`. But two write paths in `brush-core/src/variables.rs` unconditionally overwrite `self.value` with a static array, **discarding the `Dynamic` binding**:
+
+1. `ShellVariable::convert_to_indexed_array` — the `_` arm hits for a `Dynamic` value and replaces `self.value` with `ShellValue::IndexedArray(...)`. Triggered by `declare -a` via `brush-builtins/src/declare.rs`.
+2. `ShellVariable::assign` (non-append Array-literal arm) — the match explicitly includes `ShellValue::Dynamic { .. }` in the list of variants that get overwritten with `ShellValue::indexed_array_from_literals(...)`. Triggered by a plain `VAR=([0]="...")` assignment.
+
+From that point on the variable is just an ordinary frozen array; nothing in the pipeline-execution path ever calls the getter again, because the getter closure is gone.
+
+The same class of issue affects every dynamic well-known variable (`RANDOM`, `SECONDS`, `FUNCNAME`, `BASH_LINENO`, `BASH_SOURCE`, `BASH_ALIASES`, etc.) — all of them register `setter: |_| ()`, so the setter field exists precisely for this case but isn't consulted on these two paths.
+
+## Suggested fix
+
+In both paths, route `ShellValue::Dynamic` through the setter (or simply no-op it) instead of overwriting `self.value`. Concretely, in `brush-core/src/variables.rs`:
+
+- `convert_to_indexed_array`: add an explicit `ShellValue::Dynamic { .. } => Ok(())` arm before the `_` arm.
+- `assign`: drop `ShellValue::Dynamic { .. }` from the variants that get converted to a static indexed array; the existing `(ShellValue::Dynamic { .. }, _) => Ok(())` arm below already does the right thing.
+
+### Note on `declare -A` / `convert_to_associative_array`
+
+`convert_to_associative_array` has the same overwrite pattern, but real bash is asymmetric here: `declare -A PIPESTATUS=([x]="9")` **does** permanently freeze it in bash itself (PIPESTATUS becomes a plain associative array that pipelines don't refresh). Pre-fix brush already matches bash's `-A` behavior, so it's intentionally left unchanged. (One could argue keeping dynamic vars live even after `declare -A` is more internally consistent for brush, but it would diverge from bash compat.)
+
+## Why this matters
+
+Any script that explicitly `declare -a`s `PIPESTATUS` (or any other dynamic well-known variable) will silently get a stale/wrong value for the rest of that shell's life. This surfaced in the wild when a worker-env dump/restore mechanism restored a `declare -a PIPESTATUS=([0]="1")` line and a downstream `pipestatus || die` check fired incorrectly, misreporting a successful pipeline as failed.
+
+## Environment
+
+- brush: current `origin/main` (`4ff5cc83`)
+- bash: 5.x (verified against 5.2/5.3)

--- a/brush-builtins/Cargo.toml
+++ b/brush-builtins/Cargo.toml
@@ -133,7 +133,7 @@ brush-parser = { version = "^0.4.0", path = "../brush-parser" }
 cfg-if = "1.0.4"
 chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive", "wrap_help"] }
-fancy-regex = "0.18.0"
+fancy-regex = "0.19.0"
 itertools = "0.14.0"
 strum = "0.28.0"
 thiserror = "2.0.18"

--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -398,12 +398,12 @@ impl DeclareCommand {
                     ast::AssignmentValue::Scalar(s) => {
                         if let Some(index) = &assigned_index {
                             initial_value = Some(ShellValueLiteral::Array(ArrayLiteral(vec![(
-                                Some(index.to_owned()),
-                                s.value.clone(),
+                                Some(index.to_owned().into()),
+                                s.value.clone().into(),
                             )])));
                             name_is_array = true;
                         } else {
-                            initial_value = Some(ShellValueLiteral::Scalar(s.value.clone()));
+                            initial_value = Some(ShellValueLiteral::Scalar(s.value.clone().into()));
                             name_is_array = false;
                         }
                     }
@@ -411,7 +411,10 @@ impl DeclareCommand {
                         initial_value = Some(ShellValueLiteral::Array(ArrayLiteral(
                             a.iter()
                                 .map(|(i, v)| {
-                                    (i.as_ref().map(|w| w.value.clone()), v.value.clone())
+                                    (
+                                        i.as_ref().map(|w| w.value.clone().into()),
+                                        v.value.clone().into(),
+                                    )
                                 })
                                 .collect(),
                         )));

--- a/brush-builtins/src/export.rs
+++ b/brush-builtins/src/export.rs
@@ -106,12 +106,14 @@ impl ExportCommand {
 
                 let value = match &assignment.value {
                     ast::AssignmentValue::Scalar(s) => {
-                        variables::ShellValueLiteral::Scalar(s.flatten())
+                        variables::ShellValueLiteral::Scalar(s.flatten().into())
                     }
                     ast::AssignmentValue::Array(a) => {
                         variables::ShellValueLiteral::Array(variables::ArrayLiteral(
                             a.iter()
-                                .map(|(k, v)| (k.as_ref().map(|k| k.flatten()), v.flatten()))
+                                .map(|(k, v)| {
+                                    (k.as_ref().map(|k| k.flatten().into()), v.flatten().into())
+                                })
                                 .collect(),
                         ))
                     }

--- a/brush-builtins/src/getopts.rs
+++ b/brush-builtins/src/getopts.rs
@@ -255,7 +255,7 @@ fn parse_next_option<SE: brush_core::ShellExtensions>(
         // and request that OPTIND not be updated.
         context.shell.env_mut().update_or_add(
             VAR_GETOPTS_NEXT_CHAR_INDEX,
-            variables::ShellValueLiteral::Scalar((next_char_index + 1).to_string()),
+            variables::ShellValueLiteral::Scalar((next_char_index + 1).to_string().into()),
             |v| {
                 v.hide_from_enumeration();
                 Ok(())
@@ -348,7 +348,7 @@ fn update_variables<SE: brush_core::ShellExtensions>(
     // Update variable value.
     context.shell.env_mut().update_or_add(
         variable_name,
-        variables::ShellValueLiteral::Scalar(result.variable_value),
+        variables::ShellValueLiteral::Scalar(result.variable_value.into()),
         |_| Ok(()),
         brush_core::env::EnvironmentLookup::Anywhere,
         brush_core::env::EnvironmentScope::Global,
@@ -358,7 +358,7 @@ fn update_variables<SE: brush_core::ShellExtensions>(
     if let Some(optarg) = result.optarg {
         context.shell.env_mut().update_or_add(
             "OPTARG",
-            variables::ShellValueLiteral::Scalar(optarg),
+            variables::ShellValueLiteral::Scalar(optarg.into()),
             |_| Ok(()),
             brush_core::env::EnvironmentLookup::Anywhere,
             brush_core::env::EnvironmentScope::Global,
@@ -371,14 +371,14 @@ fn update_variables<SE: brush_core::ShellExtensions>(
     let optind_str = result.optind.to_string();
     context.shell.env_mut().update_or_add(
         "OPTIND",
-        variables::ShellValueLiteral::Scalar(optind_str.clone()),
+        variables::ShellValueLiteral::Scalar(optind_str.clone().into()),
         |_| Ok(()),
         brush_core::env::EnvironmentLookup::Anywhere,
         brush_core::env::EnvironmentScope::Global,
     )?;
     context.shell.env_mut().update_or_add(
         VAR_GETOPTS_LAST_OPTIND,
-        variables::ShellValueLiteral::Scalar(optind_str),
+        variables::ShellValueLiteral::Scalar(optind_str.into()),
         |v| {
             v.hide_from_enumeration();
             Ok(())

--- a/brush-builtins/src/mapfile.rs
+++ b/brush-builtins/src/mapfile.rs
@@ -174,7 +174,7 @@ impl MapFileCommand {
                 line.pop();
             }
 
-            let line_str = String::from_utf8_lossy(&line).to_string();
+            let line_str = brush_core::BString::from(line);
 
             entries.push((None, line_str));
         }

--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -169,7 +169,12 @@ fn assign_input_to_variables(
         let literal_fields = build_array_fields(input_line, ifs, skip_ifs_splitting);
         shell.env_mut().update_or_add(
             array_variable,
-            variables::ShellValueLiteral::Array(variables::ArrayLiteral(literal_fields)),
+            variables::ShellValueLiteral::Array(variables::ArrayLiteral(
+                literal_fields
+                    .into_iter()
+                    .map(|(k, v)| (k.map(Into::into), v.into()))
+                    .collect(),
+            )),
             |_| Ok(()),
             env::EnvironmentLookup::Anywhere,
             env::EnvironmentScope::Global,
@@ -179,7 +184,7 @@ fn assign_input_to_variables(
     } else {
         shell.env_mut().update_or_add(
             "REPLY",
-            variables::ShellValueLiteral::Scalar(input_line.unwrap_or_default().to_owned()),
+            variables::ShellValueLiteral::Scalar(input_line.unwrap_or_default().to_owned().into()),
             |_| Ok(()),
             env::EnvironmentLookup::Anywhere,
             env::EnvironmentScope::Global,
@@ -217,7 +222,7 @@ fn assign_to_named_variables(
 
         shell.env_mut().update_or_add(
             name,
-            variables::ShellValueLiteral::Scalar(value),
+            variables::ShellValueLiteral::Scalar(value.into()),
             |_| Ok(()),
             env::EnvironmentLookup::Anywhere,
             env::EnvironmentScope::Global,

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -31,7 +31,7 @@ cfg-if = "1.0.4"
 chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive", "wrap_help"] }
 color-print = "0.3.7"
-fancy-regex = "0.18.0"
+fancy-regex = "0.19.0"
 futures = "0.3.32"
 inherent = "1.0.13"
 itertools = "0.14.0"

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -18,12 +18,13 @@ workspace = true
 
 [features]
 default = []
-serde = ["dep:serde", "brush-parser/serde", "rpds/serde", "chrono/serde"]
+serde = ["dep:serde", "brush-parser/serde", "rpds/serde", "chrono/serde", "bstr/serde"]
 experimental-parser = ["brush-parser/winnow-parser"]
 
 [dependencies]
 async-recursion = "1.1.1"
 async-trait = "0.1.89"
+bstr = "1.12.0"
 brush-parser = { version = "^0.4.0", path = "../brush-parser" }
 bon = "3.9.1"
 cached = "0.59.0"

--- a/brush-core/src/arithmetic.rs
+++ b/brush-core/src/arithmetic.rs
@@ -210,7 +210,9 @@ fn deref_lvalue(
                     |(_, v)| v.value().get_at(index_str.as_str(), shell),
                 )
                 .map_err(|_err| EvalError::FailedToAccessArray)?
-                .unwrap_or(Cow::Borrowed(""))
+                .map(|v| v.to_string())
+                .unwrap_or_default()
+                .into()
         }
     };
 
@@ -373,7 +375,7 @@ fn assign(
                 .env_mut()
                 .update_or_add(
                     name.as_str(),
-                    variables::ShellValueLiteral::Scalar(value.to_string()),
+                    variables::ShellValueLiteral::Scalar(value.to_string().into()),
                     |_| Ok(()),
                     env::EnvironmentLookup::Anywhere,
                     env::EnvironmentScope::Global,

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -199,7 +199,8 @@ pub fn compose_std_command<S: AsRef<OsStr>, SE: extensions::ShellExtensions>(
             // that are set (i.e., have a value). This means a variable that
             // shows up in `declare -p` but has no *set* value will be omitted.
             if v.value().is_set() {
-                cmd.env(k.as_str(), v.value().to_cow_str(context.shell).as_ref());
+                let val = v.value().to_cow_str(context.shell);
+                cmd.env(k.as_str(), val.to_string());
             }
         }
         // Set _ to the resolved command path for external commands.
@@ -261,7 +262,7 @@ pub(crate) async fn on_preexecute(
     let full_cmd = cmd.args.iter().map(|arg| arg.to_string()).join(" ");
     cmd.shell.env_mut().update_or_add(
         "BASH_COMMAND",
-        variables::ShellValueLiteral::Scalar(full_cmd),
+        variables::ShellValueLiteral::Scalar(full_cmd.into()),
         |_| Ok(()),
         env::EnvironmentLookup::Anywhere,
         env::EnvironmentScope::Global,

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -799,12 +799,12 @@ impl Spec {
                 match reply.value() {
                     variables::ShellValue::IndexedArray(values) => {
                         return Ok(Answer::Candidates(
-                            values.values().map(|v| v.to_owned()).collect(),
+                            values.values().map(|v| v.to_string()).collect(),
                             ProcessingOptions::default(),
                         ));
                     }
                     variables::ShellValue::String(s) => {
-                        let candidates = vec![s.to_owned()];
+                        let candidates = vec![s.to_string()];
                         return Ok(Answer::Candidates(candidates, ProcessingOptions::default()));
                     }
                     _ => (),

--- a/brush-core/src/env.rs
+++ b/brush-core/src/env.rs
@@ -275,8 +275,10 @@ impl ShellEnvironment {
         name: S,
         shell: &Shell<SE>,
     ) -> Option<Cow<'_, str>> {
-        self.get(name.as_ref())
-            .map(|(_, v)| v.value().to_cow_str(shell))
+        self.get(name.as_ref()).map(|(_, v)| {
+            let cow = v.value().to_cow_str(shell);
+            Cow::Owned(cow.to_string())
+        })
     }
 
     /// Checks if a variable of the given name is set in the environment.
@@ -507,16 +509,22 @@ impl ShellEnvironment {
     /// * `updater` - A function to call to update the variable after assigning the value.
     /// * `lookup_policy` - The policy to use when looking up the variable.
     /// * `scope_if_creating` - The scope to create the variable in if it doesn't already exist.
-    pub fn update_or_add_array_element<N: Into<String>>(
+    pub fn update_or_add_array_element<
+        N: Into<String>,
+        I: Into<bstr::BString>,
+        V: Into<bstr::BString>,
+    >(
         &mut self,
         name: N,
-        index: String,
-        value: String,
+        index: I,
+        value: V,
         updater: impl Fn(&mut ShellVariable) -> Result<(), error::Error>,
         lookup_policy: EnvironmentLookup,
         scope_if_creating: EnvironmentScope,
     ) -> Result<(), error::Error> {
         let name = name.into();
+        let index = index.into();
+        let value = value.into();
 
         if let Some(var) = self.get_mut_using_policy(&name, lookup_policy) {
             var.assign_at_index(index, value, false)?;

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -323,8 +323,8 @@ impl From<ExpansionPiece> for String {
 impl From<ExpansionPiece> for patterns::PatternPiece {
     fn from(piece: ExpansionPiece) -> Self {
         match piece {
-            ExpansionPiece::Unsplittable(s) => Self::Literal(bstring_to_string(s)),
-            ExpansionPiece::Splittable(s) => Self::Pattern(bstring_to_string(s)),
+            ExpansionPiece::Unsplittable(s) => Self::Literal(s),
+            ExpansionPiece::Splittable(s) => Self::Pattern(s),
         }
     }
 }
@@ -332,8 +332,8 @@ impl From<ExpansionPiece> for patterns::PatternPiece {
 impl From<ExpansionPiece> for crate::regex::RegexPiece {
     fn from(piece: ExpansionPiece) -> Self {
         match piece {
-            ExpansionPiece::Unsplittable(s) => Self::Literal(bstring_to_string(s)),
-            ExpansionPiece::Splittable(s) => Self::Pattern(bstring_to_string(s)),
+            ExpansionPiece::Unsplittable(s) => Self::Literal(s),
+            ExpansionPiece::Splittable(s) => Self::Pattern(s),
         }
     }
 }
@@ -670,7 +670,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                     .map(patterns::PatternPiece::from)
                     .collect::<Vec<_>>()
             })
-            .intersperse(vec![patterns::PatternPiece::Literal(String::from(" "))])
+            .intersperse(vec![patterns::PatternPiece::Literal(
+                String::from(" ").into(),
+            )])
             .flatten()
             .collect();
 
@@ -697,7 +699,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                     .map(crate::regex::RegexPiece::from)
                     .collect::<Vec<_>>()
             })
-            .intersperse(vec![crate::regex::RegexPiece::Literal(String::from(" "))])
+            .intersperse(vec![crate::regex::RegexPiece::Literal(
+                String::from(" ").into(),
+            )])
             .flatten()
             .collect();
 

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -5,6 +5,7 @@ use std::cmp::min;
 use std::io::Write as _;
 
 use brush_parser::word::{ParameterTransformOp, SubstringMatchKind};
+use bstr::{BString, ByteSlice, ByteVec};
 use itertools::Itertools;
 
 use crate::ExecutionParameters;
@@ -124,7 +125,7 @@ impl Expansion {
         let non_empty = self
             .fields
             .iter()
-            .any(|field| field.0.iter().any(|piece| !piece.as_str().is_empty()));
+            .any(|field| field.0.iter().any(|piece| !piece.is_empty()));
 
         if self.undefined {
             ParameterState::Undefined
@@ -195,8 +196,7 @@ impl Expansion {
                     // Get the inner string of the piece, and figure out how many
                     // characters are in it; make sure to get the *character count*
                     // and not just call `.len()` to get the byte count.
-                    let piece_str = piece.as_str();
-                    let piece_char_count = piece_str.chars().count();
+                    let piece_char_count = piece.chars().count();
 
                     // If the interesting data isn't even in this piece yet, then
                     // continue until we find it.
@@ -216,13 +216,15 @@ impl Expansion {
                             s.chars()
                                 .skip(desired_offset_into_this_piece)
                                 .take(len_from_this_piece)
-                                .collect(),
+                                .collect::<String>()
+                                .into(),
                         ),
                         ExpansionPiece::Splittable(s) => ExpansionPiece::Splittable(
                             s.chars()
                                 .skip(desired_offset_into_this_piece)
                                 .take(len_from_this_piece)
-                                .collect(),
+                                .collect::<String>()
+                                .into(),
                         ),
                     };
 
@@ -286,21 +288,34 @@ impl From<ExpansionPiece> for WordField {
 
 impl From<String> for WordField {
     fn from(value: String) -> Self {
+        Self(vec![ExpansionPiece::Splittable(value.into())])
+    }
+}
+
+impl From<BString> for WordField {
+    fn from(value: BString) -> Self {
         Self(vec![ExpansionPiece::Splittable(value)])
     }
 }
 
+/// Converts a [`BString`] to a [`String`], preserving valid UTF-8 and falling
+/// back to lossy conversion only when the bytes are not valid UTF-8.
+fn bstring_to_string(s: BString) -> String {
+    String::from_utf8(Vec::from(s))
+        .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).into_owned())
+}
+
 #[derive(Clone, Debug, PartialEq)]
 enum ExpansionPiece {
-    Unsplittable(String),
-    Splittable(String),
+    Unsplittable(BString),
+    Splittable(BString),
 }
 
 impl From<ExpansionPiece> for String {
     fn from(piece: ExpansionPiece) -> Self {
         match piece {
-            ExpansionPiece::Unsplittable(s) => s,
-            ExpansionPiece::Splittable(s) => s,
+            ExpansionPiece::Unsplittable(s) => bstring_to_string(s),
+            ExpansionPiece::Splittable(s) => bstring_to_string(s),
         }
     }
 }
@@ -308,8 +323,8 @@ impl From<ExpansionPiece> for String {
 impl From<ExpansionPiece> for patterns::PatternPiece {
     fn from(piece: ExpansionPiece) -> Self {
         match piece {
-            ExpansionPiece::Unsplittable(s) => Self::Literal(s),
-            ExpansionPiece::Splittable(s) => Self::Pattern(s),
+            ExpansionPiece::Unsplittable(s) => Self::Literal(bstring_to_string(s)),
+            ExpansionPiece::Splittable(s) => Self::Pattern(bstring_to_string(s)),
         }
     }
 }
@@ -317,24 +332,31 @@ impl From<ExpansionPiece> for patterns::PatternPiece {
 impl From<ExpansionPiece> for crate::regex::RegexPiece {
     fn from(piece: ExpansionPiece) -> Self {
         match piece {
-            ExpansionPiece::Unsplittable(s) => Self::Literal(s),
-            ExpansionPiece::Splittable(s) => Self::Pattern(s),
+            ExpansionPiece::Unsplittable(s) => Self::Literal(bstring_to_string(s)),
+            ExpansionPiece::Splittable(s) => Self::Pattern(bstring_to_string(s)),
         }
     }
 }
 
 impl ExpansionPiece {
-    const fn as_str(&self) -> &str {
+    fn is_empty(&self) -> bool {
         match self {
-            Self::Unsplittable(s) => s.as_str(),
-            Self::Splittable(s) => s.as_str(),
+            Self::Unsplittable(s) => s.is_empty(),
+            Self::Splittable(s) => s.is_empty(),
         }
     }
 
-    const fn len(&self) -> usize {
+    fn len(&self) -> usize {
         match self {
             Self::Unsplittable(s) => s.len(),
             Self::Splittable(s) => s.len(),
+        }
+    }
+
+    fn chars(&self) -> bstr::Chars<'_> {
+        match self {
+            Self::Unsplittable(s) => s.chars(),
+            Self::Splittable(s) => s.chars(),
         }
     }
 
@@ -699,7 +721,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
             &['$', '`', '\\', '\'', '\"', '~', '{']
         };
         if !word.contains(expansion_chars) {
-            return Ok(Expansion::from(ExpansionPiece::Splittable(word.to_owned())));
+            return Ok(Expansion::from(ExpansionPiece::Splittable(
+                word.to_owned().into(),
+            )));
         }
 
         // Apply brace expansion first, before anything else (not applicable to heredoc bodies).
@@ -843,11 +867,11 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                                 }
                             } else {
                                 match current_field.0.last_mut() {
-                                    Some(ExpansionPiece::Splittable(last)) => last.push(c),
+                                    Some(ExpansionPiece::Splittable(last)) => last.push_char(c),
                                     Some(ExpansionPiece::Unsplittable(_)) | None => {
                                         current_field
                                             .0
-                                            .push(ExpansionPiece::Splittable(c.to_string()));
+                                            .push(ExpansionPiece::Splittable(c.to_string().into()));
                                     }
                                 }
                             }
@@ -909,19 +933,17 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
     ) -> Result<Expansion, error::Error> {
         let expansion: Expansion = match word_piece {
             brush_parser::word::WordPiece::Text(s) => {
-                Expansion::from(ExpansionPiece::Splittable(s))
+                Expansion::from(ExpansionPiece::Splittable(s.into()))
             }
             brush_parser::word::WordPiece::SingleQuotedText(s) => {
-                Expansion::from(ExpansionPiece::Unsplittable(s))
+                Expansion::from(ExpansionPiece::Unsplittable(s.into()))
             }
             brush_parser::word::WordPiece::AnsiCQuotedText(s) => {
                 let (expanded, _) = escape::expand_backslash_escapes(
                     s.as_str(),
                     escape::EscapeExpansionMode::AnsiCQuotes,
                 )?;
-                Expansion::from(ExpansionPiece::Unsplittable(
-                    String::from_utf8_lossy(expanded.as_slice()).into_owned(),
-                ))
+                Expansion::from(ExpansionPiece::Unsplittable(BString::from(expanded)))
             }
             brush_parser::word::WordPiece::DoubleQuotedSequence(pieces)
             | brush_parser::word::WordPiece::GettextDoubleQuotedSequence(pieces) => {
@@ -944,7 +966,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 // If there were no pieces, then make sure we yield a single field containing an
                 // empty, unsplittable string.
                 if pieces_is_empty {
-                    fields.push(WordField::from(ExpansionPiece::Unsplittable(String::new())));
+                    fields.push(WordField::from(ExpansionPiece::Unsplittable(
+                        String::new().into(),
+                    )));
                 }
 
                 Expansion {
@@ -956,7 +980,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
             }
             brush_parser::word::WordPiece::TildeExpansion(tilde_expr) => {
                 Expansion::from(ExpansionPiece::Unsplittable(
-                    self.expand_tilde_expression(&tilde_expr)?.to_string(),
+                    self.expand_tilde_expression(&tilde_expr)?
+                        .to_string()
+                        .into(),
                 ))
             }
             brush_parser::word::WordPiece::ParameterExpansion(p) => {
@@ -984,13 +1010,13 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 let trimmed_len = cmd_output.trim_end_matches('\n').len();
                 cmd_output.truncate(trimmed_len);
 
-                Expansion::from(ExpansionPiece::Splittable(cmd_output))
+                Expansion::from(ExpansionPiece::Splittable(cmd_output.into()))
             }
             brush_parser::word::WordPiece::EscapeSequence(s) => {
                 let Some(escaped) = s.strip_prefix('\\') else {
                     // We don't ever expect this case, as it breaks our invariant--but
                     // we handle it to avoid panicking.
-                    return Ok(Expansion::from(ExpansionPiece::Unsplittable(s)));
+                    return Ok(Expansion::from(ExpansionPiece::Unsplittable(s.into())));
                 };
 
                 // Inside actual double-quoted text, the parser only emits an
@@ -998,36 +1024,36 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 // we always strip the backslash there.
                 if self.in_double_quotes {
                     return Ok(Expansion::from(ExpansionPiece::Unsplittable(
-                        escaped.to_owned(),
+                        escaped.to_owned().into(),
                     )));
                 }
 
                 match self.unquoted_backslash_handling {
                     UnquotedBackslashHandling::Strip => {
                         // Default unquoted semantics: consume the backslash.
-                        Expansion::from(ExpansionPiece::Unsplittable(escaped.to_owned()))
+                        Expansion::from(ExpansionPiece::Unsplittable(escaped.to_owned().into()))
                     }
                     UnquotedBackslashHandling::Preserve => {
                         // Preserve `\X` verbatim (e.g., for pattern syntax).
-                        Expansion::from(ExpansionPiece::Splittable(s))
+                        Expansion::from(ExpansionPiece::Splittable(s.into()))
                     }
                     UnquotedBackslashHandling::DoubleQuoted => {
                         // `\<newline>` is a line continuation: both characters
                         // are consumed.
                         if escaped.starts_with('\n') {
-                            Expansion::from(ExpansionPiece::Unsplittable(String::new()))
+                            Expansion::from(ExpansionPiece::Unsplittable(String::new().into()))
                         } else if escaped.starts_with(DOUBLE_QUOTED_ESCAPE_CHARS) {
                             // Consume the backslash; preserve the next char.
-                            Expansion::from(ExpansionPiece::Unsplittable(escaped.to_owned()))
+                            Expansion::from(ExpansionPiece::Unsplittable(escaped.to_owned().into()))
                         } else {
                             // Preserve both characters.
-                            Expansion::from(ExpansionPiece::Unsplittable(s))
+                            Expansion::from(ExpansionPiece::Unsplittable(s.into()))
                         }
                     }
                 }
             }
             brush_parser::word::WordPiece::ArithmeticExpression(e) => Expansion::from(
-                ExpansionPiece::Splittable(self.expand_arithmetic_expr(e).await?),
+                ExpansionPiece::Splittable(self.expand_arithmetic_expr(e).await?.into()),
             ),
         };
 
@@ -1118,7 +1144,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                             .collect()
                     })
                     .intersperse(vec![ExpansionPiece::Unsplittable(
-                        concatenation_joiner.to_string(),
+                        concatenation_joiner.to_string().into(),
                     )])
                     .flatten()
                     .collect();
@@ -1126,7 +1152,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 // If there were no pieces, make sure there's an empty string after
                 // concatenation.
                 if concatenated.is_empty() {
-                    concatenated.push(ExpansionPiece::Splittable(String::new()));
+                    concatenated.push(ExpansionPiece::Splittable(String::new().into()));
                 }
 
                 vec![WordField(concatenated)]
@@ -1357,7 +1383,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
 
                     expanded_parameter.fields.insert(
                         0,
-                        WordField::from(ExpansionPiece::Splittable(shell_name.to_string())),
+                        WordField::from(ExpansionPiece::Splittable(shell_name.to_string().into())),
                     );
                 }
 
@@ -1596,7 +1622,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                     Ok(Expansion {
                         fields: matching_names
                             .into_iter()
-                            .map(|name| WordField(vec![ExpansionPiece::Splittable(name)]))
+                            .map(|name| WordField(vec![ExpansionPiece::Splittable(name.into())]))
                             .collect(),
                         concatenate,
                         from_array: true,
@@ -1617,7 +1643,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 Ok(Expansion {
                     fields: keys
                         .into_iter()
-                        .map(|key| WordField(vec![ExpansionPiece::Splittable(key.to_string())]))
+                        .map(|key| WordField(vec![ExpansionPiece::Splittable(key)]))
                         .collect(),
                     concatenate,
                     from_array: true,
@@ -1845,9 +1871,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                     Ok(Expansion {
                         fields: values
                             .into_iter()
-                            .map(|value| {
-                                WordField(vec![ExpansionPiece::Splittable(value.to_string())])
-                            })
+                            .map(|value| WordField(vec![ExpansionPiece::Splittable(value)]))
                             .collect(),
                         concatenate: *concatenate,
                         from_array: true,
@@ -1892,7 +1916,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 Expansion {
                     fields: args
                         .into_iter()
-                        .map(|param| WordField(vec![ExpansionPiece::Splittable(param.to_owned())]))
+                        .map(|param| {
+                            WordField(vec![ExpansionPiece::Splittable(param.to_owned().into())])
+                        })
                         .collect(),
                     concatenate: *concatenate,
                     from_array: true,
@@ -2244,7 +2270,7 @@ mod tests {
         let expansion = Expansion {
             fields: vec![
                 WordField(vec![ExpansionPiece::Unsplittable("A".into())]),
-                WordField(vec![ExpansionPiece::Unsplittable(String::new())]),
+                WordField(vec![ExpansionPiece::Unsplittable(String::new().into())]),
             ],
             ..Expansion::default()
         };
@@ -2254,8 +2280,8 @@ mod tests {
         assert_eq!(
             fields,
             vec![
-                WordField(vec![ExpansionPiece::Unsplittable(String::from("A"))]),
-                WordField(vec![ExpansionPiece::Unsplittable(String::new())])
+                WordField(vec![ExpansionPiece::Unsplittable(BString::from("A"))]),
+                WordField(vec![ExpansionPiece::Unsplittable(BString::new(vec![]))])
             ]
         );
 

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1617,7 +1617,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 Ok(Expansion {
                     fields: keys
                         .into_iter()
-                        .map(|key| WordField(vec![ExpansionPiece::Splittable(key)]))
+                        .map(|key| WordField(vec![ExpansionPiece::Splittable(key.to_string())]))
                         .collect(),
                     concatenate,
                     from_array: true,
@@ -1674,7 +1674,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         } else {
             self.shell.env_mut().update_or_add(
                 variable_name,
-                variables::ShellValueLiteral::Scalar(value),
+                variables::ShellValueLiteral::Scalar(value.into()),
                 |_| Ok(()),
                 env::EnvironmentLookup::Anywhere,
                 env::EnvironmentScope::Global,
@@ -1845,7 +1845,9 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                     Ok(Expansion {
                         fields: values
                             .into_iter()
-                            .map(|value| WordField(vec![ExpansionPiece::Splittable(value)]))
+                            .map(|value| {
+                                WordField(vec![ExpansionPiece::Splittable(value.to_string())])
+                            })
                             .collect(),
                         concatenate: *concatenate,
                         from_array: true,
@@ -1972,9 +1974,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         if let Some(pattern) = pattern {
             if !pattern.is_empty() {
                 let regex = pattern.to_regex(false, false)?;
-                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_, str>| {
-                    transform(&caps[0])
-                });
+                let result = regex
+                    .replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_, str>| {
+                        transform(&caps[0])
+                    });
                 Ok(result.into_owned())
             } else {
                 Ok(transform(s))

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1972,7 +1972,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         if let Some(pattern) = pattern {
             if !pattern.is_empty() {
                 let regex = pattern.to_regex(false, false)?;
-                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_>| {
+                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_, str>| {
                     transform(&caps[0])
                 });
                 Ok(result.into_owned())

--- a/brush-core/src/extendedtests.rs
+++ b/brush-core/src/extendedtests.rs
@@ -228,7 +228,7 @@ async fn apply_binary_predicate(
             let captures_value = variables::ShellValueLiteral::Array(ArrayLiteral(
                 captures
                     .into_iter()
-                    .map(|c| (None, c.unwrap_or_default()))
+                    .map(|c| (None, c.unwrap_or_default().into()))
                     .collect(),
             ));
 

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -847,7 +847,7 @@ impl Execute for ast::ForClauseCommand {
             // Update the variable.
             shell.env_mut().update_or_add(
                 &self.variable_name,
-                ShellValueLiteral::Scalar(value),
+                ShellValueLiteral::Scalar(value.into()),
                 |_| Ok(()),
                 EnvironmentLookup::Anywhere,
                 EnvironmentScope::Global,
@@ -1504,7 +1504,7 @@ async fn apply_assignment(
         ast::AssignmentValue::Scalar(unexpanded_value) => {
             let value =
                 expansion::basic_expand_assignment_word(shell, params, unexpanded_value).await?;
-            ShellValueLiteral::Scalar(value)
+            ShellValueLiteral::Scalar(value.into())
         }
         ast::AssignmentValue::Array(unexpanded_values) => {
             let mut elements = vec![];
@@ -1521,14 +1521,14 @@ async fn apply_assignment(
                     let value =
                         expansion::basic_expand_assignment_word(shell, params, unexpanded_value)
                             .await?;
-                    elements.push((key, value));
+                    elements.push((key.map(|k| k.into()), value.into()));
                 } else {
                     // Array elements are treated as regular words, not assignments
                     let values =
                         expansion::full_expand_and_split_word(shell, params, unexpanded_value)
                             .await?;
                     for value in values {
-                        elements.push((None, value));
+                        elements.push((None, value.into()));
                     }
                 }
             }
@@ -1580,7 +1580,7 @@ async fn apply_assignment(
             if let Some(array_index) = array_index {
                 match new_value {
                     ShellValueLiteral::Scalar(s) => {
-                        existing_value.assign_at_index(array_index, s, assignment.append)?;
+                        existing_value.assign_at_index(array_index.into(), s, assignment.append)?;
                     }
                     ShellValueLiteral::Array(_) => {
                         return error::unimp("replacing an array item with an array");
@@ -1609,9 +1609,9 @@ async fn apply_assignment(
     // If we fell down here, then we need to add it.
     let new_value = if let Some(array_index) = array_index {
         match new_value {
-            ShellValueLiteral::Scalar(s) => {
-                ShellValue::indexed_array_from_literals(ArrayLiteral(vec![(Some(array_index), s)]))
-            }
+            ShellValueLiteral::Scalar(s) => ShellValue::indexed_array_from_literals(ArrayLiteral(
+                vec![(Some(array_index.into()), s)],
+            )),
             ShellValueLiteral::Array(_) => {
                 return error::unimp("cannot assign list to array member");
             }

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -72,6 +72,7 @@ use std::os::unix::ffi::{OsStrExt, OsStringExt};
 /// Converts an [`OsString`] to a [`bstr::BString`], preserving raw bytes on Unix
 /// (so non-UTF-8 paths/environment values are not corrupted). On non-Unix
 /// platforms a lossy conversion is used as a fallback.
+#[allow(clippy::needless_pass_by_value)]
 pub fn os_string_to_bstring(value: std::ffi::OsString) -> bstr::BString {
     cfg_if::cfg_if! {
         if #[cfg(unix)] {

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -62,3 +62,33 @@ pub use shell::{
 };
 pub use sourceinfo::SourceInfo;
 pub use variables::{ShellValue, ShellVariable};
+
+/// Re-export of [`bstr::BString`] for downstream use.
+pub use bstr::BString;
+
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+/// Converts an [`OsString`] to a [`bstr::BString`], preserving raw bytes on Unix
+/// (so non-UTF-8 paths/environment values are not corrupted). On non-Unix
+/// platforms a lossy conversion is used as a fallback.
+pub fn os_string_to_bstring(value: std::ffi::OsString) -> bstr::BString {
+    cfg_if::cfg_if! {
+        if #[cfg(unix)] {
+            bstr::BString::new(value.into_vec())
+        } else {
+            bstr::BString::from(value.to_string_lossy().into_owned())
+        }
+    }
+}
+
+/// Converts a [`Path`] to a [`bstr::BString`], preserving raw bytes on Unix.
+pub fn path_to_bstring(path: impl AsRef<std::path::Path>) -> bstr::BString {
+    cfg_if::cfg_if! {
+        if #[cfg(unix)] {
+            bstr::BString::new(path.as_ref().as_os_str().as_bytes().to_vec())
+        } else {
+            bstr::BString::from(path.as_ref().to_string_lossy().into_owned())
+        }
+    }
+}

--- a/brush-core/src/pathcache.rs
+++ b/brush-core/src/pathcache.rs
@@ -41,7 +41,7 @@ impl PathCache {
         let pairs = self
             .cache
             .iter()
-            .map(|(k, v)| (Some(k.to_owned()), v.to_string_lossy().to_string()))
+            .map(|(k, v)| (Some(k.as_str().into()), crate::path_to_bstring(v)))
             .collect::<Vec<_>>();
 
         variables::ShellValue::associative_array_from_literals(variables::ArrayLiteral(pairs))

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -3,18 +3,19 @@
 use bstr::ByteSlice;
 
 use crate::{error, regex, sys, trace_categories};
+use std::borrow::Cow;
 use std::{collections::VecDeque, path::Path};
 
 /// Returns the raw bytes of an [`OsStr`] file-name component. On Unix this
 /// preserves non-UTF-8 bytes losslessly; on other platforms it falls back to
 /// the lossy UTF-8 representation.
-fn file_name_bytes(name: &std::ffi::OsStr) -> &[u8] {
+fn file_name_bytes(name: &std::ffi::OsStr) -> Cow<'_, [u8]> {
     cfg_if::cfg_if! {
         if #[cfg(unix)] {
             use std::os::unix::ffi::OsStrExt;
-            name.as_bytes()
+            Cow::Borrowed(name.as_bytes())
         } else {
-            name.to_string_lossy().as_bytes()
+            Cow::Owned(name.to_string_lossy().into_owned().into_bytes())
         }
     }
 }
@@ -317,7 +318,7 @@ impl Pattern {
                 let regex = subpattern.to_regex(true, true)?;
                 let matches_regex = |dir_entry: &std::fs::DirEntry| {
                     regex
-                        .is_match(file_name_bytes(&dir_entry.file_name()))
+                        .is_match(file_name_bytes(&dir_entry.file_name()).as_ref())
                         .unwrap_or(false)
                 };
 
@@ -388,18 +389,28 @@ impl Pattern {
             regex_str.push('^');
         }
 
+        // Build a glob pattern string for the glob-to-regex converter. Non-UTF-8
+        // bytes are encoded as Private Use Area characters (U+E000 + byte value)
+        // so they survive the converter (which requires valid UTF-8 and only
+        // interprets ASCII metacharacters). They are converted to \xHH regex
+        // hex escapes after the conversion.
         let mut current_pattern = String::new();
         for piece in &self.pieces {
             match piece {
                 PatternPiece::Pattern(s) => {
-                    current_pattern.push_str(s.to_str().unwrap_or(""));
+                    append_bytes_with_pua(&mut current_pattern, s.as_slice());
                 }
                 PatternPiece::Literal(s) => {
-                    for c in s.to_str().unwrap_or("").chars() {
-                        if crate::regex::regex_char_is_special(c) {
-                            current_pattern.push('\\');
+                    for chunk in s.as_slice().utf8_chunks() {
+                        for c in chunk.valid().chars() {
+                            if crate::regex::regex_char_is_special(c) {
+                                current_pattern.push('\\');
+                            }
+                            current_pattern.push(c);
                         }
-                        current_pattern.push(c);
+                        for &b in chunk.invalid() {
+                            current_pattern.push(pua_char_for_byte(b));
+                        }
                     }
                 }
             }
@@ -407,7 +418,8 @@ impl Pattern {
 
         let regex_piece =
             pattern_to_regex_str(current_pattern.as_str(), self.enable_extended_globbing)?;
-        regex_str.push_str(regex_piece.as_str());
+        let regex_piece = replace_pua_with_hex_escapes(regex_piece);
+        regex_str.push_str(&regex_piece);
 
         if strict_suffix_match {
             regex_str.push('$');
@@ -455,6 +467,55 @@ impl Pattern {
 /// the single source of truth for what constitutes a glob metacharacter.
 fn requires_expansion(s: &str, enable_extended_globbing: bool) -> bool {
     brush_parser::pattern::pattern_has_glob_metacharacters(s, enable_extended_globbing)
+}
+
+/// Maps a non-UTF-8 byte to a Private Use Area character (U+E000 + byte).
+/// This lets the byte survive the glob-to-regex converter (which requires
+/// valid UTF-8) as an innocuous non-metacharacter. It is later converted
+/// back to a `\xHH` regex hex escape by [`replace_pua_with_hex_escapes`].
+fn pua_char_for_byte(b: u8) -> char {
+    char::from_u32(0xE000 + u32::from(b)).unwrap_or('\u{FFFD}')
+}
+
+/// Appends bytes to a [`String`], encoding non-UTF-8 bytes as PUA characters
+/// via [`pua_char_for_byte`]. Valid UTF-8 sequences pass through unchanged.
+fn append_bytes_with_pua(dest: &mut String, bytes: &[u8]) {
+    for chunk in bytes.utf8_chunks() {
+        dest.push_str(chunk.valid());
+        for &b in chunk.invalid() {
+            dest.push(pua_char_for_byte(b));
+        }
+    }
+}
+
+/// Replaces Private Use Area characters (U+E000–U+E0FF) in a regex string with
+/// `\xHH` hex escapes so the compiled regex matches the original raw bytes.
+fn replace_pua_with_hex_escapes(s: String) -> String {
+    const PUA_START: u32 = 0xE000;
+    const PUA_END: u32 = 0xE0FF;
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    if !s
+        .chars()
+        .any(|c| (PUA_START..=PUA_END).contains(&(c as u32)))
+    {
+        return s;
+    }
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        let code = c as u32;
+        if (PUA_START..=PUA_END).contains(&code) {
+            // Safe: we verified code is in 0xE000..=0xE0FF, so code - 0xE000 fits in u8.
+            #[expect(clippy::cast_possible_truncation)]
+            let b = (code - PUA_START) as u8;
+            result.push('\\');
+            result.push('x');
+            result.push(HEX[(b >> 4) as usize] as char);
+            result.push(HEX[(b & 0xf) as usize] as char);
+        } else {
+            result.push(c);
+        }
+    }
+    result
 }
 
 fn pattern_to_regex_str(

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -3,6 +3,20 @@
 use crate::{error, regex, sys, trace_categories};
 use std::{collections::VecDeque, path::Path};
 
+/// Returns the raw bytes of an [`OsStr`] file-name component. On Unix this
+/// preserves non-UTF-8 bytes losslessly; on other platforms it falls back to
+/// the lossy UTF-8 representation.
+fn file_name_bytes(name: &std::ffi::OsStr) -> &[u8] {
+    cfg_if::cfg_if! {
+        if #[cfg(unix)] {
+            use std::os::unix::ffi::OsStrExt;
+            name.as_bytes()
+        } else {
+            name.to_string_lossy().as_bytes()
+        }
+    }
+}
+
 /// Represents a piece of a shell pattern.
 #[derive(Clone, Debug)]
 pub(crate) enum PatternPiece {
@@ -295,13 +309,13 @@ impl Pattern {
                     || subpattern_starts_with_dot;
 
                 let matches_dotfile_policy = |dir_entry: &std::fs::DirEntry| {
-                    !dir_entry.file_name().to_string_lossy().starts_with('.') || allow_dot_files
+                    !file_name_bytes(&dir_entry.file_name()).starts_with(b".") || allow_dot_files
                 };
 
                 let regex = subpattern.to_regex(true, true)?;
                 let matches_regex = |dir_entry: &std::fs::DirEntry| {
                     regex
-                        .is_match(dir_entry.file_name().to_string_lossy().as_ref())
+                        .is_match(file_name_bytes(&dir_entry.file_name()))
                         .unwrap_or(false)
                 };
 

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -1,5 +1,7 @@
 //! Shell patterns
 
+use bstr::ByteSlice;
+
 use crate::{error, regex, sys, trace_categories};
 use std::{collections::VecDeque, path::Path};
 
@@ -21,16 +23,16 @@ fn file_name_bytes(name: &std::ffi::OsStr) -> &[u8] {
 #[derive(Clone, Debug)]
 pub(crate) enum PatternPiece {
     /// A pattern that should be interpreted as a shell pattern.
-    Pattern(String),
+    Pattern(bstr::BString),
     /// A literal string that should be matched exactly.
-    Literal(String),
+    Literal(bstr::BString),
 }
 
 impl PatternPiece {
     pub fn as_str(&self) -> &str {
         match self {
-            Self::Pattern(s) => s,
-            Self::Literal(s) => s,
+            Self::Pattern(s) => s.to_str().unwrap_or(""),
+            Self::Literal(s) => s.to_str().unwrap_or(""),
         }
     }
 }
@@ -110,7 +112,7 @@ impl From<&PatternWord> for Pattern {
 impl From<&str> for Pattern {
     fn from(value: &str) -> Self {
         Self {
-            pieces: vec![PatternPiece::Pattern(value.to_owned())],
+            pieces: vec![PatternPiece::Pattern(value.into())],
             ..Default::default()
         }
     }
@@ -119,7 +121,7 @@ impl From<&str> for Pattern {
 impl From<String> for Pattern {
     fn from(value: String) -> Self {
         Self {
-            pieces: vec![PatternPiece::Pattern(value)],
+            pieces: vec![PatternPiece::Pattern(value.into())],
             ..Default::default()
         }
     }
@@ -219,8 +221,8 @@ impl Pattern {
         for piece in &self.pieces {
             let mut split_result: VecDeque<_> = sys::fs::split_path_for_pattern(piece.as_str())
                 .map(|s| match piece {
-                    PatternPiece::Pattern(_) => PatternPiece::Pattern(s.to_owned()),
-                    PatternPiece::Literal(_) => PatternPiece::Literal(s.to_owned()),
+                    PatternPiece::Pattern(_) => PatternPiece::Pattern(s.into()),
+                    PatternPiece::Literal(_) => PatternPiece::Literal(s.into()),
                 })
                 .collect();
 
@@ -390,10 +392,10 @@ impl Pattern {
         for piece in &self.pieces {
             match piece {
                 PatternPiece::Pattern(s) => {
-                    current_pattern.push_str(s);
+                    current_pattern.push_str(s.to_str().unwrap_or(""));
                 }
                 PatternPiece::Literal(s) => {
-                    for c in s.chars() {
+                    for c in s.to_str().unwrap_or("").chars() {
                         if crate::regex::regex_char_is_special(c) {
                             current_pattern.push('\\');
                         }
@@ -625,21 +627,21 @@ mod tests {
     #[test]
     fn test_pattern_word_translation() -> Result<()> {
         assert_eq!(
-            pattern_to_exact_regex_str(vec![PatternPiece::Pattern("a*".to_owned())])?.as_str(),
+            pattern_to_exact_regex_str(vec![PatternPiece::Pattern("a*".into())])?.as_str(),
             "^a.*$"
         );
         assert_eq!(
             pattern_to_exact_regex_str(vec![
-                PatternPiece::Pattern("a*".to_owned()),
-                PatternPiece::Literal("b".to_owned()),
+                PatternPiece::Pattern("a*".into()),
+                PatternPiece::Literal("b".into()),
             ])?
             .as_str(),
             "^a.*b$"
         );
         assert_eq!(
             pattern_to_exact_regex_str(vec![
-                PatternPiece::Literal("a*".to_owned()),
-                PatternPiece::Pattern("b".to_owned()),
+                PatternPiece::Literal("a*".into()),
+                PatternPiece::Pattern("b".into()),
             ])?
             .as_str(),
             r"^a\*b$"

--- a/brush-core/src/regex.rs
+++ b/brush-core/src/regex.rs
@@ -3,6 +3,8 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 
+use bstr::ByteSlice;
+
 use crate::error;
 use cached::Cached;
 
@@ -15,16 +17,19 @@ thread_local! {
 #[derive(Clone, Debug)]
 pub(crate) enum RegexPiece {
     /// A pattern that should be interpreted as a regular expression.
-    Pattern(String),
+    Pattern(bstr::BString),
     /// A literal string that should be matched exactly.
-    Literal(String),
+    Literal(bstr::BString),
 }
 
 impl RegexPiece {
     fn to_regex_str(&self) -> Cow<'_, str> {
         match self {
-            Self::Pattern(s) => Cow::Borrowed(s.as_str()),
-            Self::Literal(s) => escape_literal_regex_piece(s.as_str()),
+            Self::Pattern(s) => {
+                // Regex pattern syntax is expected to be valid UTF-8.
+                Cow::Owned(s.to_str().unwrap_or("").to_string())
+            }
+            Self::Literal(s) => escape_literal_regex_piece(s.as_slice()),
         }
     }
 }
@@ -180,16 +185,25 @@ fn add_missing_escape_chars_to_regex(s: &str) -> Cow<'_, str> {
     updated.into()
 }
 
-fn escape_literal_regex_piece(s: &str) -> Cow<'_, str> {
+fn escape_literal_regex_piece(s: &[u8]) -> Cow<'_, str> {
     let mut result = String::new();
 
-    for c in s.chars() {
-        match c {
-            c if regex_char_is_special(c) => {
+    for chunk in s.utf8_chunks() {
+        for c in chunk.valid().chars() {
+            if regex_char_is_special(c) {
                 result.push('\\');
-                result.push(c);
             }
-            c => result.push(c),
+            result.push(c);
+        }
+        for &b in chunk.invalid() {
+            // Escape non-UTF-8 bytes as \xHH so the regex engine matches the
+            // raw byte (works with BytesMode::UnicodeBytes enabled at compile
+            // time).
+            const HEX: &[u8; 16] = b"0123456789abcdef";
+            result.push('\\');
+            result.push('x');
+            result.push(HEX[(b >> 4) as usize] as char);
+            result.push(HEX[(b & 0xf) as usize] as char);
         }
     }
 

--- a/brush-core/src/regex.rs
+++ b/brush-core/src/regex.rs
@@ -123,6 +123,7 @@ pub(crate) fn compile_regex(
 
     let mut builder = fancy_regex::RegexBuilder::new(regex_str.as_ref());
     builder.case_insensitive(case_insensitive);
+    builder.bytes_mode(fancy_regex::BytesMode::UnicodeBytes);
 
     let re = match builder.build() {
         Ok(re) => re,

--- a/brush-core/src/shell/fs.rs
+++ b/brush-core/src/shell/fs.rs
@@ -35,7 +35,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         // Normalize the path (but don't canonicalize it).
         let cleaned_path = abs_path.normalize();
 
-        let pwd = cleaned_path.to_string_lossy().to_string();
+        let pwd = crate::path_to_bstring(&cleaned_path);
 
         self.env.update_or_add(
             "PWD",
@@ -48,7 +48,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
 
         self.env.update_or_add(
             "OLDPWD",
-            variables::ShellValueLiteral::Scalar(oldpwd.to_string_lossy().to_string()),
+            variables::ShellValueLiteral::Scalar(crate::path_to_bstring(&oldpwd)),
             |_| Ok(()),
             EnvironmentLookup::Anywhere,
             EnvironmentScope::Global,

--- a/brush-core/src/shell/io.rs
+++ b/brush-core/src/shell/io.rs
@@ -55,6 +55,7 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
             && let Ok(fd) = xtracefd_var
                 .value()
                 .to_cow_str(self)
+                .to_string()
                 .parse::<super::ShellFd>()
             && let Some(file) = self.open_files.try_fd(fd)
         {

--- a/brush-core/src/shell/readline.rs
+++ b/brush-core/src/shell/readline.rs
@@ -30,7 +30,14 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
         let point = self
             .env
             .unset("READLINE_POINT")?
-            .and_then(|point| point.value().to_cow_str(self).parse::<usize>().ok())
+            .and_then(|point| {
+                point
+                    .value()
+                    .to_cow_str(self)
+                    .to_string()
+                    .parse::<usize>()
+                    .ok()
+            })
             .unwrap_or(0);
 
         if let Some(line) = line {

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -5,6 +5,8 @@ use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fmt::{Display, Write};
 
+use bstr::{BStr, BString, ByteSlice};
+
 use crate::shell::{Shell, ShellState};
 use crate::{error, escape, extensions};
 
@@ -47,7 +49,7 @@ pub enum ShellVariableUpdateTransform {
 impl Default for ShellVariable {
     fn default() -> Self {
         Self {
-            value: ShellValue::String(String::new()),
+            value: ShellValue::String(BString::new(Vec::new())),
             exported: false,
             readonly: false,
             enumerable: true,
@@ -198,7 +200,7 @@ impl ShellVariable {
                 let mut new_values = BTreeMap::new();
                 new_values.insert(
                     0,
-                    self.value.to_cow_str_without_dynamic_support().to_string(),
+                    self.value.to_cow_str_without_dynamic_support().into_owned(),
                 );
                 self.value = ShellValue::IndexedArray(new_values);
                 Ok(())
@@ -214,10 +216,10 @@ impl ShellVariable {
                 Err(error::ErrorKind::ConvertingIndexedArrayToAssociativeArray.into())
             }
             _ => {
-                let mut new_values: BTreeMap<String, String> = BTreeMap::new();
+                let mut new_values: BTreeMap<BString, BString> = BTreeMap::new();
                 new_values.insert(
-                    String::from("0"),
-                    self.value.to_cow_str_without_dynamic_support().to_string(),
+                    BString::from("0"),
+                    self.value.to_cow_str_without_dynamic_support().into_owned(),
                 );
                 self.value = ShellValue::AssociativeArray(new_values);
                 Ok(())
@@ -256,7 +258,7 @@ impl ShellVariable {
                 // start with the empty string. This will result in the right thing happening,
                 // even in treat-as-integer cases.
                 (ShellValue::Unset(_), ShellValueLiteral::Scalar(_)) => {
-                    self.assign(ShellValueLiteral::Scalar(String::new()), false)?;
+                    self.assign(ShellValueLiteral::Scalar(BString::new(Vec::new())), false)?;
                 }
                 // If we're trying to append an array to a string, we first promote the string to be
                 // an array with the string being present at index 0.
@@ -273,12 +275,12 @@ impl ShellVariable {
                 ShellValue::String(base) => match value {
                     ShellValueLiteral::Scalar(suffix) => {
                         if treat_as_int {
-                            let int_value = base.parse::<i64>().unwrap_or(0)
-                                + suffix.parse::<i64>().unwrap_or(0);
-                            base.clear();
-                            base.push_str(int_value.to_string().as_str());
+                            let int_value =
+                                base.to_str().unwrap_or("0").parse::<i64>().unwrap_or(0)
+                                    + suffix.to_str().unwrap_or("0").parse::<i64>().unwrap_or(0);
+                            *base = int_value.to_string().into_bytes().into();
                         } else {
-                            base.push_str(suffix.as_str());
+                            Self::append_bstring(base, suffix.as_bytes());
                             Self::apply_value_transforms(base, treat_as_int, update_transform);
                         }
                         Ok(())
@@ -290,7 +292,7 @@ impl ShellVariable {
                 },
                 ShellValue::IndexedArray(existing_values) => match value {
                     ShellValueLiteral::Scalar(new_value) => {
-                        self.assign_at_index(String::from("0"), new_value, append)
+                        self.assign_at_index(BString::from("0"), new_value, append)
                     }
                     ShellValueLiteral::Array(new_values) => {
                         ShellValue::update_indexed_array_from_literals(existing_values, new_values);
@@ -299,7 +301,7 @@ impl ShellVariable {
                 },
                 ShellValue::AssociativeArray(existing_values) => match value {
                     ShellValueLiteral::Scalar(new_value) => {
-                        self.assign_at_index(String::from("0"), new_value, append)
+                        self.assign_at_index(BString::from("0"), new_value, append)
                     }
                     ShellValueLiteral::Array(new_values) => {
                         ShellValue::update_associative_array_from_literals(
@@ -323,7 +325,7 @@ impl ShellVariable {
                         ShellValueUnsetType::AssociativeArray | ShellValueUnsetType::IndexedArray,
                     ),
                     ShellValueLiteral::Scalar(s),
-                ) => self.assign_at_index(String::from("0"), s, false),
+                ) => self.assign_at_index(BString::from("0"), s, false),
 
                 // If we're updating an indexed array value with an array, then preserve the array
                 // type. We also default to using an indexed array if we are
@@ -365,6 +367,10 @@ impl ShellVariable {
         }
     }
 
+    fn append_bstring(base: &mut BString, suffix: &[u8]) {
+        base.extend_from_slice(suffix);
+    }
+
     /// Assign the given value to the variable at the given index, conditionally appending to the
     /// preexisting value present at that element within the value.
     ///
@@ -376,8 +382,8 @@ impl ShellVariable {
     ///   index.
     pub fn assign_at_index(
         &mut self,
-        array_index: String,
-        value: String,
+        array_index: BString,
+        value: BString,
         append: bool,
     ) -> Result<(), error::Error> {
         match &self.value {
@@ -395,19 +401,21 @@ impl ShellVariable {
 
         match &mut self.value {
             ShellValue::IndexedArray(arr) => {
-                let key = get_key_for_indexed_array(arr, array_index.as_str())?;
+                let key = get_key_for_indexed_array(arr, array_index.as_bytes())?;
 
                 if append {
-                    let existing_value = arr.get(&key).map_or("", |v| v.as_str());
+                    let existing_value = arr.get(&key).map_or("", |v| v.to_str().unwrap_or(""));
 
                     let mut new_value;
                     if treat_as_int {
-                        new_value = (existing_value.parse::<i64>().unwrap_or(0)
-                            + value.parse::<i64>().unwrap_or(0))
-                        .to_string();
+                        new_value = BString::from(
+                            (existing_value.parse::<i64>().unwrap_or(0)
+                                + value.to_str().unwrap_or("0").parse::<i64>().unwrap_or(0))
+                            .to_string(),
+                        );
                     } else {
-                        new_value = existing_value.to_owned();
-                        new_value.push_str(value.as_str());
+                        new_value = BString::from(existing_value);
+                        Self::append_bstring(&mut new_value, value.as_bytes());
                     }
 
                     arr.insert(key, new_value);
@@ -419,26 +427,30 @@ impl ShellVariable {
             }
             ShellValue::AssociativeArray(arr) => {
                 if append {
-                    let existing_value = arr.get(array_index.as_str()).map_or("", |v| v.as_str());
+                    let existing_value = arr
+                        .get(array_index.as_bytes())
+                        .map_or("", |v| v.to_str().unwrap_or(""));
 
                     let mut new_value;
                     if treat_as_int {
-                        new_value = (existing_value.parse::<i64>().unwrap_or(0)
-                            + value.parse::<i64>().unwrap_or(0))
-                        .to_string();
+                        new_value = BString::from(
+                            (existing_value.parse::<i64>().unwrap_or(0)
+                                + value.to_str().unwrap_or("0").parse::<i64>().unwrap_or(0))
+                            .to_string(),
+                        );
                     } else {
-                        new_value = existing_value.to_owned();
-                        new_value.push_str(value.as_str());
+                        new_value = BString::from(existing_value);
+                        Self::append_bstring(&mut new_value, value.as_bytes());
                     }
 
-                    arr.insert(array_index, new_value.clone());
+                    arr.insert(array_index, new_value);
                 } else {
                     arr.insert(array_index, value);
                 }
                 Ok(())
             }
             _ => {
-                tracing::error!("assigning to index {array_index} of {:?}", self.value);
+                tracing::error!("assigning to index {array_index:?} of {:?}", self.value);
                 error::unimp("assigning to index of non-array variable")
             }
         }
@@ -459,7 +471,7 @@ impl ShellVariable {
         }
     }
 
-    fn convert_value_str_for_assignment(&self, mut s: String) -> String {
+    fn convert_value_str_for_assignment(&self, mut s: BString) -> BString {
         Self::apply_value_transforms(
             &mut s,
             self.is_treated_as_integer(),
@@ -470,23 +482,32 @@ impl ShellVariable {
     }
 
     fn apply_value_transforms(
-        s: &mut String,
+        s: &mut BString,
         treat_as_int: bool,
         update_transform: ShellVariableUpdateTransform,
     ) {
         if treat_as_int {
-            *s = (*s).parse::<i64>().unwrap_or(0).to_string();
+            let val = s.to_str().unwrap_or("0").parse::<i64>().unwrap_or(0);
+            *s = val.to_string().into_bytes().into();
         } else {
             match update_transform {
                 ShellVariableUpdateTransform::None => (),
-                ShellVariableUpdateTransform::Lowercase => *s = (*s).to_lowercase(),
-                ShellVariableUpdateTransform::Uppercase => *s = (*s).to_uppercase(),
+                ShellVariableUpdateTransform::Lowercase => {
+                    let lowered = s.to_str().unwrap_or("").to_lowercase();
+                    *s = lowered.into_bytes().into();
+                }
+                ShellVariableUpdateTransform::Uppercase => {
+                    let uppered = s.to_str().unwrap_or("").to_uppercase();
+                    *s = uppered.into_bytes().into();
+                }
                 ShellVariableUpdateTransform::Capitalize => {
                     // This isn't really title-case; only the first character is capitalized.
-                    *s = s.to_lowercase();
-                    if let Some(c) = s.chars().next() {
-                        s.replace_range(0..1, &c.to_uppercase().to_string());
+                    let as_str = s.to_str().unwrap_or("");
+                    let mut lowered = as_str.to_lowercase();
+                    if let Some(c) = lowered.chars().next() {
+                        lowered.replace_range(0..c.len_utf8(), &c.to_uppercase().to_string());
                     }
+                    *s = lowered.into_bytes().into();
                 }
             }
         }
@@ -507,9 +528,9 @@ impl ShellVariable {
                 }
             },
             ShellValue::String(_) => Err(error::ErrorKind::NotArray.into()),
-            ShellValue::AssociativeArray(values) => Ok(values.remove(index).is_some()),
+            ShellValue::AssociativeArray(values) => Ok(values.remove(index.as_bytes()).is_some()),
             ShellValue::IndexedArray(values) => {
-                let key = get_key_for_indexed_array(values, index)?;
+                let key = get_key_for_indexed_array(values, index.as_bytes())?;
                 Ok(values.remove(&key).is_some())
             }
             ShellValue::Dynamic { .. } => Ok(false),
@@ -596,11 +617,11 @@ pub enum ShellValue {
     /// A value that has been typed but not yet set.
     Unset(ShellValueUnsetType),
     /// A string.
-    String(String),
+    String(BString),
     /// An associative array.
-    AssociativeArray(BTreeMap<String, String>),
+    AssociativeArray(BTreeMap<BString, BString>),
     /// An indexed array.
-    IndexedArray(BTreeMap<u64, String>),
+    IndexedArray(BTreeMap<u64, BString>),
     /// A value that is dynamically computed.
     Dynamic {
         /// Function that can query the value.
@@ -622,7 +643,7 @@ pub enum ShellValue {
 
 #[cfg(feature = "serde")]
 fn default_dynamic_value_getter() -> DynamicValueGetter {
-    |_shell: &dyn ShellState| ShellValue::String(String::new())
+    |_shell: &dyn ShellState| ShellValue::String(BString::new(Vec::new()))
 }
 
 #[cfg(feature = "serde")]
@@ -646,7 +667,7 @@ pub enum ShellValueUnsetType {
 #[derive(Clone, Debug)]
 pub enum ShellValueLiteral {
     /// A scalar value.
-    Scalar(String),
+    Scalar(BString),
     /// An array value.
     Array(ArrayLiteral),
 }
@@ -654,7 +675,7 @@ pub enum ShellValueLiteral {
 impl ShellValueLiteral {
     pub(crate) fn fmt_for_tracing(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Scalar(s) => Self::fmt_scalar_for_tracing(s.as_str(), f),
+            Self::Scalar(s) => Self::fmt_scalar_for_tracing(s.as_bstr(), f),
             Self::Array(elements) => {
                 write!(f, "(")?;
                 for (i, (key, value)) in elements.0.iter().enumerate() {
@@ -663,18 +684,19 @@ impl ShellValueLiteral {
                     }
                     if let Some(key) = key {
                         write!(f, "[")?;
-                        Self::fmt_scalar_for_tracing(key.as_str(), f)?;
+                        Self::fmt_scalar_for_tracing(key.as_bstr(), f)?;
                         write!(f, "]=")?;
                     }
-                    Self::fmt_scalar_for_tracing(value.as_str(), f)?;
+                    Self::fmt_scalar_for_tracing(value.as_bstr(), f)?;
                 }
                 write!(f, ")")
             }
         }
     }
 
-    fn fmt_scalar_for_tracing(s: &str, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let processed = escape::quote_if_needed(s, escape::QuoteMode::SingleQuote);
+    fn fmt_scalar_for_tracing(s: &BStr, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let processed =
+            escape::quote_if_needed(s.to_str().unwrap_or(""), escape::QuoteMode::SingleQuote);
         write!(f, "{processed}")
     }
 }
@@ -687,27 +709,30 @@ impl Display for ShellValueLiteral {
 
 impl From<&str> for ShellValueLiteral {
     fn from(value: &str) -> Self {
-        Self::Scalar(value.to_owned())
+        Self::Scalar(BString::from(value))
     }
 }
 
 impl From<String> for ShellValueLiteral {
     fn from(value: String) -> Self {
-        Self::Scalar(value)
+        Self::Scalar(BString::from(value))
     }
 }
 
 impl From<Vec<&str>> for ShellValueLiteral {
     fn from(value: Vec<&str>) -> Self {
         Self::Array(ArrayLiteral(
-            value.into_iter().map(|s| (None, s.to_owned())).collect(),
+            value
+                .into_iter()
+                .map(|s| (None, BString::from(s)))
+                .collect(),
         ))
     }
 }
 
 /// An array literal.
 #[derive(Clone, Debug)]
-pub struct ArrayLiteral(pub Vec<(Option<String>, String)>);
+pub struct ArrayLiteral(pub Vec<(Option<BString>, BString)>);
 
 /// Style for formatting a shell variable's value.
 #[derive(Copy, Clone, Debug)]
@@ -743,7 +768,7 @@ impl ShellValue {
     /// * `values` - The slice of strings to construct the indexed array from.
     pub fn indexed_array_from_strings<S>(values: S) -> Self
     where
-        S: IntoIterator<Item = String>,
+        S: IntoIterator<Item = BString>,
     {
         let mut owned_values = BTreeMap::new();
         for (i, value) in values.into_iter().enumerate() {
@@ -761,7 +786,7 @@ impl ShellValue {
     pub fn indexed_array_from_strs(values: &[&str]) -> Self {
         let mut owned_values = BTreeMap::new();
         for (i, value) in values.iter().enumerate() {
-            owned_values.insert(i as u64, (*value).to_string());
+            owned_values.insert(i as u64, BString::from(*value));
         }
 
         Self::IndexedArray(owned_values)
@@ -780,7 +805,7 @@ impl ShellValue {
     }
 
     fn update_indexed_array_from_literals(
-        existing_values: &mut BTreeMap<u64, String>,
+        existing_values: &mut BTreeMap<u64, BString>,
         literal_values: ArrayLiteral,
     ) {
         let mut new_key = if let Some((largest_index, _)) = existing_values.last_key_value() {
@@ -791,7 +816,7 @@ impl ShellValue {
 
         for (key, value) in literal_values.0 {
             if let Some(key) = key {
-                new_key = key.parse().unwrap_or(0);
+                new_key = key.to_str().unwrap_or("0").parse().unwrap_or(0);
             }
 
             existing_values.insert(new_key, value);
@@ -812,7 +837,7 @@ impl ShellValue {
     }
 
     fn update_associative_array_from_literals(
-        existing_values: &mut BTreeMap<String, String>,
+        existing_values: &mut BTreeMap<BString, BString>,
         literal_values: ArrayLiteral,
     ) -> Result<(), error::Error> {
         let mut current_key = None;
@@ -831,7 +856,7 @@ impl ShellValue {
         }
 
         if let Some(current_key) = current_key {
-            existing_values.insert(current_key, String::new());
+            existing_values.insert(current_key, BString::new(Vec::new()));
         }
 
         Ok(())
@@ -849,24 +874,31 @@ impl ShellValue {
     ) -> Result<Cow<'_, str>, error::Error> {
         match self {
             Self::Unset(_) => Ok("".into()),
-            Self::String(s) => match style {
-                FormatStyle::Basic => Ok(escape::quote_if_needed(
-                    s.as_str(),
-                    escape::QuoteMode::SingleQuote,
-                )),
-                FormatStyle::DeclarePrint => {
-                    Ok(escape::force_quote(s.as_str(), escape::QuoteMode::DoubleQuote).into())
+            Self::String(s) => {
+                let s_str = s.to_str().unwrap_or("");
+                match style {
+                    FormatStyle::Basic => Ok(escape::quote_if_needed(
+                        s_str,
+                        escape::QuoteMode::SingleQuote,
+                    )),
+                    FormatStyle::DeclarePrint => {
+                        Ok(escape::force_quote(s_str, escape::QuoteMode::DoubleQuote).into())
+                    }
                 }
-            },
+            }
             Self::AssociativeArray(values) => {
                 let mut result = String::new();
                 result.push('(');
 
                 for (key, value) in values {
-                    let formatted_key =
-                        escape::quote_if_needed(key.as_str(), escape::QuoteMode::DoubleQuote);
-                    let formatted_value =
-                        escape::force_quote(value.as_str(), escape::QuoteMode::DoubleQuote);
+                    let formatted_key = escape::quote_if_needed(
+                        key.to_str().unwrap_or(""),
+                        escape::QuoteMode::DoubleQuote,
+                    );
+                    let formatted_value = escape::force_quote(
+                        value.to_str().unwrap_or(""),
+                        escape::QuoteMode::DoubleQuote,
+                    );
 
                     // N.B. We include an unconditional trailing space character (even after the
                     // last entry in the associative array) to match standard
@@ -886,8 +918,10 @@ impl ShellValue {
                         result.push(' ');
                     }
 
-                    let formatted_value =
-                        escape::force_quote(value.as_str(), escape::QuoteMode::DoubleQuote);
+                    let formatted_value = escape::force_quote(
+                        value.to_str().unwrap_or(""),
+                        escape::QuoteMode::DoubleQuote,
+                    );
                     write!(result, "[{key}]={formatted_value}")?;
                 }
 
@@ -911,44 +945,46 @@ impl ShellValue {
         &self,
         index: &str,
         shell: &Shell<impl extensions::ShellExtensions>,
-    ) -> Result<Option<Cow<'_, str>>, error::Error> {
+    ) -> Result<Option<Cow<'_, BStr>>, error::Error> {
         match self {
             Self::Unset(_) => Ok(None),
             Self::String(s) => {
                 if index.parse::<u64>().unwrap_or(0) == 0 {
-                    Ok(Some(Cow::Borrowed(s)))
+                    Ok(Some(Cow::Borrowed(s.as_bstr())))
                 } else {
                     Ok(None)
                 }
             }
-            Self::AssociativeArray(values) => {
-                Ok(values.get(index).map(|s| Cow::Borrowed(s.as_str())))
-            }
+            Self::AssociativeArray(values) => Ok(values
+                .get(index.as_bytes())
+                .map(|s| Cow::Borrowed(s.as_bstr()))),
             Self::IndexedArray(values) => {
-                let key = get_key_for_indexed_array(values, index)?;
-                Ok(values.get(&key).map(|s| Cow::Borrowed(s.as_str())))
+                let key = get_key_for_indexed_array(values, index.as_bytes())?;
+                Ok(values.get(&key).map(|s| Cow::Borrowed(s.as_bstr())))
             }
             Self::Dynamic { getter, .. } => {
                 let dynamic_value = getter(shell);
                 let result = dynamic_value.get_at(index, shell)?;
-                Ok(result.map(|s| s.to_string().into()))
+                Ok(result.map(|s| Cow::Owned(s.into_owned())))
             }
         }
     }
 
     /// Returns the keys of the elements in this variable.
-    pub fn element_keys(&self, shell: &Shell<impl extensions::ShellExtensions>) -> Vec<String> {
+    pub fn element_keys(&self, shell: &Shell<impl extensions::ShellExtensions>) -> Vec<BString> {
         match self {
             Self::Unset(_) => vec![],
-            Self::String(_) => vec!["0".to_owned()],
+            Self::String(_) => vec![BString::from("0")],
             Self::AssociativeArray(array) => array.keys().map(|k| k.to_owned()).collect(),
-            Self::IndexedArray(array) => array.keys().map(|k| k.to_string()).collect(),
+            Self::IndexedArray(array) => {
+                array.keys().map(|k| BString::from(k.to_string())).collect()
+            }
             Self::Dynamic { getter, .. } => getter(shell).element_keys(shell),
         }
     }
 
     /// Returns the values of the elements in this variable.
-    pub fn element_values(&self, shell: &Shell<impl extensions::ShellExtensions>) -> Vec<String> {
+    pub fn element_values(&self, shell: &Shell<impl extensions::ShellExtensions>) -> Vec<BString> {
         match self {
             Self::Unset(_) => vec![],
             Self::String(s) => vec![s.to_owned()],
@@ -958,39 +994,42 @@ impl ShellValue {
         }
     }
 
-    /// Converts this value to a string.
-    pub fn to_cow_str(&self, shell: &Shell<impl extensions::ShellExtensions>) -> Cow<'_, str> {
-        self.try_get_cow_str(shell).unwrap_or(Cow::Borrowed(""))
+    /// Converts this value to a cow `BStr`.
+    pub fn to_cow_str(&self, shell: &Shell<impl extensions::ShellExtensions>) -> Cow<'_, BStr> {
+        self.try_get_cow_str(shell)
+            .unwrap_or_else(|| Cow::Owned(BString::new(Vec::new())))
     }
 
-    fn to_cow_str_without_dynamic_support(&self) -> Cow<'_, str> {
+    fn to_cow_str_without_dynamic_support(&self) -> Cow<'_, BStr> {
         self.try_get_cow_str_without_dynamic_support()
-            .unwrap_or(Cow::Borrowed(""))
+            .unwrap_or_else(|| Cow::Owned(BString::new(Vec::new())))
     }
 
-    /// Tries to convert this value to a string; returns `None` if the value is unset
+    /// Tries to convert this value to a cow `BStr`; returns `None` if the value is unset
     /// or otherwise doesn't exist.
     pub fn try_get_cow_str(
         &self,
         shell: &Shell<impl extensions::ShellExtensions>,
-    ) -> Option<Cow<'_, str>> {
+    ) -> Option<Cow<'_, BStr>> {
         match self {
             Self::Dynamic { getter, .. } => {
                 let dynamic_value = getter(shell);
                 dynamic_value
                     .try_get_cow_str(shell)
-                    .map(|s| s.to_string().into())
+                    .map(|s| Cow::Owned(s.into_owned()))
             }
             _ => self.try_get_cow_str_without_dynamic_support(),
         }
     }
 
-    fn try_get_cow_str_without_dynamic_support(&self) -> Option<Cow<'_, str>> {
+    fn try_get_cow_str_without_dynamic_support(&self) -> Option<Cow<'_, BStr>> {
         match self {
             Self::Unset(_) => None,
-            Self::String(s) => Some(Cow::Borrowed(s.as_str())),
-            Self::AssociativeArray(values) => values.get("0").map(|s| Cow::Borrowed(s.as_str())),
-            Self::IndexedArray(values) => values.get(&0).map(|s| Cow::Borrowed(s.as_str())),
+            Self::String(s) => Some(Cow::Borrowed(s.as_bstr())),
+            Self::AssociativeArray(values) => values
+                .get(b"0".as_bstr())
+                .map(|s| Cow::Borrowed(s.as_bstr())),
+            Self::IndexedArray(values) => values.get(&0).map(|s| Cow::Borrowed(s.as_bstr())),
             Self::Dynamic { .. } => None,
         }
     }
@@ -1008,14 +1047,14 @@ impl ShellValue {
         match self {
             Self::Unset(_) => Ok(String::new()),
             Self::String(s) => Ok(escape::force_quote(
-                s.as_str(),
+                s.to_str().unwrap_or(""),
                 escape::QuoteMode::SingleQuote,
             )),
             Self::AssociativeArray(_) | Self::IndexedArray(_) => {
                 if let Some(index) = index {
                     if let Ok(Some(value)) = self.get_at(index, shell) {
                         Ok(escape::force_quote(
-                            value.as_ref(),
+                            value.to_str().unwrap_or(""),
                             escape::QuoteMode::SingleQuote,
                         ))
                     } else {
@@ -1031,9 +1070,10 @@ impl ShellValue {
 }
 
 fn get_key_for_indexed_array(
-    values: &BTreeMap<u64, String>,
-    index_str: &str,
+    values: &BTreeMap<u64, BString>,
+    index_str: &[u8],
 ) -> Result<u64, error::Error> {
+    let index_str = std::str::from_utf8(index_str).unwrap_or("0");
     let mut index_value = index_str.parse::<i64>().unwrap_or(0);
 
     // Handle negative indices, but check for out-of-range values.
@@ -1053,36 +1093,48 @@ fn get_key_for_indexed_array(
 
 impl From<&str> for ShellValue {
     fn from(value: &str) -> Self {
-        Self::String(value.to_owned())
+        Self::String(BString::from(value))
     }
 }
 
 impl From<&String> for ShellValue {
     fn from(value: &String) -> Self {
-        Self::String(value.clone())
+        Self::String(BString::from(value.as_bytes()))
     }
 }
 
 impl From<String> for ShellValue {
     fn from(value: String) -> Self {
-        Self::String(value)
+        Self::String(BString::from(value))
     }
 }
 
 impl From<OsString> for ShellValue {
     fn from(value: OsString) -> Self {
-        Self::String(value.to_string_lossy().into_owned())
+        Self::String(crate::os_string_to_bstring(value))
     }
 }
 
 impl From<Vec<String>> for ShellValue {
     fn from(values: Vec<String>) -> Self {
-        Self::indexed_array_from_strings(values)
+        Self::indexed_array_from_strings(values.into_iter().map(BString::from))
     }
 }
 
 impl From<Vec<&str>> for ShellValue {
     fn from(values: Vec<&str>) -> Self {
         Self::indexed_array_from_strs(values.as_slice())
+    }
+}
+
+impl From<BString> for ShellValue {
+    fn from(value: BString) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<Vec<BString>> for ShellValue {
+    fn from(values: Vec<BString>) -> Self {
+        Self::indexed_array_from_strings(values)
     }
 }

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use bstr::BString;
 use rand::RngExt as _;
 
 use crate::shell::ShellState;
@@ -44,7 +45,7 @@ pub(crate) fn inherit_env_vars(
             continue;
         }
 
-        let mut var = ShellVariable::new(ShellValue::String(v));
+        let mut var = ShellVariable::new(ShellValue::String(v.into()));
         var.export();
         shell.env_mut().set_global(k, var)?;
     }
@@ -83,7 +84,7 @@ pub(crate) fn init_well_known_vars(
     #[cfg(not(target_family = "wasm"))]
     {
         let mut bashpid_var =
-            ShellVariable::new(ShellValue::String(std::process::id().to_string()));
+            ShellVariable::new(ShellValue::String(std::process::id().to_string().into()));
         bashpid_var.treat_as_integer();
         shell.env_mut().set_global("BASHPID", bashpid_var)?;
     }
@@ -97,7 +98,7 @@ pub(crate) fn init_well_known_vars(
                     shell
                         .aliases()
                         .iter()
-                        .map(|(k, v)| (Some(k.to_owned()), v.to_owned()))
+                        .map(|(k, v)| (Some(k.as_str().into()), v.as_str().into()))
                         .collect::<Vec<_>>(),
                 );
 
@@ -268,7 +269,7 @@ pub(crate) fn init_well_known_vars(
 
     // EUID
     if let Ok(euid) = sys::users::get_effective_uid() {
-        let mut euid_var = ShellVariable::new(ShellValue::String(format!("{euid}")));
+        let mut euid_var = ShellVariable::new(ShellValue::String(format!("{euid}").into()));
         euid_var.treat_as_integer().set_readonly();
         shell.env_mut().set_global("EUID", euid_var)?;
     }
@@ -291,7 +292,7 @@ pub(crate) fn init_well_known_vars(
             getter: |_shell| {
                 let groups = get_current_user_gids();
                 ShellValue::indexed_array_from_strings(
-                    groups.into_iter().map(|gid| gid.to_string()),
+                    groups.into_iter().map(|gid| BString::from(gid.to_string())),
                 )
             },
             setter: |_| (),
@@ -317,19 +318,16 @@ pub(crate) fn init_well_known_vars(
         let histfile = home_dir.join(".brush_history");
         shell.env_mut().set_global(
             "HISTFILE",
-            ShellVariable::new(ShellValue::String(histfile.to_string_lossy().to_string())),
+            ShellVariable::new(ShellValue::String(crate::path_to_bstring(histfile))),
         )?;
     }
 
     // HOSTNAME
     shell.env_mut().set_global(
         "HOSTNAME",
-        ShellVariable::new(
-            sys::network::get_hostname()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
-        ),
+        ShellVariable::new(crate::os_string_to_bstring(
+            sys::network::get_hostname().unwrap_or_default(),
+        )),
     )?;
 
     // HOSTTYPE
@@ -414,7 +412,10 @@ pub(crate) fn init_well_known_vars(
         ShellVariable::new(ShellValue::Dynamic {
             getter: |shell| {
                 ShellValue::indexed_array_from_strings(
-                    shell.last_pipeline_statuses().iter().map(|s| s.to_string()),
+                    shell
+                        .last_pipeline_statuses()
+                        .iter()
+                        .map(|s| BString::from(s.to_string())),
                 )
             },
             setter: |_| (),
@@ -516,14 +517,14 @@ pub(crate) fn init_well_known_vars(
     // we inherited an out-of-sync version of the variable. Future updates
     // will be handled by set_working_dir().
     //
-    let pwd = shell.working_dir().to_string_lossy().to_string();
+    let pwd = crate::path_to_bstring(shell.working_dir());
     let mut pwd_var = ShellVariable::new(pwd);
     pwd_var.export();
     shell.env_mut().set_global("PWD", pwd_var)?;
 
     // UID
     if let Ok(uid) = sys::users::get_current_uid() {
-        let mut uid_var = ShellVariable::new(ShellValue::String(format!("{uid}")));
+        let mut uid_var = ShellVariable::new(ShellValue::String(format!("{uid}").into()));
         uid_var.treat_as_integer().set_readonly();
         shell.env_mut().set_global("UID", uid_var)?;
     }

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -342,12 +342,12 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             if let Some(prompt_cmd_var) = shell.env_var("PROMPT_COMMAND") {
                 match prompt_cmd_var.value() {
                     brush_core::ShellValue::String(cmd_str) => {
-                        Self::run_pre_prompt_command(shell, cmd_str.to_owned()).await?;
+                        Self::run_pre_prompt_command(shell, cmd_str.to_string()).await?;
                     }
                     brush_core::ShellValue::IndexedArray(values) => {
                         let owned_values: Vec<_> = values.values().cloned().collect();
                         for cmd_str in owned_values {
-                            Self::run_pre_prompt_command(shell, cmd_str).await?;
+                            Self::run_pre_prompt_command(shell, cmd_str.to_string()).await?;
                         }
                     }
                     // Other types are ignored.
@@ -368,7 +368,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
                 for func_name in precmd_funcs.values() {
                     let _ = shell
                         .invoke_function(
-                            func_name,
+                            func_name.to_string(),
                             std::iter::empty::<&str>(),
                             shell.default_exec_params(),
                         )
@@ -407,7 +407,11 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             {
                 for func_name in preexec_funcs.values() {
                     let _ = shell
-                        .invoke_function(func_name, &[command_line], shell.default_exec_params())
+                        .invoke_function(
+                            func_name.to_string(),
+                            &[command_line],
+                            shell.default_exec_params(),
+                        )
                         .await;
                 }
             }

--- a/todo/dynamic-variable-setters.md
+++ b/todo/dynamic-variable-setters.md
@@ -1,0 +1,212 @@
+# Dynamic well-known variables never honor assignment (RANDOM=N, SECONDS=N, ...)
+
+## Status
+
+Not started. This is a planning doc, written up per request instead of rushing into
+a large cross-cutting change. Nothing below has been implemented yet.
+
+## Problem
+
+Assigning a scalar to a dynamic well-known variable is always a silent no-op in
+brush today:
+
+```bash
+RANDOM=5
+echo $RANDOM   # bash: reseeds the sequence (still "random", but deterministic from
+               # here on for a given seed). brush: ignored, unaffected.
+
+SECONDS=100
+sleep 1
+echo $SECONDS  # bash: 101 (offset applied). brush: whatever the real elapsed time is,
+               # unaffected by the assignment.
+```
+
+This is *separate* from the `declare -a`/`declare -A` shape-conversion bug fixed
+earlier in this branch (`DynamicValueKind`, `convert_to_*_array_for_reassignment`,
+etc.) — that work fixed what happens when a dynamic variable's *shape* is
+force-converted. This doc is about what happens when a dynamic variable is
+*assigned a value through its normal setter path*, which today does nothing at all
+for every dynamic variable, on every path.
+
+## Root cause
+
+- `ShellValue::Dynamic` stores a `setter: DynamicValueSetter` where
+  `type DynamicValueSetter = fn(&dyn ShellState) -> ();` (`brush-core/src/variables.rs`).
+  It takes **no value parameter** — even if something called it, it couldn't know what
+  was being assigned.
+- Grepping the whole tree: **the `setter` field is never invoked anywhere.** It's
+  dead code. `ShellVariable::assign()`'s two `Dynamic` match arms (append and
+  non-append) are unconditional `Ok(())` no-ops (see the `// TODO(dynamic)` comments
+  already in place there).
+- `RANDOM`/`SRANDOM`'s getters (`wellknownvars.rs`) draw straight from
+  `rand::rng()`, the global thread-local RNG — there is no per-shell RNG state to
+  reseed in the first place.
+- `SECONDS`'s getter computes `now - shell.last_stopwatch_time() + shell.last_stopwatch_offset()`.
+  `Shell` already stores both fields and exposes read-only accessors
+  (`last_stopwatch_time()`, `last_stopwatch_offset()`) but **no setter** for either.
+
+## Why this is bigger than it looks
+
+To make `RANDOM=N`/`SECONDS=N` actually do something, the setter needs to run with
+access to shell-level state (RNG seed, stopwatch fields), and it needs to run at
+every place a scalar can be assigned to a variable. I traced where scalar
+assignment actually happens and it's not just the 10 direct callers of
+`ShellVariable::assign()`:
+
+- Direct `ShellVariable::assign()` callers (10): `env.rs` (x3, inside
+  `update_or_add`/`update_or_add_array_element`), `variables.rs` (x3, internal
+  unset-defaulting, never Dynamic in practice), `declare.rs` (x2), `export.rs` (x1),
+  `interp.rs` (x1, the general array/associative in-place update path).
+- But the *common* path for `NAME=value`, arithmetic assignment, `read`, `getopts`,
+  `mapfile`, completion, and array-default expansion (`${x:=default}`) all go
+  through **`ShellEnvironment::update_or_add()` / `update_or_add_array_element()`**
+  (`brush-core/src/env.rs`), which is called from ~16 more sites across:
+  `interp.rs`, `arithmetic.rs`, `completion.rs`, `expansion.rs` (x2),
+  `commands.rs`, `extendedtests.rs`, `shell/fs.rs` (x2), and the builtins
+  `read.rs` (x3), `getopts.rs` (x4), `mapfile.rs` (x2), `export.rs` (x1).
+- **`ShellEnvironment` has no reference to `Shell` at all.** It's a strictly
+  lower-level construct (just the variable scope stack). `update_or_add` cannot
+  reach RNG state or the stopwatch fields today, structurally.
+- At least one call site aliases badly if we naively add a `&dyn ShellState`
+  parameter: `shell/fs.rs` calls `self.env.update_or_add(...)` where `self` **is**
+  the `Shell`. A `&dyn ShellState` parameter sourced from that same `self` would
+  be borrowing all of `self` immutably while `self.env` is already borrowed
+  mutably as the method receiver — the trait object erases field boundaries, so
+  the borrow checker can't see that RNG/stopwatch fields are disjoint from `env`.
+  A concrete, narrow reference (see Option B below) sidesteps this; a `&dyn
+  ShellState` trait object does not.
+
+So doing this consistently (not just for the one or two most common paths) means
+touching on the order of **25+ call sites across a dozen files**, several of which
+have borrow-checker traps, not just plumbing.
+
+## Options considered
+
+### Option A — Thread `&dyn ShellState` (or `&mut dyn ShellState`) through `assign()` and `update_or_add()`
+
+Most "obvious" fix. Add a parameter to `ShellVariable::assign()` and
+`ShellEnvironment::update_or_add[_array_element]()`, update every call site to pass
+the shell handle through.
+
+- Pro: reuses the existing `ShellState` trait, no new state-sharing primitive.
+- Con: hits the `shell/fs.rs`-style aliasing problem described above at every
+  `impl Shell` method that calls `self.env.update_or_add(...)` directly (need to
+  check exactly how many; `shell/fs.rs` is a confirmed instance). Would likely
+  need `self.env.update_or_add(&self.random_state, ...)`-style disjoint field
+  splitting anyway, undermining the "just pass `&dyn ShellState`" simplicity.
+  Largest diff of the three options; touches the most files.
+
+### Option B — Concrete narrow state, not a trait object
+
+Give `Shell` two small fields for exactly what setters need:
+`random_state: Cell<u64>` (or similar; see "RANDOM reseeding" below) and change
+`last_stopwatch_time`/`last_stopwatch_offset` to `Cell<SystemTime>`/`Cell<u32>` (both
+`Copy`, `Cell` is a natural fit). Pass `&Cell<u64>` / `&Cell<SystemTime>` /
+`&Cell<u32>` — concrete types, not a trait object — into `update_or_add`/`assign`
+only where needed.
+
+- Pro: because these are literal disjoint fields (not an opaque "whole shell" view),
+  Rust's borrow checker allows `self.env.update_or_add(&self.random_state, ...)`
+  even while `self.env` is mutably borrowed as the receiver — no aliasing problem
+  at the `shell/fs.rs`-style call sites.
+- Con: still requires adding a parameter (now 2-3 concrete params instead of 1
+  trait-object param) through the same ~25+ call sites. Less elegant call
+  signature. `Cell` requires the setter logic to be synchronous, single-threaded,
+  which is already true for everything else in `Shell`.
+
+### Option C — Move the mutable state out of `Shell`'s borrow entirely (recommended)
+
+Change `DynamicValueGetter`/`DynamicValueSetter` from bare `fn` pointers to
+capturing closures (`Rc<dyn Fn(...)>`, since `Shell` is not required to be
+`Send`/`Sync` today — confirm before committing to `Rc` vs `Arc`) that close over a
+`Rc<Cell<u64>>` (RNG) / `Rc<Cell<(SystemTime, u32)>>` (stopwatch) created once when
+the variable is registered in `wellknownvars.rs::init_well_known_vars`. Then:
+
+- `assign()` calls `setter(new_value)` directly — **no shell reference needed at
+  all**, because the closure already owns a handle to the state it mutates. This
+  eliminates the entire plumbing problem: `ShellEnvironment::update_or_add` and
+  every one of its ~16 callers need **zero changes**.
+- `ShellVariable::assign()`'s two `Dynamic` arms change from unconditional
+  `Ok(())` to `(setter)(value); Ok(())` (roughly) — a small, contained change.
+- Getters (`get_random_value`, `get_srandom_value`, the `SECONDS` getter in
+  `wellknownvars.rs`) switch from reading `rand::rng()` / `shell.last_stopwatch_*()`
+  to reading the same captured `Rc<Cell<_>>`.
+- Needs care in `impl Clone for Shell` (`shell.rs:148`): today
+  `last_stopwatch_time`/`last_stopwatch_offset` are plain `Copy` fields, so
+  `Shell::clone()` naturally gives a subshell an independent copy that diverges
+  after fork — which matches real bash (a forked subshell's `RANDOM` sequence
+  diverges from the parent's after the fork point). If the state becomes a shared
+  `Rc<Cell<_>>` captured inside the `Dynamic` closures at variable-registration
+  time, a naive `Shell::clone()` would **share** the `Rc` (same pointer), which is
+  wrong — parent and subshell would then mutate the *same* cell instead of
+  diverging. Cloning must re-run `init_well_known_vars`-style re-registration (or
+  explicitly unwrap-and-rewrap each `Rc<Cell<_>>` with a fresh `Rc::new(old.get())`)
+  so each clone gets an independent cell seeded from the parent's current value.
+  This needs to be gotten right and tested (fork/subshell + `RANDOM`/`SECONDS`
+  compat cases) or subshells will corrupt each other's RNG/stopwatch state.
+- `ShellValue` derives `Debug`; a `Rc<dyn Fn>` field isn't `Debug`. Same shape of
+  problem it already has with `serde` on `Dynamic` (see the existing
+  `#[cfg_attr(feature = "serde", serde(skip, default = ...))]` pattern) — will
+  need either a manual `Debug` impl for `ShellValue`, or a small non-`Debug`-derived
+  wrapper type around the closure with a hand-written `Debug` that just prints
+  `"<dynamic>"` or similar.
+- Con: bare `fn` pointers today are trivially `Copy`/`Clone`/(pseudo-)`Debug`-safe
+  and cheap; moving to `Rc<dyn Fn>` adds an allocation per dynamic variable (only
+  at shell-init/clone time, not per-read) and a bit of ceremony (custom `Debug`,
+  careful `Clone`).
+- Pro: by far the smallest, most contained diff of the three options. Confines the
+  change to `variables.rs` (type defs + the two `assign()` arms) and
+  `wellknownvars.rs` (closure construction for `RANDOM`/`SRANDOM`/`SECONDS`, plus
+  updating `Shell::clone()`). Zero changes to `env.rs`, and zero changes to any of
+  the ~25 call sites enumerated above.
+
+## Recommendation
+
+Option C. It turns a 25+-call-site, multi-file refactor with borrow-checker risk
+into a change confined to two files, at the cost of a bit of closure/`Rc`/`Debug`
+ceremony and needing to get `Shell::clone()` right for subshell isolation. Worth
+double-checking whether `Shell`/its extensions are required to be `Send`/`Sync`
+anywhere (async executor bounds?) before committing to `Rc` over `Arc`+`Mutex` —
+if `Send` is required, the closures and cells need to be `Arc<Mutex<_>>` or
+`Arc<AtomicU64>`/atomics instead, which changes some details above but not the
+overall shape of the plan.
+
+## Scope for RANDOM/SRANDOM specifically
+
+Bash's actual `RANDOM` PRNG algorithm can't be replicated bit-for-bit without
+reimplementing bash's specific internal generator, and no one should try — any
+compat test for this can only assert **self-consistency** (same seed via `RANDOM=N`
+twice in the same shell produces the same subsequent value; different seeds
+produce different sequences), never exact cross-shell value equality. The existing
+`RANDOM`/`SRANDOM` compat tests already follow this pattern (checking
+non-determinism/range, not exact values) — new tests for reseeding should follow
+the same style, e.g.:
+
+```yaml
+- name: "RANDOM reseeds deterministically"
+  stdin: |
+    RANDOM=42
+    first=$RANDOM
+    RANDOM=42
+    second=$RANDOM
+    [[ $first == $second ]] && echo "RANDOM reseeds deterministically"
+```
+
+## Suggested follow-up steps (once this plan is agreed)
+
+1. Confirm `Send`/`Sync` requirements on `Shell<SE>` (check `extensions::ShellExtensions`
+   bounds and anywhere `Shell` crosses an `async` boundary) to settle `Rc` vs `Arc`.
+2. Change `DynamicValueGetter`/`DynamicValueSetter` typedefs and add the captured-cell
+   construction helpers in `wellknownvars.rs`.
+3. Wire `RANDOM`/`SRANDOM` to the new per-shell RNG cell; re-derive their exact algorithm
+   choice (doesn't need to match bash, just needs to be a real, seedable PRNG).
+4. Wire `SECONDS` to a captured stopwatch cell; drop `Shell`'s now-redundant
+   `last_stopwatch_time`/`last_stopwatch_offset` fields (or keep them as the
+   canonical initial values seeded into the cell at shell construction — decide
+   during implementation).
+5. Fix `impl Clone for Shell` so cloned/forked shells get independent cells seeded
+   from the parent's current value, not shared pointers.
+6. Change `ShellVariable::assign()`'s two `Dynamic` arms to actually invoke the setter.
+7. Add compat tests (self-consistency style, per above) for `RANDOM=N` and `SECONDS=N`.
+8. Manually verify subshell isolation: `( RANDOM=1; echo $RANDOM ); echo $RANDOM` should
+   show the subshell's reseeded seq without affecting the parent's.


### PR DESCRIPTION
## Summary

- Convert `ShellValue`, `ShellValueLiteral`, and `ArrayLiteral` from `String` to `bstr::BString` so arbitrary bytes are preserved throughout the shell variable system
- Fix silent data corruption in `echo -e`, `mapfile`, ANSI-C quoting (`$'...'`), `${var@E}`, PWD/OLDPWD, and `From<OsString>` for `ShellValue`

Closes #1115

## Details

Bash treats all data (filenames, variable values, command output) as raw byte sequences. Rust's `String` requires valid UTF-8, so every `from_utf8_lossy` or `to_string_lossy` call was a potential silent data corruption point.

The core change replaces `String` with `bstr::BString` (backed by `Vec<u8>`) in `ShellValue::String`, `AssociativeArray`, and `IndexedArray`, plus all related types. Key fixes:

- **`echo -e '\x80'`**: now writes raw bytes to stdout instead of lossy-converting
- **`mapfile`**: stores raw bytes as `BString`
- **ANSI-C quoting** (`$'\x80'`): preserves non-UTF-8 bytes
- **`${var@E}`**: same as above
- **PWD/OLDPWD**: uses `OsStrExt::as_bytes()` on Unix to preserve raw path bytes
- **`From<OsString>`**: uses `into_vec()` on Unix instead of `to_string_lossy()`

24 files changed, all tests passing (49 unit + 224 parser + 25 builtins + 1696 compat).

Co-Authored-by: opencode <opencode@anomaly.co>
Assisted-by: glm-5.1