### PR TITLE
fix(parser)!: track byte offsets instead of char counts in source locations

### DIFF
--- a/brush-core/src/callstack.rs
+++ b/brush-core/src/callstack.rs
@@ -191,7 +191,7 @@ impl Frame {
         let mut new_start = if let Some(existing_start) = &self.source_info.start {
             if let Some(current) = pos {
                 Some(Arc::new(crate::SourcePosition {
-                    index: existing_start.index + current.index,
+                    offset: existing_start.offset + current.offset,
                     line: existing_start.line + (current.line - 1),
                     column: if current.line <= 1 {
                         existing_start.column + (current.column - 1)
@@ -214,7 +214,7 @@ impl Frame {
                 Some(Arc::new(pos))
             } else {
                 Some(Arc::new(crate::SourcePosition {
-                    index: 0,
+                    offset: 0,
                     line: self.current_line_offset + 1,
                     column: 1,
                 }))

--- a/brush-interactive/src/highlighting.rs
+++ b/brush-interactive/src/highlighting.rs
@@ -188,13 +188,13 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
             for token in tokens {
                 match token {
                     brush_parser::Token::Operator(_op, token_location) => {
-                        let start = global_offset + byte_offset(token_location.start.index);
-                        let end = global_offset + byte_offset(token_location.end.index);
+                        let start = global_offset + byte_offset(token_location.start.offset);
+                        let end = global_offset + byte_offset(token_location.end.offset);
                         self.append_span(HighlightKind::Operator, start..end);
                     }
                     brush_parser::Token::Word(w, token_location) => {
-                        let start_byte = byte_offset(token_location.start.index);
-                        let end_byte = byte_offset(token_location.end.index);
+                        let start_byte = byte_offset(token_location.start.offset);
+                        let end_byte = byte_offset(token_location.end.offset);
 
                         // Parse the raw slice from `line`, not `w.as_str()`: the tokenizer may
                         // drop chars from `w` (e.g. `\<newline>` continuations), so offsets into

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -2368,7 +2368,7 @@ echo there
             SourcePosition {
                 line: 1,
                 column: 1,
-                index: 0
+                offset: 0
             }
         );
         assert_eq!(
@@ -2376,7 +2376,7 @@ echo there
             SourcePosition {
                 line: 2,
                 column: 11,
-                index: 18
+                offset: 18
             }
         );
     }
@@ -2404,7 +2404,7 @@ my_func
             SourcePosition {
                 line: 1,
                 column: 1,
-                index: 0
+                offset: 0
             }
         );
         assert_eq!(
@@ -2412,7 +2412,7 @@ my_func
             SourcePosition {
                 line: 4,
                 column: 2,
-                index: 36
+                offset: 36
             }
         );
     }
@@ -2435,7 +2435,7 @@ my_func
             SourcePosition {
                 line: 1,
                 column: 1,
-                index: 0
+                offset: 0
             }
         );
         assert_eq!(
@@ -2443,8 +2443,76 @@ my_func
             SourcePosition {
                 line: 1,
                 column: 28,
-                index: 27
+                offset: 27
             }
         );
+    }
+
+    #[test]
+    fn simple_cmd_loc_after_multibyte_comment() {
+        // Line 1: "# café\n" — 'é' is 2 bytes (0xC3 0xA9), total 8 bytes
+        // Line 2: "ls\n" — 'l' is at byte offset 8, total 3 bytes
+        let input = "# café\nls\n";
+
+        let program = parse(input);
+
+        let Command::Simple(cmd) = &program.complete_commands[0].0[0].0.first.seq[0] else {
+            panic!("expected simple command");
+        };
+
+        let loc = cmd.location().unwrap();
+
+        assert_eq!(
+            *(loc.start),
+            SourcePosition {
+                line: 2,
+                column: 1,
+                offset: 8
+            }
+        );
+        assert_eq!(
+            *(loc.end),
+            SourcePosition {
+                line: 2,
+                column: 3,
+                offset: 10
+            }
+        );
+
+        assert_eq!(input.get(loc.start.offset..loc.end.offset), Some("ls"));
+    }
+
+    #[test]
+    fn simple_cmd_loc_after_multiple_multibyte_chars() {
+        // "# café 日本語\n" = 18 bytes (é=2, 日=3, 本=3, 語=3 + ASCII)
+        // "ls" starts at byte offset 18
+        let input = "# café 日本語\nls\n";
+
+        let program = parse(input);
+
+        let Command::Simple(cmd) = &program.complete_commands[0].0[0].0.first.seq[0] else {
+            panic!("expected simple command");
+        };
+
+        let loc = cmd.location().unwrap();
+
+        assert_eq!(
+            *(loc.start),
+            SourcePosition {
+                line: 2,
+                column: 1,
+                offset: 18
+            }
+        );
+        assert_eq!(
+            *(loc.end),
+            SourcePosition {
+                line: 2,
+                column: 3,
+                offset: 20
+            }
+        );
+
+        assert_eq!(input.get(loc.start.offset..loc.end.offset), Some("ls"));
     }
 }

--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -753,7 +753,7 @@ fn add_pipe_extension_redirection(c: &mut ast::Command) -> Result<(), &'static s
 
 #[inline]
 fn locations_are_contiguous(loc_left: &crate::SourceSpan, loc_right: &crate::SourceSpan) -> bool {
-    loc_left.end.index == loc_right.start.index
+    loc_left.end.offset == loc_right.start.offset
 }
 
 impl peg::Parse for Tokens<'_> {
@@ -811,13 +811,13 @@ impl<'a> peg::ParseSlice<'a> for Tokens<'a> {
             let loc = token.location();
 
             if let Some(prev_end) = prev_end_index {
-                if loc.start.index > prev_end {
+                if loc.start.offset > prev_end {
                     result.push(' ');
                 }
             }
 
             result.push_str(token.to_str());
-            prev_end_index = Some(loc.end.index);
+            prev_end_index = Some(loc.end.offset);
         }
 
         result

--- a/brush-parser/src/parser/tests/mod.rs
+++ b/brush-parser/src/parser/tests/mod.rs
@@ -96,7 +96,7 @@ fn is_source_span(value: &Value) -> bool {
 fn normalize_source_span(value: &mut Value) {
     if let Value::Object(map) = value {
         let placeholder_pos = serde_json::json!({
-            "index": 0,
+            "offset": 0,
             "line": 0,
             "column": 0
         });

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__complex__parse_nested_if_while.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__complex__parse_nested_if_while.snap
@@ -72,12 +72,12 @@ ParseResult(
                           loc: "[location]",
                         ), SourceSpan(
                           start: SourcePosition(
-                            index: 18,
+                            offset: 18,
                             line: 2,
                             column: 5,
                           ),
                           end: SourcePosition(
-                            index: 67,
+                            offset: 67,
                             line: 4,
                             column: 9,
                           ),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_until.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_until.snap
@@ -47,12 +47,12 @@ ParseResult(
                 loc: "[location]",
               ), SourceSpan(
                 start: SourcePosition(
-                  index: 0,
+                  offset: 0,
                   line: 1,
                   column: 1,
                 ),
                 end: SourcePosition(
-                  index: 31,
+                  offset: 31,
                   line: 1,
                   column: 32,
                 ),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_while.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_while.snap
@@ -47,12 +47,12 @@ ParseResult(
                 loc: "[location]",
               ), SourceSpan(
                 start: SourcePosition(
-                  index: 0,
+                  offset: 0,
                   line: 1,
                   column: 1,
                 ),
                 end: SourcePosition(
-                  index: 30,
+                  offset: 30,
                   line: 1,
                   column: 31,
                 ),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_while_multiline.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__compound_commands__parse_while_multiline.snap
@@ -59,12 +59,12 @@ ParseResult(
                 loc: "[location]",
               ), SourceSpan(
                 start: SourcePosition(
-                  index: 0,
+                  offset: 0,
                   line: 1,
                   column: 1,
                 ),
                 end: SourcePosition(
-                  index: 42,
+                  offset: 42,
                   line: 5,
                   column: 5,
                 ),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__parse_program.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__parse_program.snap
@@ -17,12 +17,12 @@ ParseResult(
                     value: "A",
                     loc: Some(SourceSpan(
                       start: SourcePosition(
-                        index: 32,
+                        offset: 32,
                         line: 5,
                         column: 10,
                       ),
                       end: SourcePosition(
-                        index: 33,
+                        offset: 33,
                         line: 5,
                         column: 11,
                       ),
@@ -32,12 +32,12 @@ ParseResult(
                     value: "B",
                     loc: Some(SourceSpan(
                       start: SourcePosition(
-                        index: 34,
+                        offset: 34,
                         line: 5,
                         column: 12,
                       ),
                       end: SourcePosition(
-                        index: 35,
+                        offset: 35,
                         line: 5,
                         column: 13,
                       ),
@@ -47,12 +47,12 @@ ParseResult(
                     value: "C",
                     loc: Some(SourceSpan(
                       start: SourcePosition(
-                        index: 36,
+                        offset: 36,
                         line: 5,
                         column: 14,
                       ),
                       end: SourcePosition(
-                        index: 37,
+                        offset: 37,
                         line: 5,
                         column: 15,
                       ),
@@ -69,12 +69,12 @@ ParseResult(
                               value: "echo",
                               loc: Some(SourceSpan(
                                 start: SourcePosition(
-                                  index: 60,
+                                  offset: 60,
                                   line: 8,
                                   column: 5,
                                 ),
                                 end: SourcePosition(
-                                  index: 64,
+                                  offset: 64,
                                   line: 8,
                                   column: 9,
                                 ),
@@ -85,12 +85,12 @@ ParseResult(
                                 value: "\"${f@L}\"",
                                 loc: Some(SourceSpan(
                                   start: SourcePosition(
-                                    index: 65,
+                                    offset: 65,
                                     line: 8,
                                     column: 10,
                                   ),
                                   end: SourcePosition(
-                                    index: 73,
+                                    offset: 73,
                                     line: 8,
                                     column: 18,
                                   ),
@@ -100,12 +100,12 @@ ParseResult(
                                 value: "2",
                                 loc: Some(SourceSpan(
                                   start: SourcePosition(
-                                    index: 76,
+                                    offset: 76,
                                     line: 8,
                                     column: 21,
                                   ),
                                   end: SourcePosition(
-                                    index: 77,
+                                    offset: 77,
                                     line: 8,
                                     column: 22,
                                   ),
@@ -119,12 +119,12 @@ ParseResult(
                   ]),
                   loc: SourceSpan(
                     start: SourcePosition(
-                      index: 39,
+                      offset: 39,
                       line: 5,
                       column: 17,
                     ),
                     end: SourcePosition(
-                      index: 86,
+                      offset: 86,
                       line: 10,
                       column: 8,
                     ),
@@ -132,12 +132,12 @@ ParseResult(
                 ),
                 loc: SourceSpan(
                   start: SourcePosition(
-                    index: 23,
+                    offset: 23,
                     line: 5,
                     column: 1,
                   ),
                   end: SourcePosition(
-                    index: 86,
+                    offset: 86,
                     line: 10,
                     column: 8,
                   ),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__pipelines__parse_negated_timed_pipeline.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__pipelines__parse_negated_timed_pipeline.snap
@@ -11,12 +11,12 @@ ParseResult(
           first: Pipeline(
             timed: Some(Timed(SourceSpan(
               start: SourcePosition(
-                index: 0,
+                offset: 0,
                 line: 1,
                 column: 1,
               ),
               end: SourcePosition(
-                index: 4,
+                offset: 4,
                 line: 1,
                 column: 5,
               ),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__pipelines__parse_timed_pipeline.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__pipelines__parse_timed_pipeline.snap
@@ -11,12 +11,12 @@ ParseResult(
           first: Pipeline(
             timed: Some(Timed(SourceSpan(
               start: SourcePosition(
-                index: 0,
+                offset: 0,
                 line: 1,
                 column: 1,
               ),
               end: SourcePosition(
-                index: 4,
+                offset: 4,
                 line: 1,
                 column: 5,
               ),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__pipelines__parse_timed_pipeline_posix.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__pipelines__parse_timed_pipeline_posix.snap
@@ -11,12 +11,12 @@ ParseResult(
           first: Pipeline(
             timed: Some(TimedWithPosixOutput(SourceSpan(
               start: SourcePosition(
-                index: 0,
+                offset: 0,
                 line: 1,
                 column: 1,
               ),
               end: SourcePosition(
-                index: 7,
+                offset: 7,
                 line: 1,
                 column: 8,
               ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("a$((1+2))b", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
     )),
     Word("c", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 1,
         column: 12,
       ),
       end: SourcePosition(
-        index: 12,
+        offset: 12,
         line: 1,
         column: 13,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_parens.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_parens.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$(( (0) ))", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_space.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_arithmetic_expression_with_space.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$(( 1 ))", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 8,
+        offset: 8,
         line: 1,
         column: 9,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_backquote_with_escape.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_backquote_with_escape.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("`echo\\`hi`", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 15,
+        offset: 15,
         line: 1,
         column: 16,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion-2.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("a${x}b", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("${x}", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion_with_escaping.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_braced_parameter_expansion_with_escaping.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("a${x\\}}b", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 8,
+        offset: 8,
         line: 1,
         column: 9,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("a$(echo hi)b", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 12,
+        offset: 12,
         line: 1,
         column: 13,
       ),
     )),
     Word("c", SourceSpan(
       start: SourcePosition(
-        index: 13,
+        offset: 13,
         line: 1,
         column: 14,
       ),
       end: SourcePosition(
-        index: 14,
+        offset: 14,
         line: 1,
         column: 15,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_containing_extglob.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_containing_extglob.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("$(echo !(x))", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 17,
+        offset: 17,
         line: 1,
         column: 18,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_with_subshell.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_command_substitution_with_subshell.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$( (:) )", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 8,
+        offset: 8,
         line: 1,
         column: 9,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("a", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 1,
+        offset: 1,
         line: 1,
         column: 2,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment_at_eof.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_comment_at_eof.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("a", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 1,
+        offset: 1,
         line: 1,
         column: 2,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_complex_here_docs_in_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_complex_here_docs_in_command_substitution.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("$(cat <<HERE1 <<HERE2 | wc -l\nTEXT\nHERE1\nOTHER\nHERE2\n)", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 59,
+        offset: 59,
         line: 6,
         column: 2,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quote.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("x\"a b\"y", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 7,
+        offset: 7,
         line: 1,
         column: 8,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_arithmetic_expression.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_arithmetic_expression.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("x\"$((1+2))\"y", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 12,
+        offset: 12,
         line: 1,
         column: 13,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_double_quoted_command_substitution.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("x\"$(echo hi)\"y", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 14,
+        offset: 14,
         line: 1,
         column: 15,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_empty_here_doc.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_empty_here_doc.snap
@@ -7,72 +7,72 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
       end: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
     )),
     Word("", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 16,
+        offset: 16,
         line: 3,
         column: 1,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 16,
+        offset: 16,
         line: 3,
         column: 1,
       ),
       end: SourcePosition(
-        index: 16,
+        offset: 16,
         line: 3,
         column: 1,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_escaped_whitespace.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_escaped_whitespace.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("1\\ 2", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("3", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-2.snap
@@ -7,72 +7,72 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
       end: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
     )),
     Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-3.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-3.snap
@@ -7,84 +7,84 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
       end: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
     )),
     Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 27,
+        offset: 27,
         line: 5,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-4.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc-4.snap
@@ -7,72 +7,72 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
       end: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
     )),
     Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 25,
+        offset: 25,
         line: 3,
         column: 5,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 25,
+        offset: 25,
         line: 3,
         column: 5,
       ),
       end: SourcePosition(
-        index: 25,
+        offset: 25,
         line: 3,
         column: 5,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc.snap
@@ -7,108 +7,108 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
       end: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
     )),
     Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 10,
+        offset: 10,
         line: 1,
         column: 11,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 2,
         column: 1,
       ),
     )),
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 26,
+        offset: 26,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 30,
+        offset: 30,
         line: 4,
         column: 5,
       ),
     )),
     Word("after", SourceSpan(
       start: SourcePosition(
-        index: 31,
+        offset: 31,
         line: 4,
         column: 6,
       ),
       end: SourcePosition(
-        index: 36,
+        offset: 36,
         line: 4,
         column: 11,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 36,
+        offset: 36,
         line: 4,
         column: 11,
       ),
       end: SourcePosition(
-        index: 37,
+        offset: 37,
         line: 5,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_command_substitution.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("$(cat <<HERE\nTEXT\nHERE\n)", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 29,
+        offset: 29,
         line: 4,
         column: 2,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("\"$(cat <<HERE\nTEXT\nHERE\n)\"", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 31,
+        offset: 31,
         line: 4,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution_with_space.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_in_double_quoted_command_substitution_with_space.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("\"$(cat << HERE\nTEXT\nHERE\n)\"", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 32,
+        offset: 32,
         line: 4,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_other_tokens.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_other_tokens.snap
@@ -7,108 +7,108 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
     )),
     Word("EOF", SourceSpan(
       start: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
       end: SourcePosition(
-        index: 9,
+        offset: 9,
         line: 1,
         column: 10,
       ),
     )),
     Word("A B C\n1 2 3\nD E F\n", SourceSpan(
       start: SourcePosition(
-        index: 18,
+        offset: 18,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 40,
+        offset: 40,
         line: 6,
         column: 1,
       ),
     )),
     Word("EOF", SourceSpan(
       start: SourcePosition(
-        index: 40,
+        offset: 40,
         line: 6,
         column: 1,
       ),
       end: SourcePosition(
-        index: 40,
+        offset: 40,
         line: 6,
         column: 1,
       ),
     )),
     Operator("|", SourceSpan(
       start: SourcePosition(
-        index: 9,
+        offset: 9,
         line: 1,
         column: 10,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 1,
         column: 12,
       ),
     )),
     Word("wc", SourceSpan(
       start: SourcePosition(
-        index: 12,
+        offset: 12,
         line: 1,
         column: 13,
       ),
       end: SourcePosition(
-        index: 14,
+        offset: 14,
         line: 1,
         column: 15,
       ),
     )),
     Word("-l", SourceSpan(
       start: SourcePosition(
-        index: 14,
+        offset: 14,
         line: 1,
         column: 15,
       ),
       end: SourcePosition(
-        index: 17,
+        offset: 17,
         line: 1,
         column: 18,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 17,
+        offset: 17,
         line: 1,
         column: 18,
       ),
       end: SourcePosition(
-        index: 18,
+        offset: 18,
         line: 2,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_tab_removal.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_here_doc_with_tab_removal.snap
@@ -7,72 +7,72 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<-", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 7,
+        offset: 7,
         line: 1,
         column: 8,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 7,
+        offset: 7,
         line: 1,
         column: 8,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 1,
         column: 12,
       ),
     )),
     Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
-        index: 12,
+        offset: 12,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 29,
+        offset: 29,
         line: 4,
         column: 1,
       ),
     )),
     Word("HERE", SourceSpan(
       start: SourcePosition(
-        index: 29,
+        offset: 29,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 29,
+        offset: 29,
         line: 4,
         column: 1,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 1,
         column: 12,
       ),
       end: SourcePosition(
-        index: 12,
+        offset: 12,
         line: 2,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_line_continuation.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_line_continuation.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("abc", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 2,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_multiple_here_docs.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_multiple_here_docs.snap
@@ -7,156 +7,156 @@ TokenizerResult(
   result: [
     Word("cat", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
     )),
     Word("HERE1", SourceSpan(
       start: SourcePosition(
-        index: 6,
+        offset: 6,
         line: 1,
         column: 7,
       ),
       end: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 1,
         column: 12,
       ),
     )),
     Word("SOMETHING\n", SourceSpan(
       start: SourcePosition(
-        index: 20,
+        offset: 20,
         line: 2,
         column: 1,
       ),
       end: SourcePosition(
-        index: 36,
+        offset: 36,
         line: 4,
         column: 1,
       ),
     )),
     Word("HERE1", SourceSpan(
       start: SourcePosition(
-        index: 36,
+        offset: 36,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 36,
+        offset: 36,
         line: 4,
         column: 1,
       ),
     )),
     Operator("<<", SourceSpan(
       start: SourcePosition(
-        index: 11,
+        offset: 11,
         line: 1,
         column: 12,
       ),
       end: SourcePosition(
-        index: 14,
+        offset: 14,
         line: 1,
         column: 15,
       ),
     )),
     Word("HERE2", SourceSpan(
       start: SourcePosition(
-        index: 14,
+        offset: 14,
         line: 1,
         column: 15,
       ),
       end: SourcePosition(
-        index: 19,
+        offset: 19,
         line: 1,
         column: 20,
       ),
     )),
     Word("OTHER\n", SourceSpan(
       start: SourcePosition(
-        index: 36,
+        offset: 36,
         line: 4,
         column: 1,
       ),
       end: SourcePosition(
-        index: 48,
+        offset: 48,
         line: 6,
         column: 1,
       ),
     )),
     Word("HERE2", SourceSpan(
       start: SourcePosition(
-        index: 48,
+        offset: 48,
         line: 6,
         column: 1,
       ),
       end: SourcePosition(
-        index: 48,
+        offset: 48,
         line: 6,
         column: 1,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 19,
+        offset: 19,
         line: 1,
         column: 20,
       ),
       end: SourcePosition(
-        index: 20,
+        offset: 20,
         line: 2,
         column: 1,
       ),
     )),
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 48,
+        offset: 48,
         line: 6,
         column: 1,
       ),
       end: SourcePosition(
-        index: 52,
+        offset: 52,
         line: 6,
         column: 5,
       ),
     )),
     Word("after", SourceSpan(
       start: SourcePosition(
-        index: 53,
+        offset: 53,
         line: 6,
         column: 6,
       ),
       end: SourcePosition(
-        index: 58,
+        offset: 58,
         line: 6,
         column: 11,
       ),
     )),
     Operator("\n", SourceSpan(
       start: SourcePosition(
-        index: 58,
+        offset: 58,
         line: 6,
         column: 11,
       ),
       end: SourcePosition(
-        index: 59,
+        offset: 59,
         line: 7,
         column: 1,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_operators.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_operators.snap
@@ -7,36 +7,36 @@ TokenizerResult(
   result: [
     Word("a", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 1,
+        offset: 1,
         line: 1,
         column: 2,
       ),
     )),
     Operator(">>", SourceSpan(
       start: SourcePosition(
-        index: 1,
+        offset: 1,
         line: 1,
         column: 2,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Word("b", SourceSpan(
       start: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_simple_backquote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_simple_backquote.snap
@@ -7,24 +7,24 @@ TokenizerResult(
   result: [
     Word("echo", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
     )),
     Word("`echo hi`", SourceSpan(
       start: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),
       end: SourcePosition(
-        index: 14,
+        offset: 14,
         line: 1,
         column: 15,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_single_quote.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_single_quote.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("x\'a b\'y", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 7,
+        offset: 7,
         line: 1,
         column: 8,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-2.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$@", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-3.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-3.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$!", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-4.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-4.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$?", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-5.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters-5.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$*", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_special_parameters.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$$", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion-2.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion-2.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("a$x", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_unbraced_parameter_expansion.snap
@@ -7,12 +7,12 @@ TokenizerResult(
   result: [
     Word("$x", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),

--- a/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_whitespace.snap
+++ b/brush-parser/src/snapshots/brush_parser__tokenizer__tests__tokenize_whitespace.snap
@@ -7,36 +7,36 @@ TokenizerResult(
   result: [
     Word("1", SourceSpan(
       start: SourcePosition(
-        index: 0,
+        offset: 0,
         line: 1,
         column: 1,
       ),
       end: SourcePosition(
-        index: 1,
+        offset: 1,
         line: 1,
         column: 2,
       ),
     )),
     Word("2", SourceSpan(
       start: SourcePosition(
-        index: 2,
+        offset: 2,
         line: 1,
         column: 3,
       ),
       end: SourcePosition(
-        index: 3,
+        offset: 3,
         line: 1,
         column: 4,
       ),
     )),
     Word("3", SourceSpan(
       start: SourcePosition(
-        index: 4,
+        offset: 4,
         line: 1,
         column: 5,
       ),
       end: SourcePosition(
-        index: 5,
+        offset: 5,
         line: 1,
         column: 6,
       ),

--- a/brush-parser/src/source.rs
+++ b/brush-parser/src/source.rs
@@ -8,11 +8,11 @@ use std::{fmt::Display, sync::Arc};
     derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)
 )]
 pub struct SourcePosition {
-    /// The 0-based index of the character in the input stream.
-    pub index: usize,
+    /// The 0-based byte offset in the input stream.
+    pub offset: usize,
     /// The 1-based line number.
     pub line: usize,
-    /// The 1-based column number.
+    /// The 1-based column number (character count within the line).
     pub column: usize,
 }
 
@@ -31,7 +31,7 @@ impl SourcePosition {
     #[must_use]
     pub const fn offset(&self, offset: &SourcePositionOffset) -> Self {
         Self {
-            index: self.index + offset.index,
+            offset: self.offset + offset.offset,
             line: self.line + offset.line,
             column: if offset.line == 0 {
                 self.column + offset.column
@@ -46,7 +46,7 @@ impl SourcePosition {
 impl From<&SourcePosition> for miette::SourceOffset {
     #[allow(clippy::cast_sign_loss)]
     fn from(position: &SourcePosition) -> Self {
-        position.index.into()
+        position.offset.into()
     }
 }
 
@@ -58,8 +58,8 @@ impl From<&SourcePosition> for miette::SourceOffset {
     derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)
 )]
 pub struct SourcePositionOffset {
-    /// The 0-based character offset.
-    pub index: usize,
+    /// The 0-based byte offset.
+    pub offset: usize,
     /// The 0-based line offset.
     pub line: usize,
     /// The 0-based column offset.
@@ -81,9 +81,9 @@ pub struct SourceSpan {
 }
 
 impl SourceSpan {
-    /// Returns the length of the token in characters.
+    /// Returns the length of the span in bytes.
     pub fn length(&self) -> usize {
-        self.end.index - self.start.index
+        self.end.offset - self.start.offset
     }
     pub(crate) fn within(start: &Self, end: &Self) -> Self {
         Self {

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -539,7 +539,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
             char_reader: reader.chars().peekable(),
             cross_state: CrossTokenParseState {
                 cursor: SourcePosition {
-                    index: 0,
+                    offset: 0,
                     line: 1,
                     column: 1,
                 },
@@ -570,7 +570,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
             } else {
                 self.cross_state.cursor.column += 1;
             }
-            self.cross_state.cursor.index += 1;
+            self.cross_state.cursor.offset += ch.len_utf8();
         }
 
         Ok(c)
@@ -1133,7 +1133,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
                 } else {
                     // Make sure we don't include this char in the token range.
                     state.start_position.column += 1;
-                    state.start_position.index += 1;
+                    state.start_position.offset += c.len_utf8();
                 }
 
                 self.consume_char()?;


### PR DESCRIPTION
## Summary

- `SourcePosition.index` now tracks **byte offsets** rather than UTF-8 character counts, fixing off-by-one drift per multi-byte character that broke any downstream use of the index for source slicing (diagnostics, syntax highlighting, LSP, etc.)
- Two fixes in the tokenizer: `next_char()` increments by `ch.len_utf8()` instead of `1`, and the whitespace-skip branch does the same
- Updated doc comments on `SourcePosition`, `SourcePositionOffset`, and `SourceSpan::length()` to reflect byte semantics
- Added two tests verifying correct byte indices for tokens following multi-byte UTF-8 characters

Closes #1127

## Breaking change

`SourcePosition.index` previously documented as a "character index" now returns a byte offset. Any downstream consumer relying on character-count semantics will need to adjust.