### PR TITLE
fix(history): emit diagnostic when HISTFILE is unset for -a/-w

### DIFF
--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -50,6 +50,7 @@ pub(crate) struct HistoryCommand {
 
 struct HistoryConfig {
     default_history_file_path: Option<PathBuf>,
+    shell_name: String,
     time_format: Option<String>,
 }
 
@@ -63,6 +64,10 @@ impl builtins::Command for HistoryCommand {
         // Retrieve the shell's history config while we still can.
         let config = HistoryConfig {
             default_history_file_path: context.shell.history_file_path(),
+            shell_name: context
+                .shell
+                .current_shell_name()
+                .map_or_else(|| String::from("brush"), |name| name.to_string()),
             time_format: context.shell.history_time_format(),
         };
 
@@ -135,7 +140,8 @@ impl HistoryCommand {
                 None => {
                     writeln!(
                         stderr,
-                        "brush: history: HISTFILE: parameter null or not set"
+                        "{}: history: HISTFILE: parameter null or not set",
+                        config.shell_name
                     )?;
                 }
             }
@@ -167,7 +173,8 @@ impl HistoryCommand {
                 None => {
                     writeln!(
                         stderr,
-                        "brush: history: HISTFILE: parameter null or not set"
+                        "{}: history: HISTFILE: parameter null or not set",
+                        config.shell_name
                     )?;
                 }
             }
@@ -261,5 +268,21 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_empty_default_history_file_path_is_unset() {
+        assert_eq!(
+            get_effective_history_file_path(Some(PathBuf::from("")), None),
+            None
+        );
+    }
+
+    #[test]
+    fn test_explicit_empty_history_file_path_is_authoritative() {
+        assert_eq!(
+            get_effective_history_file_path(Some(PathBuf::from("default-history")), Some(&String::new())),
+            Some(PathBuf::from(""))
+        );
     }
 }

--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -133,7 +133,10 @@ impl HistoryCommand {
                     )?;
                 }
                 None => {
-                    writeln!(stderr, "brush: history: HISTFILE: parameter null or not set")?;
+                    writeln!(
+                        stderr,
+                        "brush: history: HISTFILE: parameter null or not set"
+                    )?;
                 }
             }
 
@@ -162,7 +165,10 @@ impl HistoryCommand {
                     )?;
                 }
                 None => {
-                    writeln!(stderr, "brush: history: HISTFILE: parameter null or not set")?;
+                    writeln!(
+                        stderr,
+                        "brush: history: HISTFILE: parameter null or not set"
+                    )?;
                 }
             }
 

