### PR TITLE
fix: support `export -a NAME` (declare-as-array + export); unblocks `mise activate bash`

### DIFF
--- a/brush-builtins/src/export.rs
+++ b/brush-builtins/src/export.rs
@@ -6,12 +6,16 @@ use brush_core::{
     ExecutionExitCode, ExecutionResult, builtins,
     env::{EnvironmentLookup, EnvironmentScope},
     parser::ast,
-    variables,
+    variables::{self, ShellValue, ShellValueUnsetType, ShellVariable},
 };
 
 /// Add or update exported shell variables.
 #[derive(Parser)]
 pub(crate) struct ExportCommand {
+    /// Mark names as indexed arrays (combined with the export attribute).
+    #[arg(short = 'a')]
+    make_indexed_array: bool,
+
     /// Names are treated as function names.
     #[arg(short = 'f')]
     names_are_functions: bool,
@@ -88,11 +92,29 @@ impl ExportCommand {
                 // Try to find the variable already present; if we find it, then mark it
                 // exported.
                 else if let Some((_, variable)) = context.shell.env_mut().get_mut(s) {
+                    if self.make_indexed_array {
+                        variable.convert_to_indexed_array()?;
+                    }
                     if self.unexport {
                         variable.unexport();
                     } else {
                         variable.export();
                     }
+                }
+                // If `-a` was passed and the name doesn't yet exist, create it as an unset
+                // indexed array with the export attribute (mirrors `declare -ax NAME`). This
+                // is what bash does for `export -a NAME` and what `mise activate bash` relies
+                // on when seeding `chpwd_functions`.
+                else if self.make_indexed_array {
+                    let mut var =
+                        ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::IndexedArray));
+                    if !self.unexport {
+                        var.export();
+                    }
+                    context
+                        .shell
+                        .env_mut()
+                        .add(s.clone(), var, EnvironmentScope::Global)?;
                 }
             }
             brush_core::CommandArg::Assignment(assignment) => {
@@ -118,10 +140,16 @@ impl ExportCommand {
                 };
 
                 // Update the variable with the provided value and then mark it exported.
+                // When `-a` is set, ensure the variable is converted to an indexed array
+                // before the assignment lands (so a scalar assignment like `export -a foo=x`
+                // ends up as `foo=([0]="x")`, matching bash's `declare -ax foo=([0]="x")`).
                 context.shell.env_mut().update_or_add(
                     name,
                     value,
                     |var| {
+                        if self.make_indexed_array {
+                            var.convert_to_indexed_array()?;
+                        }
                         if self.unexport {
                             var.unexport();
                         } else {

--- a/brush-builtins/src/export.rs
+++ b/brush-builtins/src/export.rs
@@ -6,12 +6,16 @@ use brush_core::{
     ExecutionExitCode, ExecutionResult, builtins,
     env::{EnvironmentLookup, EnvironmentScope},
     parser::ast,
-    variables,
+    variables::{self, ShellValue, ShellValueUnsetType, ShellVariable},
 };
 
 /// Add or update exported shell variables.
 #[derive(Parser)]
 pub(crate) struct ExportCommand {
+    /// Mark names as indexed arrays (combined with the export attribute).
+    #[arg(short = 'a')]
+    make_indexed_array: bool,
+
     /// Names are treated as function names.
     #[arg(short = 'f')]
     names_are_functions: bool,
@@ -88,11 +92,31 @@ impl ExportCommand {
                 // Try to find the variable already present; if we find it, then mark it
                 // exported.
                 else if let Some((_, variable)) = context.shell.env_mut().get_mut(s) {
+                    if self.make_indexed_array {
+                        variable.convert_to_indexed_array()?;
+                    }
                     if self.unexport {
                         variable.unexport();
                     } else {
                         variable.export();
                     }
+                }
+                // If `-a` was passed and the name doesn't yet exist, create it as an unset
+                // indexed array with the export attribute (mirrors `declare -ax NAME`). This
+                // is what bash does for `export -a NAME` and what `mise activate bash` relies
+                // on when seeding `chpwd_functions`.
+                //
+                // But `-n` (unexport) on a name that doesn't exist yet is a no-op in bash --
+                // there's nothing to unexport, so don't materialize a new unset array var just
+                // because `-a` was also given. Only create the var on the exporting path.
+                else if self.make_indexed_array && !self.unexport {
+                    let mut var =
+                        ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::IndexedArray));
+                    var.export();
+                    context
+                        .shell
+                        .env_mut()
+                        .add(s.clone(), var, EnvironmentScope::Global)?;
                 }
             }
             brush_core::CommandArg::Assignment(assignment) => {
@@ -121,9 +145,16 @@ impl ExportCommand {
                 // bare `name+=value`. update_or_add always replaces, so when the
                 // variable already exists honor the append here. A missing variable
                 // falls through: appending to nothing is a plain assignment.
+                //
+                // When `-a` is also set, convert to an indexed array first (mirrors
+                // bash's `declare -ax foo+=x`) so the append lands on an array rather
+                // than silently ignoring `-a` on this path.
                 if assignment.append
                     && let Some((_, variable)) = context.shell.env_mut().get_mut(name)
                 {
+                    if self.make_indexed_array {
+                        variable.convert_to_indexed_array()?;
+                    }
                     variable.assign(value, true)?;
                     if self.unexport {
                         variable.unexport();
@@ -134,10 +165,19 @@ impl ExportCommand {
                 }
 
                 // Update the variable with the provided value and then mark it exported.
+                // `update_or_add` assigns the scalar value first and only then invokes this
+                // updater closure, so when `-a` is set we convert to an indexed array *after*
+                // the assignment lands -- `convert_to_indexed_array` takes whatever scalar was
+                // just assigned and re-seeds it as index 0. Net effect: `export -a foo=x` ends
+                // up as `foo=([0]="x")`, matching bash's `declare -ax foo=([0]="x")`, but via a
+                // convert-after-assign step, not a before-assign one.
                 context.shell.env_mut().update_or_add(
                     name,
                     value,
                     |var| {
+                        if self.make_indexed_array {
+                            var.convert_to_indexed_array()?;
+                        }
                         if self.unexport {
                             var.unexport();
                         } else {

--- a/brush-shell/tests/cases/compat/builtins/export.yaml
+++ b/brush-shell/tests/cases/compat/builtins/export.yaml
@@ -34,3 +34,33 @@ cases:
       export ref="exported_value"
       echo "MY_EXPORT_VAR: $MY_EXPORT_VAR"
       env | grep MY_EXPORT_VAR
+
+  - name: "export -a marks indexed array and exports (with array element assignment)"
+    stdin: |
+      export -a arr
+      arr[0]=hello
+      arr[1]=world
+      declare -p arr
+
+  - name: "export -a with scalar assignment auto-promotes to array"
+    stdin: |
+      export -a arr=hello
+      declare -p arr
+
+  - name: "export -a with array literal assignment"
+    stdin: |
+      export -a arr=(a b c)
+      declare -p arr
+
+  - name: "export -a converts an existing scalar to an indexed array"
+    stdin: |
+      foo=hello
+      export -a foo
+      foo[1]=world
+      declare -p foo
+
+  - name: "export -an unmarks an indexed array's export attribute"
+    stdin: |
+      export -a arr=(x y z)
+      export -n arr
+      declare -p arr

--- a/brush-shell/tests/cases/compat/builtins/export.yaml
+++ b/brush-shell/tests/cases/compat/builtins/export.yaml
@@ -51,3 +51,52 @@ cases:
     stdin: |
       export MYVAR+="first"
       echo "MYVAR: $MYVAR"
+
+  - name: "export -a marks indexed array and exports (with array element assignment)"
+    stdin: |
+      export -a arr
+      arr[0]=hello
+      arr[1]=world
+      declare -p arr
+
+  - name: "export -a with scalar assignment auto-promotes to array"
+    stdin: |
+      export -a arr=hello
+      declare -p arr
+
+  - name: "export -a with array literal assignment"
+    stdin: |
+      export -a arr=(a b c)
+      declare -p arr
+
+  - name: "export -a converts an existing scalar to an indexed array"
+    stdin: |
+      foo=hello
+      export -a foo
+      foo[1]=world
+      declare -p foo
+
+  - name: "export -an together unmarks export on an existing array, without creating a new var"
+    stdin: |
+      export -a arr=(x y z)
+      export -an arr
+      declare -p arr
+
+  - name: "export -an on a name that doesn't exist is a no-op (does not create an unset array)"
+    ignore_stderr: true # Different error messages (bash prefixes "bash: line N:", brush doesn't)
+    stdin: |
+      export -an brand_new_name
+      declare -p brand_new_name
+
+  - name: "export -a foo+=bar appends onto an indexed array, honoring -a"
+    stdin: |
+      declare -a arr=(one)
+      export -a arr+=two
+      declare -p arr
+
+  - name: "export -a chpwd_functions (mise activate bash's real-world trigger, issue #1132)"
+    stdin: |
+      export -a chpwd_functions
+      chpwd_functions+=(__zsh_like_cd)
+      chpwd_functions+=(__another_hook)
+      declare -p chpwd_functions


### PR DESCRIPTION
## Summary

Implements `export -a NAME` (declare-as-array combined with export attribute), so the builtin no longer rejects the `-a` flag. This matches bash's behavior and unblocks `mise activate bash`, which emits `export -a chpwd_functions` early in its setup — without this fix, every mise-activated brush session prints `error: unexpected argument '-a' found` to stderr (mise still loads, but the `chpwd_functions` array isn't properly seeded).

Closes #1132.

## Behavior

- **`export -a NAME`** on an existing variable: convert to indexed array, mark exported
- **`export -a NAME`** on a name that doesn't yet exist: create as unset indexed array with export attribute
- **`export -a NAME=value`** (scalar): auto-promote to indexed array with `[0]=value` and mark exported, matching bash's `declare -ax NAME=([0]="value")`
- **`export -a NAME=(a b c)`** (array literal): standard array initialization with export attribute
- **`export -an NAME`**: combined with `-n`, removes the export attribute on an indexed array

## Tests

Added five compat tests under `brush-shell/tests/cases/compat/builtins/export.yaml`:
- `export -a` followed by element assignments (`arr[0]=x; arr[1]=y`)
- `export -a NAME=value` scalar auto-promote
- `export -a NAME=(a b c)` array literal
- `export -a` converting an existing scalar to an indexed array
- `export -an` removing the export attribute from an indexed array

Each is verified against bash via the compat oracle.

## Known cosmetic divergence (documented, not fixed in this PR)

Bash is *lazy* about showing the `-a` attribute in `declare -p` for a declared-but-unassigned indexed array — it prints `declare -x foo` until the array is populated, then upgrades to `declare -ax foo=([0]="...")`. Brush is *eager* — it prints `declare -ax foo` immediately after `export -a foo`. The functional behavior is identical (the array is correctly typed and exported in both cases); only the `declare -p` representation for an *empty* declared array differs. The new tests therefore exercise the assignment paths, where bash and brush agree exactly. Happy to follow up with a "lazy attribute display" change if the maintainer wants exact `declare -p` parity, but it felt out of scope for this fix.

## Local verification

- `cargo xtask ci pre-commit` — fmt, build, lint, deps, schemas, unit tests all green; integration tests pass except for the pre-existing `brush-interactive-tests::run_in_bg_then_fg` flake unrelated to this change (also fails on `main` on this dev machine; the local interactive `.bashrc` references `mise`/`direnv`/`atuin`/`zoxide` hook functions that aren't present in CI).
- `mise activate bash | brush -c '. /dev/stdin && type mise'` now succeeds with no stderr noise.

Filed as a draft for early input.

---

`Assisted-by: Claude (Anthropic) (JMO's friend)`
