### PR TITLE
fix: implement history -n and history -r

### DIFF
--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -132,12 +132,26 @@ impl HistoryCommand {
             return Ok(ExecutionResult::success());
         }
 
-        if self.append_rest_of_file_to_session.is_some() {
-            return error::unimp("history -n is not yet implemented");
+        if let Some(append_rest_option) = &self.append_rest_of_file_to_session {
+            if let Some(file_path) = get_effective_history_file_path(
+                config.default_history_file_path,
+                append_rest_option.as_ref(),
+            ) {
+                history.read_new_from_file(file_path)?;
+            }
+
+            return Ok(ExecutionResult::success());
         }
 
-        if self.append_file_to_session.is_some() {
-            return error::unimp("history -r is not yet implemented");
+        if let Some(append_file_option) = &self.append_file_to_session {
+            if let Some(file_path) = get_effective_history_file_path(
+                config.default_history_file_path,
+                append_file_option.as_ref(),
+            ) {
+                history.reload_from_file(file_path)?;
+            }
+
+            return Ok(ExecutionResult::success());
         }
 
         if let Some(write_option) = &self.write_session_to_file {
@@ -157,7 +171,7 @@ impl HistoryCommand {
         }
 
         if self.expand_args.is_some() {
-            return error::unimp("history -p is not yet implemented");
+            return error::unimp_with_issue("history -p is not yet implemented", 100);
         }
 
         if let Some(args) = &self.append_args_to_session {
@@ -238,6 +252,40 @@ mod tests {
         let cmd = HistoryCommand::try_parse_from(["history", "-a", "token"])?;
         assert_eq!(
             cmd.append_session_to_file,
+            Some(Some(String::from("token")))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_dash_n() -> Result<()> {
+        let cmd = HistoryCommand::try_parse_from(["history", "5"])?;
+        assert_matches!(cmd.append_rest_of_file_to_session, None);
+
+        let cmd = HistoryCommand::try_parse_from(["history", "-n"])?;
+        assert_matches!(cmd.append_rest_of_file_to_session, Some(None));
+
+        let cmd = HistoryCommand::try_parse_from(["history", "-n", "token"])?;
+        assert_eq!(
+            cmd.append_rest_of_file_to_session,
+            Some(Some(String::from("token")))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_dash_r() -> Result<()> {
+        let cmd = HistoryCommand::try_parse_from(["history", "5"])?;
+        assert_matches!(cmd.append_file_to_session, None);
+
+        let cmd = HistoryCommand::try_parse_from(["history", "-r"])?;
+        assert_matches!(cmd.append_file_to_session, Some(None));
+
+        let cmd = HistoryCommand::try_parse_from(["history", "-r", "token"])?;
+        assert_eq!(
+            cmd.append_file_to_session,
             Some(Some(String::from("token")))
         );
 

--- a/brush-core/src/history.rs
+++ b/brush-core/src/history.rs
@@ -19,6 +19,12 @@ pub struct History {
     items: rpds::VectorSync<ItemId>,
     id_map: rpds::HashTrieMapSync<ItemId, Item>,
     next_id: ItemId,
+    /// Tracks how many items were present in the history file the last time we read it.
+    /// Used by `read_new_from_file` (`history -n`) to skip already-loaded entries.
+    /// Serde-skipped: not persisted across serialization boundaries; resets to 0 on
+    /// deserialization (safe — subsequent `-n` reads everything new from the file).
+    #[cfg_attr(feature = "serde", serde(skip))]
+    last_file_read_count: usize,
 }
 
 impl History {
@@ -32,11 +38,110 @@ impl History {
     /// * `reader` - The readable stream to import history from.
     pub fn import(reader: impl Read) -> Result<Self, error::Error> {
         let mut history = Self::default();
+        history.parse_and_append_lines(std::io::BufReader::new(reader).lines())?;
+        history.last_file_read_count = history.count();
+        Ok(history)
+    }
 
-        let buf_reader = std::io::BufReader::new(reader);
+    /// Reads any history entries that were added to the file since the last time we read it,
+    /// appending them to the current in-memory history. This implements `history -n` semantics.
+    ///
+    /// If the file appears to have been truncated externally (i.e., it now contains fewer entries
+    /// than we last read), the baseline is reset so future appends remain visible.
+    ///
+    /// Note: this re-parses the full file on each call. Acceptable for typical history sizes;
+    /// this is a known cost, not an optimization target.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the history file.
+    pub fn read_new_from_file(&mut self, path: impl AsRef<Path>) -> Result<(), error::Error> {
+        const MAX_FILE_SIZE_FOR_HISTORY_IMPORT: u64 = 1024 * 1024 * 1024; // 1 GiB
 
+        let file = std::fs::File::options().read(true).open(path.as_ref())?;
+
+        let file_size = file.metadata()?.len();
+        if file_size > MAX_FILE_SIZE_FOR_HISTORY_IMPORT {
+            return Err(error::ErrorKind::HistoryFileTooLargeToImport.into());
+        }
+
+        // Re-parse the full file into a scratch history to count entries.
+        let scratch = Self::import(file)?;
+
+        if scratch.count() < self.last_file_read_count {
+            // File was truncated externally. Reset the baseline so the next call sees new
+            // entries correctly, but do not append anything this time.
+            self.last_file_read_count = scratch.count();
+            return Ok(());
+        }
+
+        // Append only the entries that are new (i.e., those after the last read position).
+        let skip = self.last_file_read_count;
+        for item in scratch.iter().skip(skip) {
+            let new_item = Item {
+                id: self.next_id,
+                command_line: item.command_line.clone(),
+                timestamp: item.timestamp,
+                dirty: false,
+            };
+            self.add(new_item)?;
+        }
+
+        self.last_file_read_count = scratch.count();
+
+        Ok(())
+    }
+
+    /// Appends the full contents of the given file to the current in-memory history.
+    /// This implements `history -r` semantics: bash appends (does not replace) the
+    /// file content, matching the field name `append_file_to_session`.
+    ///
+    /// `last_file_read_count` is updated to reflect the new file baseline so that a
+    /// subsequent `history -n` does not re-read these entries.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the history file.
+    pub fn reload_from_file(&mut self, path: impl AsRef<Path>) -> Result<(), error::Error> {
+        const MAX_FILE_SIZE_FOR_HISTORY_IMPORT: u64 = 1024 * 1024 * 1024; // 1 GiB
+
+        let file = std::fs::File::options().read(true).open(path.as_ref())?;
+
+        let file_size = file.metadata()?.len();
+        if file_size > MAX_FILE_SIZE_FOR_HISTORY_IMPORT {
+            return Err(error::ErrorKind::HistoryFileTooLargeToImport.into());
+        }
+
+        // Re-parse the full file into a scratch history to count entries.
+        let scratch = Self::import(file)?;
+
+        // Append all file entries to the current in-memory history (bash -r semantics: append,
+        // not replace).
+        for item in scratch.iter() {
+            let new_item = Item {
+                id: self.next_id,
+                command_line: item.command_line.clone(),
+                timestamp: item.timestamp,
+                dirty: false,
+            };
+            self.add(new_item)?;
+        }
+
+        // Update the baseline so subsequent history -n calls skip these entries.
+        self.last_file_read_count = scratch.count();
+
+        Ok(())
+    }
+
+    /// Parses history lines from the given iterator and appends the resulting items to `self`.
+    /// Items are constructed with `dirty: false` because they originate from a file (not from
+    /// the user's current session).
+    fn parse_and_append_lines(
+        &mut self,
+        lines: impl Iterator<Item = std::io::Result<String>>,
+    ) -> Result<(), error::Error> {
         let mut next_timestamp = None;
-        for line_result in buf_reader.lines() {
+        for line_result in lines {
             let line = match line_result {
                 Ok(line) => line,
                 // If we couldn't decode the line due to invalid data (perhaps it wasn't
@@ -65,16 +170,16 @@ impl History {
             }
 
             let item = Item {
-                id: history.next_id,
+                id: self.next_id,
                 command_line: line,
                 timestamp: next_timestamp.take(),
                 dirty: false,
             };
 
-            history.add(item)?;
+            self.add(item)?;
         }
 
-        Ok(history)
+        Ok(())
     }
 
     /// Tries to retrieve a history item by its unique identifier. Returns `None` if no item is
@@ -158,10 +263,14 @@ impl History {
         Ok(())
     }
 
-    /// Clears all history items.
+    /// Clears all history items and resets the file-read baseline used by `read_new_from_file`.
     pub fn clear(&mut self) -> Result<(), error::Error> {
         self.id_map = rpds::HashTrieMapSync::new_sync();
         self.items = rpds::VectorSync::new_sync();
+        self.last_file_read_count = 0;
+        // NOTE: `next_id` is intentionally NOT reset here: item IDs must remain
+        // monotonically increasing across a `history -c` / `history -r` cycle so
+        // that reedline's ID-based lookups remain stable.
         Ok(())
     }
 

--- a/brush-core/src/history.rs
+++ b/brush-core/src/history.rs
@@ -11,6 +11,11 @@ use crate::error;
 /// Represents a unique identifier for a history item.
 type ItemId = i64;
 
+/// Maximum file size accepted when importing a history file. Files larger than this are
+/// rejected with `HistoryFileTooLargeToImport`. Applies to all file-import paths
+/// (`load_history`, `read_new_from_file`, `reload_from_file`).
+pub(crate) const MAX_FILE_SIZE_FOR_HISTORY_IMPORT: u64 = 1024 * 1024 * 1024; // 1 GiB
+
 /// Interface for querying and manipulating the shell's recorded history of commands.
 // TODO(history): support maximum item count
 #[derive(Clone, Default)]
@@ -56,8 +61,6 @@ impl History {
     ///
     /// * `path` - The path to the history file.
     pub fn read_new_from_file(&mut self, path: impl AsRef<Path>) -> Result<(), error::Error> {
-        const MAX_FILE_SIZE_FOR_HISTORY_IMPORT: u64 = 1024 * 1024 * 1024; // 1 GiB
-
         let file = std::fs::File::options().read(true).open(path.as_ref())?;
 
         let file_size = file.metadata()?.len();
@@ -103,8 +106,6 @@ impl History {
     ///
     /// * `path` - The path to the history file.
     pub fn reload_from_file(&mut self, path: impl AsRef<Path>) -> Result<(), error::Error> {
-        const MAX_FILE_SIZE_FOR_HISTORY_IMPORT: u64 = 1024 * 1024 * 1024; // 1 GiB
-
         let file = std::fs::File::options().read(true).open(path.as_ref())?;
 
         let file_size = file.metadata()?.len();

--- a/brush-core/src/shell/history.rs
+++ b/brush-core/src/shell/history.rs
@@ -6,8 +6,6 @@ use crate::{error, openfiles};
 
 impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
     pub(super) fn load_history(&self) -> Result<Option<crate::history::History>, error::Error> {
-        const MAX_FILE_SIZE_FOR_HISTORY_IMPORT: u64 = 1024 * 1024 * 1024; // 1 GiB
-
         let Some(history_path) = self.history_file_path() else {
             return Ok(None);
         };
@@ -31,7 +29,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
             }
 
             // Bail if the file is unrealistically large. For now we just refuse to import it.
-            if file_size > MAX_FILE_SIZE_FOR_HISTORY_IMPORT {
+            if file_size > crate::history::MAX_FILE_SIZE_FOR_HISTORY_IMPORT {
                 return Err(error::ErrorKind::HistoryFileTooLargeToImport.into());
             }
         }

--- a/brush-shell/tests/cases/compat/builtins/history.yaml
+++ b/brush-shell/tests/cases/compat/builtins/history.yaml
@@ -191,3 +191,198 @@ cases:
     stdin: |
       bash -c 'printf "\xff\xfe\xfd" >history-file.txt'
       HISTFILE=history-file.txt $0 -o history -c 'echo hi'
+
+  # Tests for history -r and history -n.
+  #
+  # These tests use skip_oracle + expected_stdout rather than comparing against bash's oracle,
+  # because bash non-interactive mode does not load HISTFILE at startup (unlike brush), and
+  # bash records stdin commands in history (unlike brush non-interactive mode). The functional
+  # behavior being tested -- that -r appends file content and -n reads only new entries -- is
+  # independent of these pre-existing behavioral differences.
+
+  - name: "history -r: loads file contents into session"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "source.txt"
+        contents: |
+          a b c
+          1 2 3
+    stdin: |
+      history -r ./source.txt
+      history -w out.txt
+      cat out.txt
+    # Brush runs interactively (add_to_history before each command), so stdin commands
+    # appear in history. history -w out.txt captures all entries at write time.
+    expected_stdout: |
+      history -r ./source.txt
+      a b c
+      1 2 3
+      history -w out.txt
+
+  - name: "history -r: appends to existing in-memory history"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "source.txt"
+        contents: |
+          from-file
+    stdin: |
+      history -s in-mem
+      history -r ./source.txt
+      history -w out.txt
+      cat out.txt
+    # history -s in-mem adds "in-mem" entry (dirty). Then history -r appends from-file.
+    # history -w writes: history -s in-mem, in-mem, history -r ..., from-file, history -w ...
+    expected_stdout: |
+      history -s in-mem
+      in-mem
+      history -r ./source.txt
+      from-file
+      history -w out.txt
+
+  - name: "history -r: with explicit file argument"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "other.txt"
+        contents: |
+          explicit-entry
+    stdin: |
+      history -r ./other.txt
+      history -w out.txt
+      cat out.txt
+    expected_stdout: |
+      history -r ./other.txt
+      explicit-entry
+      history -w out.txt
+
+  - name: "history -n: reads new entries from file"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          cmd1
+    stdin: |
+      history -n
+      echo "cmd2" >> "$HISTFILE"
+      history -n
+      history -w out.txt
+      cat out.txt
+    # Brush starts with [cmd1] (loaded from HISTFILE, last_file_read_count=1).
+    # history -n (first): no new entries. Stdin commands accumulate in history.
+    # echo "cmd2" >> $HISTFILE: appends cmd2 to file.
+    # history -n (second): reads cmd2 from file, appends to in-memory history.
+    # history -w writes: cmd1, history -n, echo cmd2..., history -n, cmd2, history -w ...
+    expected_stdout: |
+      cmd1
+      history -n
+      echo "cmd2" >> "$HISTFILE"
+      history -n
+      cmd2
+      history -w out.txt
+
+  - name: "history -n: idempotent when no new entries"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          cmd1
+    stdin: |
+      history -n
+      history -n
+      echo "done"
+    # Two successive history -n calls with no file changes; second should add nothing.
+    expected_stdout: |
+      done
+
+  - name: "history -n: with explicit file argument"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "other.txt"
+        contents: |
+          explicit-n-entry
+    stdin: |
+      history -n ./other.txt
+      history -w out.txt
+      cat out.txt
+    # HISTFILE does not exist; brush starts with empty history.
+    # history -n ./other.txt reads explicit-n-entry from other.txt.
+    expected_stdout: |
+      history -n ./other.txt
+      explicit-n-entry
+      history -w out.txt
+
+  - name: "history -r and -n after history -c"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "source.txt"
+        contents: |
+          after-clear
+    stdin: |
+      history -c
+      history -r ./source.txt
+      history -w out.txt
+      cat out.txt
+    # history -c: clears history (including the history-c entry itself -- it was added
+    # before running, then clear wipes it). history -r appends after-clear from source.txt.
+    expected_stdout: |
+      history -r ./source.txt
+      after-clear
+      history -w out.txt
+
+  - name: "history -n after external truncation"
+    skip_oracle: true
+    args: ["-o", "history"]
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          entry1
+          entry2
+          entry3
+    stdin: |
+      history -n
+      : > "$HISTFILE"
+      history -n
+      echo "cmd2" >> "$HISTFILE"
+      history -n
+      history -w out.txt
+      cat out.txt
+    # Brush starts with [entry1, entry2, entry3], last_file_read_count=3.
+    # history -n (1st): no new entries.
+    # : > $HISTFILE: truncates file.
+    # history -n (2nd): detects truncation (scratch.count()=0 < 3), resets baseline to 0.
+    # echo "cmd2" >> $HISTFILE: writes cmd2 to file.
+    # history -n (3rd): reads cmd2, appends to history.
+    # history -w writes all in-memory history.
+    expected_stdout: |
+      entry1
+      entry2
+      entry3
+      history -n
+      : > "$HISTFILE"
+      history -n
+      echo "cmd2" >> "$HISTFILE"
+      history -n
+      cmd2
+      history -w out.txt


### PR DESCRIPTION
## Summary

Implements `history -n` and `history -r`, which previously returned `error: not yet implemented`. Also retags the `history -p` stub via `unimp_with_issue(..., 100)` so anyone hitting it lands on #100 (history expansion) directly.

The motivating case: a `__history_sync` function in `PROMPT_COMMAND` (a common pattern for keeping multi-terminal history coherent) calls `history -a` (works) and `history -n` (errors today). With this fix, those configurations stop spamming stderr on every prompt cycle.

Closes #1134.

## Behavior — matches bash

- **`history -n [filename]`**: reads all entries from the file that haven't already been read into this session, appending them to the in-memory history. Tracks a per-session "last read offset" via a new `last_file_read_count` field on `History`.
- **`history -r [filename]`**: appends the full file contents to the in-memory history. Note: bash's man page says "use them as the current history," but the actual bash implementation **appends rather than replaces** — verified empirically with `bash --norc --noprofile -c 'history -s in-mem; history -r src.txt; history'`. The tests follow the empirical behavior.
- Both flags accept an optional explicit file argument; absent that, fall back to `$HISTFILE`.
- **Truncation recovery**: if the history file shrinks externally between two `-n` calls (log rotation, another session doing `history -w`), `last_file_read_count` is reset to the new (smaller) count so subsequent appends remain visible.
- **1 GiB file-size guard** is applied to `-n` and `-r`, matching the existing `load_history` behavior. While we were there, the constant was lifted to a single `pub(crate) const` so the threshold stays in lockstep across the three import paths.

## Design notes worth flagging

- **`last_file_read_count` is `serde(skip)`**: it's session-local state. Resetting to 0 across serialization boundaries is safe — a subsequent `-n` just re-reads everything from the file (the conservative outcome).
- **`clear()` resets `last_file_read_count` to 0** (so `history -c; history -n` reads everything from the file, matching bash). `next_id` is intentionally **not** reset — comment in code explains why (reedline ID stability across clear/reload cycles).
- **Items loaded from the file are constructed via direct `Item { dirty: false, ... }` literal**, not `Item::new()` (which sets `dirty: true`). That ensures `history -a` doesn't double-write entries that came from the file.
- **Reedline-clone investigation**: `brush-interactive/src/reedline/history.rs` accesses `History` exclusively through `MutexGuard` borrows; no `History::clone()` calls. The `Clone` derive on the struct exists but is not exercised by the reedline integration, so `last_file_read_count` doesn't get reset mid-session.

## Tests

- 8 new compat test cases under `brush-shell/tests/cases/compat/builtins/history.yaml` covering: load file, append-vs-replace, explicit file argument, incremental `-n` reads, idempotence, post-`history -c` behavior, and truncation recovery. All use `args: ["-o", "history"]` for deterministic non-interactive sequencing.
- 2 new unit tests (`test_parse_dash_n`, `test_parse_dash_r`) mirroring the existing `test_parse_dash_a`.

The new tests use `skip_oracle: true` + `expected_stdout` rather than bash-oracle comparison. Reason: brush loads `$HISTFILE` at startup in non-interactive mode while bash doesn't, which causes oracle divergence on incidental output unrelated to the feature being tested. This is a pre-existing brush↔bash divergence, not introduced by this PR. Happy to switch to oracle comparison if the maintainer prefers; this seemed like the lower-risk choice.

## Known related gap (not in this PR)

When `HISTFILE` is unset and no explicit file argument is given, `-a`/`-w`/`-n`/`-r` silently no-op (exit 0). Bash emits a diagnostic to stderr in the same situation (also exit 0). Filed as #1135. Doesn't affect the motivating `__history_sync` case (where `HISTFILE` is set), but worth tracking.

## Local verification

- `unset BASH_ENV && cargo xtask ci pre-commit` — fmt, build, lint, deps, schemas, unit tests all green; integration tests pass except for the pre-existing `brush-interactive-tests::run_in_bg_then_fg` flake unrelated to this change (also fails on `main` on this dev machine; the local `.bashrc` references `mise`/`direnv`/`atuin`/`zoxide` hook functions that aren't present in CI).
- The original repro `brush -i <<< 'history -n; exit'` now exits clean instead of printing an error.

## Two commits, one story

1. `fix: implement history -n and history -r` — the actual implementation
2. `refactor: lift MAX_FILE_SIZE_FOR_HISTORY_IMPORT to module scope` — small follow-on dedupe of the file-size constant across the three import paths

Happy to squash if the maintainer prefers a single commit.

Filed as a draft for early input.

---

`Assisted-by: Claude (Anthropic) (JMO's friend)`
