### PR TITLE
fix: retain terminal control during interactive sessions

### DIFF
--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -57,6 +57,8 @@ pub struct InteractiveShell<'a, IB: InputBackend, SE: brush_core::ShellExtension
     input: &'a mut IB,
     /// Terminal integration utility, if any.
     terminal_integration: Option<crate::term_integration::TerminalIntegration>,
+    /// Terminal-control guard, held for the lifetime of the interactive shell.
+    _terminal_control: Option<brush_core::terminal::TerminalControl>,
     /// Options.
     options: InteractiveOptions,
 }
@@ -77,9 +79,11 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
         let stdin_is_terminal = std::io::stdin().is_terminal();
 
         // Acquire terminal control if stdin is a terminal.
-        if stdin_is_terminal {
-            brush_core::terminal::TerminalControl::acquire()?;
-        }
+        let terminal_control = if stdin_is_terminal {
+            Some(brush_core::terminal::TerminalControl::acquire()?)
+        } else {
+            None
+        };
 
         // Set up terminal integration if enabled *and* if stdin is a terminal.
         let terminal_integration = if options.terminal_shell_integration && stdin_is_terminal {
@@ -98,6 +102,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             shell: shell.clone(),
             input,
             terminal_integration,
+            _terminal_control: terminal_control,
             options: options.clone(),
         })
     }

--- a/brush-shell/tests/interactive_tests.rs
+++ b/brush-shell/tests/interactive_tests.rs
@@ -6,6 +6,8 @@
 #![allow(clippy::panic_in_result_fn)]
 
 use anyhow::Context;
+use std::os::unix::process::CommandExt as _;
+
 use expectrl::{
     Expect, Session,
     process::unix::{PtyStream, UnixProcess},
@@ -120,6 +122,21 @@ fn run_pipeline_interactively() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn login_shell_via_argv0_shows_prompt() -> anyhow::Result<()> {
+    let mut session = start_shell_session_with(|cmd| {
+        cmd.arg0("-brush");
+    })?;
+
+    session.expect_prompt()?;
+    let login_shell_output = session.exec_output("shopt -q login_shell && echo login")?;
+    assert!(login_shell_output.contains("login"));
+
+    session.exit()?;
+
+    Ok(())
+}
+
 //
 // Helpers
 //
@@ -155,6 +172,12 @@ impl SessionExt for ShellSession {
 }
 
 fn start_shell_session() -> anyhow::Result<ShellSession> {
+    start_shell_session_with(|_| {})
+}
+
+fn start_shell_session_with(
+    configure: impl FnOnce(&mut std::process::Command),
+) -> anyhow::Result<ShellSession> {
     const DEFAULT_PROMPT: &str = "brush> ";
     let shell_path = assert_cmd::cargo::cargo_bin!("brush");
 
@@ -169,6 +192,7 @@ fn start_shell_session() -> anyhow::Result<ShellSession> {
     ]);
     cmd.env("PS1", DEFAULT_PROMPT);
     cmd.env("TERM", "linux");
+    configure(&mut cmd);
 
     let session = expectrl::session::Session::spawn(cmd)?;
 


### PR DESCRIPTION
## Summary

- Keep the `TerminalControl` guard alive for the full `InteractiveShell` lifetime so foreground terminal ownership is not immediately restored before interactive input starts.
- Add a pty regression test that simulates login-shell invocation with a dash-prefixed `argv[0]` and verifies the prompt appears with `login_shell` enabled.

Created by GitHub Copilot.

Fixes #1137.

## Validation

- `cargo test --test brush-interactive-tests login_shell_via_argv0_shows_prompt`
- `cargo test --test brush-interactive-tests run_pipeline_interactively`
- `cargo test --test brush-compat-tests -- 'Interactive::Basic interactive test'`
- `cargo test --workspace --lib --no-fail-fast`
- `cargo xtask ci quick` progressed through fmt, build, and clippy; the unit-test step could not run in this local environment because `cargo-nextest` is not installed.

## Manual verification

This should be manually verified on macOS with Ghostty because CI pty tests cannot fully reproduce Ghostty's login-shell/session setup.

1. Build this branch, for example: `cargo build --bin brush`.
2. Ensure the built `brush` path is allowed as a login shell, for example by adding the absolute binary path to `/etc/shells` if needed.
3. Set it as the user's login shell: `chsh -s <absolute-path-to-brush>`.
4. Reboot or log out/in, then open Ghostty and confirm a prompt appears instead of hanging.
5. In Ghostty, run `shopt -q login_shell && echo login` and a simple command like `echo ok` to confirm the shell is interactive and marked as a login shell.
6. Open Apple Terminal with the same login-shell configuration and confirm it still shows a prompt.
7. Restore the previous login shell with `chsh -s <previous-shell>` after testing.