--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -120,16 +120,21 @@ impl HistoryCommand {
         }
 
         if let Some(append_option) = &self.append_session_to_file {
-            if let Some(file_path) = get_effective_history_file_path(
+            match get_effective_history_file_path(
                 config.default_history_file_path.as_deref(),
                 append_option.as_deref(),
             ) {
-                history.flush(
-                    file_path,
-                    true,                         /* append? */
-                    true,                         /* unsaved items only */
-                    config.time_format.is_some(), /* write timestamps? */
-                )?;
+                Some(file_path) => {
+                    history.flush(
+                        file_path,
+                        true,                         /* append? */
+                        true,                         /* unsaved items only */
+                        config.time_format.is_some(), /* write timestamps? */
+                    )?;
+                }
+                None => {
+                    writeln!(stderr, "brush: history: HISTFILE: parameter null or not set")?;
+                }
             }
 
             return Ok(ExecutionResult::success());
@@ -144,16 +149,21 @@ impl HistoryCommand {
         }
 
         if let Some(write_option) = &self.write_session_to_file {
-            if let Some(file_path) = get_effective_history_file_path(
+            match get_effective_history_file_path(
                 config.default_history_file_path.as_deref(),
                 write_option.as_deref(),
             ) {
-                history.flush(
-                    file_path,
-                    false,                        /* append? */
-                    false,                        /* unsaved items only? */
-                    config.time_format.is_some(), /* write timestamps? */
-                )?;
+                Some(file_path) => {
+                    history.flush(
+                        file_path,
+                        false,                        /* append? */
+                        false,                        /* unsaved items only? */
+                        config.time_format.is_some(), /* write timestamps? */
+                    )?;
+                }
+                None => {
+                    writeln!(stderr, "brush: history: HISTFILE: parameter null or not set")?;
+                }
             }
 
             return Ok(ExecutionResult::success());
@@ -218,7 +228,10 @@ fn get_effective_history_file_path<'a>(
     default_history_file_path: Option<&'a Path>,
     option: Option<&'a str>,
 ) -> Option<&'a Path> {
-    option.map(Path::new).or(default_history_file_path)
+    match option {
+        Some(file_path) => Some(Path::new(file_path)),
+        None => default_history_file_path.filter(|path| !path.as_os_str().is_empty()),
+    }
 }
 
 #[cfg(test)]

--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -273,7 +273,7 @@ mod tests {
     #[test]
     fn test_empty_default_history_file_path_is_unset() {
         assert_eq!(
-            get_effective_history_file_path(Some(PathBuf::from("")), None),
+            get_effective_history_file_path(Some(Path::new("")), None),
             None
         );
     }
@@ -281,8 +281,8 @@ mod tests {
     #[test]
     fn test_explicit_empty_history_file_path_is_authoritative() {
         assert_eq!(
-            get_effective_history_file_path(Some(PathBuf::from("default-history")), Some(&String::new())),
-            Some(PathBuf::from(""))
+            get_effective_history_file_path(Some(Path::new("default-history")), Some("")),
+            Some(Path::new(""))
         );
     }
 }

--- a/brush-shell/tests/cases/compat/builtins/history.yaml
+++ b/brush-shell/tests/cases/compat/builtins/history.yaml
@@ -146,6 +146,24 @@ cases:
       echo "[histfile after second -w]"
       cat $HISTFILE
 
+  - name: "history -a without HISTFILE"
+    args: ["-o", "history"]
+    env:
+      HISTFILE: ""
+    stdin: |
+      history -a
+    expected_exit_code: 0
+    expected_stderr: "brush: history: HISTFILE: parameter null or not set\n"
+
+  - name: "history -w without HISTFILE"
+    args: ["-o", "history"]
+    env:
+      HISTFILE: ""
+    stdin: |
+      history -w
+    expected_exit_code: 0
+    expected_stderr: "brush: history: HISTFILE: parameter null or not set\n"
+
   - name: "history -w with explicit file"
     args: ["-o", "history"]
     env:

--- a/brush-shell/tests/cases/compat/builtins/history.yaml
+++ b/brush-shell/tests/cases/compat/builtins/history.yaml
@@ -164,6 +164,16 @@ cases:
     expected_exit_code: 0
     expected_stderr: "brush: history: HISTFILE: parameter null or not set\n"
 
+  - name: "history -a without HISTFILE respects argv0"
+    args: ["-o", "history", "-c", "exec -a custom-brush $0 -o history -c 'unset HISTFILE; history -a'"]
+    expected_exit_code: 0
+    expected_stderr: "custom-brush: history: HISTFILE: parameter null or not set\n"
+
+  - name: "history -w without HISTFILE respects argv0"
+    args: ["-o", "history", "-c", "exec -a custom-brush $0 -o history -c 'unset HISTFILE; history -w'"]
+    expected_exit_code: 0
+    expected_stderr: "custom-brush: history: HISTFILE: parameter null or not set\n"
+
   - name: "history -w with explicit file"
     args: ["-o", "history"]
     env:


### PR DESCRIPTION
## Summary

When `HISTFILE` is unset and no explicit file argument is provided, `history -a` and `history -w` previously silently succeeded with exit 0. Bash emits a diagnostic to stderr in the same situation.

This PR fixes the issue by emitting:
```
brush: history: HISTFILE: parameter null or not set
```
to stderr when the history file path resolves to `None`, matching bash's exact wording for compat-script friendliness.

## Changes

- `brush-builtins/src/history.rs`: Converted `if let Some` to `match` for both `-a` (append_session_to_file) and `-w` (write_session_to_file) code paths, adding a `None` arm that writes the diagnostic to stderr.

## Notes

- `-n` and `-r` already return "not yet implemented" errors, so they don't need the HISTFILE check yet.
- The fix preserves the existing exit code (0) to match bash behavior.

Fixes #1135