### PR TITLE
feat(core): stateful builtin infrastructure

### DIFF
--- a/.opencode/MEMORIES.md
+++ b/.opencode/MEMORIES.md
@@ -1,0 +1,25 @@
+# brush Repository Guide
+
+## Remotes
+
+- **`origin`** = `reubeno/brush.git` (upstream) — PRs go here
+- **`mine`** = `lu-zero/brush.git` (fork) — **push branches here**
+
+## Workflow
+
+1. Create feature branch
+2. `git push -u mine <branch>`
+3. `gh pr create --repo reubeno/brush --head lu-zero:<branch> --base main ...`
+
+## Key Branches
+
+- `main` — tracks upstream `origin/main`
+- `for-portage-repo` — portage-repo's dependency branch (rebased onto feature branches as needed)
+- `stateful-builtins` — stateful builtin infrastructure (PR #1151)
+
+## portage-repo Integration
+
+`../portage-repo` depends on this repo via path deps. After changes here:
+1. Rebase `for-portage-repo` onto the new feature branch
+2. Run `cargo check` / `cargo test` in portage-repo to verify
+3. Run `cargo run --example regen_cache -- gentoo 'dev-lang/python*' --jobs 4` for full integration test

--- a/brush-builtins/src/alias.rs
+++ b/brush-builtins/src/alias.rs
@@ -17,6 +17,7 @@ pub(crate) struct AliasCommand {
 
 impl builtins::Command for AliasCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/alias.rs
+++ b/brush-builtins/src/alias.rs
@@ -16,6 +16,7 @@ pub(crate) struct AliasCommand {
 }
 
 impl builtins::Command for AliasCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/bg.rs
+++ b/brush-builtins/src/bg.rs
@@ -12,6 +12,7 @@ pub(crate) struct BgCommand {
 
 impl builtins::Command for BgCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/bg.rs
+++ b/brush-builtins/src/bg.rs
@@ -11,6 +11,7 @@ pub(crate) struct BgCommand {
 }
 
 impl builtins::Command for BgCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/bind.rs
+++ b/brush-builtins/src/bind.rs
@@ -120,6 +120,7 @@ impl From<&BindError> for brush_core::ExecutionExitCode {
 }
 
 impl builtins::Command for BindCommand {
+    type State = ();
     type Error = BindError;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/bind.rs
+++ b/brush-builtins/src/bind.rs
@@ -121,6 +121,7 @@ impl From<&BindError> for brush_core::ExecutionExitCode {
 
 impl builtins::Command for BindCommand {
     type State = ();
+    type SharedState = ();
     type Error = BindError;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/break_.rs
+++ b/brush-builtins/src/break_.rs
@@ -12,6 +12,7 @@ pub(crate) struct BreakCommand {
 
 impl builtins::Command for BreakCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/break_.rs
+++ b/brush-builtins/src/break_.rs
@@ -11,6 +11,7 @@ pub(crate) struct BreakCommand {
 }
 
 impl builtins::Command for BreakCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/builder.rs
+++ b/brush-builtins/src/builder.rs
@@ -1,20 +1,17 @@
 use crate::BuiltinSet;
 
-/// Extension trait that simplifies adding default builtins to a shell builder.
-pub trait ShellBuilderExt {
-    /// Add default builtins to the shell being built.
+/// Extension trait that simplifies adding default builtins to a shell.
+pub trait ShellExt {
+    /// Register default builtins on the shell.
     ///
     /// # Arguments
     ///
-    /// * `set` - The well-known set of built-ins to add.
-    #[must_use]
-    fn default_builtins(self, set: BuiltinSet) -> Self;
+    /// * `set` - The well-known set of built-ins to register.
+    fn register_default_builtins(&mut self, set: BuiltinSet);
 }
 
-impl<SE: brush_core::extensions::ShellExtensions, S: brush_core::ShellBuilderState> ShellBuilderExt
-    for brush_core::ShellBuilder<SE, S>
-{
-    fn default_builtins(self, set: BuiltinSet) -> Self {
-        self.builtins(crate::default_builtins(set))
+impl<SE: brush_core::extensions::ShellExtensions> ShellExt for brush_core::Shell<SE> {
+    fn register_default_builtins(&mut self, set: BuiltinSet) {
+        crate::register_default_builtins(self, set);
     }
 }

--- a/brush-builtins/src/builtin_.rs
+++ b/brush-builtins/src/builtin_.rs
@@ -16,6 +16,7 @@ impl builtins::DeclarationCommand for BuiltinCommand {
 }
 
 impl builtins::Command for BuiltinCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/builtin_.rs
+++ b/brush-builtins/src/builtin_.rs
@@ -17,6 +17,7 @@ impl builtins::DeclarationCommand for BuiltinCommand {
 
 impl builtins::Command for BuiltinCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/caller.rs
+++ b/brush-builtins/src/caller.rs
@@ -11,6 +11,7 @@ pub(crate) struct CallerCommand {
 
 impl builtins::Command for CallerCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/caller.rs
+++ b/brush-builtins/src/caller.rs
@@ -10,6 +10,7 @@ pub(crate) struct CallerCommand {
 }
 
 impl builtins::Command for CallerCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/cd.rs
+++ b/brush-builtins/src/cd.rs
@@ -31,6 +31,7 @@ pub(crate) struct CdCommand {
 }
 
 impl builtins::Command for CdCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/cd.rs
+++ b/brush-builtins/src/cd.rs
@@ -32,6 +32,7 @@ pub(crate) struct CdCommand {
 
 impl builtins::Command for CdCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/command.rs
+++ b/brush-builtins/src/command.rs
@@ -33,6 +33,7 @@ impl CommandCommand {
 }
 
 impl builtins::Command for CommandCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/command.rs
+++ b/brush-builtins/src/command.rs
@@ -34,6 +34,7 @@ impl CommandCommand {
 
 impl builtins::Command for CommandCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/complete.rs
+++ b/brush-builtins/src/complete.rs
@@ -201,6 +201,7 @@ pub(crate) struct CompleteCommand {
 }
 
 impl builtins::Command for CompleteCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(
@@ -470,6 +471,7 @@ pub(crate) struct CompGenCommand {
 }
 
 impl builtins::Command for CompGenCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(
@@ -551,6 +553,7 @@ pub(crate) struct CompOptCommand {
 }
 
 impl builtins::Command for CompOptCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/complete.rs
+++ b/brush-builtins/src/complete.rs
@@ -202,6 +202,7 @@ pub(crate) struct CompleteCommand {
 
 impl builtins::Command for CompleteCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(
@@ -472,6 +473,7 @@ pub(crate) struct CompGenCommand {
 
 impl builtins::Command for CompGenCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(
@@ -554,6 +556,7 @@ pub(crate) struct CompOptCommand {
 
 impl builtins::Command for CompOptCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/continue_.rs
+++ b/brush-builtins/src/continue_.rs
@@ -12,6 +12,7 @@ pub(crate) struct ContinueCommand {
 
 impl builtins::Command for ContinueCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/continue_.rs
+++ b/brush-builtins/src/continue_.rs
@@ -11,6 +11,7 @@ pub(crate) struct ContinueCommand {
 }
 
 impl builtins::Command for ContinueCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -119,6 +119,7 @@ impl builtins::DeclarationCommand for DeclareCommand {
 
 impl builtins::Command for DeclareCommand {
     type State = ();
+    type SharedState = ();
     fn takes_plus_options() -> bool {
         true
     }

--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -118,6 +118,7 @@ impl builtins::DeclarationCommand for DeclareCommand {
 }
 
 impl builtins::Command for DeclareCommand {
+    type State = ();
     fn takes_plus_options() -> bool {
         true
     }

--- a/brush-builtins/src/dirs.rs
+++ b/brush-builtins/src/dirs.rs
@@ -48,6 +48,7 @@ pub(crate) struct DirsCommand {
 }
 
 impl builtins::Command for DirsCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/dirs.rs
+++ b/brush-builtins/src/dirs.rs
@@ -49,6 +49,7 @@ pub(crate) struct DirsCommand {
 
 impl builtins::Command for DirsCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/dot.rs
+++ b/brush-builtins/src/dot.rs
@@ -16,6 +16,7 @@ pub(crate) struct DotCommand {
 
 impl builtins::Command for DotCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/dot.rs
+++ b/brush-builtins/src/dot.rs
@@ -15,6 +15,7 @@ pub(crate) struct DotCommand {
 }
 
 impl builtins::Command for DotCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/echo.rs
+++ b/brush-builtins/src/echo.rs
@@ -25,6 +25,7 @@ pub(crate) struct EchoCommand {
 }
 
 impl builtins::Command for EchoCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     /// Override the default [`builtins::Command::new`] function to handle clap's limitation related

--- a/brush-builtins/src/echo.rs
+++ b/brush-builtins/src/echo.rs
@@ -26,6 +26,7 @@ pub(crate) struct EchoCommand {
 
 impl builtins::Command for EchoCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     /// Override the default [`builtins::Command::new`] function to handle clap's limitation related

--- a/brush-builtins/src/enable.rs
+++ b/brush-builtins/src/enable.rs
@@ -38,6 +38,7 @@ pub(crate) struct EnableCommand {
 }
 
 impl builtins::Command for EnableCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/enable.rs
+++ b/brush-builtins/src/enable.rs
@@ -39,6 +39,7 @@ pub(crate) struct EnableCommand {
 
 impl builtins::Command for EnableCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/eval.rs
+++ b/brush-builtins/src/eval.rs
@@ -11,6 +11,7 @@ pub(crate) struct EvalCommand {
 
 impl builtins::Command for EvalCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/eval.rs
+++ b/brush-builtins/src/eval.rs
@@ -10,6 +10,7 @@ pub(crate) struct EvalCommand {
 }
 
 impl builtins::Command for EvalCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/exec.rs
+++ b/brush-builtins/src/exec.rs
@@ -24,6 +24,7 @@ pub(crate) struct ExecCommand {
 }
 
 impl builtins::Command for ExecCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/exec.rs
+++ b/brush-builtins/src/exec.rs
@@ -25,6 +25,7 @@ pub(crate) struct ExecCommand {
 
 impl builtins::Command for ExecCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/exit.rs
+++ b/brush-builtins/src/exit.rs
@@ -12,6 +12,7 @@ pub(crate) struct ExitCommand {
 
 impl builtins::Command for ExitCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/exit.rs
+++ b/brush-builtins/src/exit.rs
@@ -11,6 +11,7 @@ pub(crate) struct ExitCommand {
 }
 
 impl builtins::Command for ExitCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/export.rs
+++ b/brush-builtins/src/export.rs
@@ -39,6 +39,7 @@ impl builtins::DeclarationCommand for ExportCommand {
 }
 
 impl builtins::Command for ExportCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/export.rs
+++ b/brush-builtins/src/export.rs
@@ -40,6 +40,7 @@ impl builtins::DeclarationCommand for ExportCommand {
 
 impl builtins::Command for ExportCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/factory.rs
+++ b/brush-builtins/src/factory.rs
@@ -1,10 +1,7 @@
-use std::collections::HashMap;
+use brush_core::builtins::{builtin, decl_builtin, raw_arg_builtin, simple_builtin};
 
 #[allow(clippy::wildcard_imports)]
 use super::*;
-
-#[allow(unused_imports, reason = "not all builtins are used in all configs")]
-use brush_core::builtins::{self, builtin, decl_builtin, raw_arg_builtin, simple_builtin};
 
 /// Identifies well-known sets of builtins.
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -15,17 +12,17 @@ pub enum BuiltinSet {
     BashMode,
 }
 
-/// Returns the default set of built-in commands.
+/// Registers the default set of built-in commands on the given shell.
 ///
 /// # Arguments
 ///
-/// * `set` - The set of built-ins to return.
+/// * `shell` - The shell to register builtins on.
+/// * `set` - The set of built-ins to register.
 #[allow(clippy::too_many_lines)]
-pub fn default_builtins<SE: brush_core::ShellExtensions>(
+pub fn register_default_builtins<SE: brush_core::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
     set: BuiltinSet,
-) -> HashMap<String, builtins::Registration<SE>> {
-    let mut m = HashMap::<String, builtins::Registration<SE>>::new();
-
+) {
     //
     // POSIX special builtins
     //
@@ -34,196 +31,155 @@ pub fn default_builtins<SE: brush_core::ShellExtensions>(
     //
 
     #[cfg(feature = "builtin.break")]
-    m.insert(
-        "break".into(),
-        builtin::<break_::BreakCommand, SE>().special(),
-    );
+    shell.register_builtin("break", builtin::<break_::BreakCommand, SE>().special());
     #[cfg(feature = "builtin.colon")]
-    m.insert(
-        ":".into(),
-        simple_builtin::<colon::ColonCommand, SE>().special(),
-    );
+    shell.register_builtin(":", simple_builtin::<colon::ColonCommand, SE>().special());
     #[cfg(feature = "builtin.continue")]
-    m.insert(
-        "continue".into(),
+    shell.register_builtin(
+        "continue",
         builtin::<continue_::ContinueCommand, SE>().special(),
     );
     #[cfg(feature = "builtin.dot")]
-    m.insert(".".into(), builtin::<dot::DotCommand, SE>().special());
+    shell.register_builtin(".", builtin::<dot::DotCommand, SE>().special());
     #[cfg(feature = "builtin.eval")]
-    m.insert("eval".into(), builtin::<eval::EvalCommand, SE>().special());
+    shell.register_builtin("eval", builtin::<eval::EvalCommand, SE>().special());
     #[cfg(all(feature = "builtin.exec", unix))]
-    m.insert("exec".into(), builtin::<exec::ExecCommand, SE>().special());
+    shell.register_builtin("exec", builtin::<exec::ExecCommand, SE>().special());
     #[cfg(feature = "builtin.exit")]
-    m.insert("exit".into(), builtin::<exit::ExitCommand, SE>().special());
+    shell.register_builtin("exit", builtin::<exit::ExitCommand, SE>().special());
     #[cfg(feature = "builtin.export")]
-    m.insert(
-        "export".into(),
+    shell.register_builtin(
+        "export",
         decl_builtin::<export::ExportCommand, SE>().special(),
     );
     #[cfg(feature = "builtin.return")]
-    m.insert(
-        "return".into(),
-        builtin::<return_::ReturnCommand, SE>().special(),
-    );
+    shell.register_builtin("return", builtin::<return_::ReturnCommand, SE>().special());
     #[cfg(feature = "builtin.set")]
-    m.insert("set".into(), builtin::<set::SetCommand, SE>().special());
+    shell.register_builtin("set", builtin::<set::SetCommand, SE>().special());
     #[cfg(feature = "builtin.shift")]
-    m.insert(
-        "shift".into(),
-        builtin::<shift::ShiftCommand, SE>().special(),
-    );
+    shell.register_builtin("shift", builtin::<shift::ShiftCommand, SE>().special());
     #[cfg(feature = "builtin.trap")]
-    m.insert("trap".into(), builtin::<trap::TrapCommand, SE>().special());
+    shell.register_builtin("trap", builtin::<trap::TrapCommand, SE>().special());
     #[cfg(feature = "builtin.unset")]
-    m.insert(
-        "unset".into(),
-        builtin::<unset::UnsetCommand, SE>().special(),
-    );
+    shell.register_builtin("unset", builtin::<unset::UnsetCommand, SE>().special());
 
     #[cfg(feature = "builtin.declare")]
-    m.insert(
-        "readonly".into(),
+    shell.register_builtin(
+        "readonly",
         decl_builtin::<declare::DeclareCommand, SE>().special(),
     );
     #[cfg(feature = "builtin.times")]
-    m.insert(
-        "times".into(),
-        builtin::<times::TimesCommand, SE>().special(),
-    );
+    shell.register_builtin("times", builtin::<times::TimesCommand, SE>().special());
 
     //
     // Non-special builtins
     //
 
     #[cfg(feature = "builtin.alias")]
-    m.insert("alias".into(), builtin::<alias::AliasCommand, SE>()); // TODO(alias): should be exec_declaration_builtin
+    shell.register_builtin("alias", builtin::<alias::AliasCommand, SE>()); // TODO(alias): should be exec_declaration_builtin
     #[cfg(feature = "builtin.bg")]
-    m.insert("bg".into(), builtin::<bg::BgCommand, SE>());
+    shell.register_builtin("bg", builtin::<bg::BgCommand, SE>());
     #[cfg(feature = "builtin.cd")]
-    m.insert("cd".into(), builtin::<cd::CdCommand, SE>());
+    shell.register_builtin("cd", builtin::<cd::CdCommand, SE>());
     #[cfg(feature = "builtin.command")]
-    m.insert("command".into(), builtin::<command::CommandCommand, SE>());
+    shell.register_builtin("command", builtin::<command::CommandCommand, SE>());
     #[cfg(feature = "builtin.false")]
-    m.insert("false".into(), simple_builtin::<false_::FalseCommand, SE>());
+    shell.register_builtin("false", simple_builtin::<false_::FalseCommand, SE>());
     #[cfg(feature = "builtin.fg")]
-    m.insert("fg".into(), builtin::<fg::FgCommand, SE>());
+    shell.register_builtin("fg", builtin::<fg::FgCommand, SE>());
     #[cfg(feature = "builtin.getopts")]
-    m.insert("getopts".into(), builtin::<getopts::GetOptsCommand, SE>());
+    shell.register_builtin("getopts", builtin::<getopts::GetOptsCommand, SE>());
     #[cfg(feature = "builtin.hash")]
-    m.insert("hash".into(), builtin::<hash::HashCommand, SE>());
+    shell.register_builtin("hash", builtin::<hash::HashCommand, SE>());
     #[cfg(feature = "builtin.help")]
-    m.insert("help".into(), builtin::<help::HelpCommand, SE>());
+    shell.register_builtin("help", builtin::<help::HelpCommand, SE>());
     #[cfg(feature = "builtin.jobs")]
-    m.insert("jobs".into(), builtin::<jobs::JobsCommand, SE>());
+    shell.register_builtin("jobs", builtin::<jobs::JobsCommand, SE>());
     #[cfg(all(feature = "builtin.kill", unix))]
-    m.insert("kill".into(), builtin::<kill::KillCommand, SE>());
+    shell.register_builtin("kill", builtin::<kill::KillCommand, SE>());
     #[cfg(feature = "builtin.declare")]
-    m.insert(
-        "local".into(),
-        decl_builtin::<declare::DeclareCommand, SE>(),
-    );
+    shell.register_builtin("local", decl_builtin::<declare::DeclareCommand, SE>());
     #[cfg(feature = "builtin.pwd")]
-    m.insert("pwd".into(), builtin::<pwd::PwdCommand, SE>());
+    shell.register_builtin("pwd", builtin::<pwd::PwdCommand, SE>());
     #[cfg(feature = "builtin.read")]
-    m.insert("read".into(), builtin::<read::ReadCommand, SE>());
+    shell.register_builtin("read", builtin::<read::ReadCommand, SE>());
     #[cfg(feature = "builtin.true")]
-    m.insert("true".into(), simple_builtin::<true_::TrueCommand, SE>());
+    shell.register_builtin("true", simple_builtin::<true_::TrueCommand, SE>());
     #[cfg(feature = "builtin.type")]
-    m.insert("type".into(), builtin::<type_::TypeCommand, SE>());
+    shell.register_builtin("type", builtin::<type_::TypeCommand, SE>());
     #[cfg(all(feature = "builtin.ulimit", unix))]
-    m.insert("ulimit".into(), builtin::<ulimit::ULimitCommand, SE>());
+    shell.register_builtin("ulimit", builtin::<ulimit::ULimitCommand, SE>());
     #[cfg(all(feature = "builtin.umask", unix))]
-    m.insert("umask".into(), builtin::<umask::UmaskCommand, SE>());
+    shell.register_builtin("umask", builtin::<umask::UmaskCommand, SE>());
     #[cfg(feature = "builtin.unalias")]
-    m.insert("unalias".into(), builtin::<unalias::UnaliasCommand, SE>());
+    shell.register_builtin("unalias", builtin::<unalias::UnaliasCommand, SE>());
     #[cfg(feature = "builtin.wait")]
-    m.insert("wait".into(), builtin::<wait::WaitCommand, SE>());
+    shell.register_builtin("wait", builtin::<wait::WaitCommand, SE>());
 
     #[cfg(feature = "builtin.fc")]
-    m.insert("fc".into(), builtin::<fc::FcCommand, SE>());
+    shell.register_builtin("fc", builtin::<fc::FcCommand, SE>());
 
     if matches!(set, BuiltinSet::BashMode) {
         #[cfg(feature = "builtin.builtin")]
-        m.insert(
-            "builtin".into(),
-            raw_arg_builtin::<builtin_::BuiltinCommand, SE>(),
-        );
+        shell.register_builtin("builtin", raw_arg_builtin::<builtin_::BuiltinCommand, SE>());
         #[cfg(feature = "builtin.declare")]
-        m.insert(
-            "declare".into(),
-            decl_builtin::<declare::DeclareCommand, SE>(),
-        );
+        shell.register_builtin("declare", decl_builtin::<declare::DeclareCommand, SE>());
         #[cfg(feature = "builtin.echo")]
-        m.insert("echo".into(), builtin::<echo::EchoCommand, SE>());
+        shell.register_builtin("echo", builtin::<echo::EchoCommand, SE>());
         #[cfg(feature = "builtin.enable")]
-        m.insert("enable".into(), builtin::<enable::EnableCommand, SE>());
+        shell.register_builtin("enable", builtin::<enable::EnableCommand, SE>());
         #[cfg(feature = "builtin.let")]
-        m.insert("let".into(), builtin::<let_::LetCommand, SE>());
+        shell.register_builtin("let", builtin::<let_::LetCommand, SE>());
         #[cfg(feature = "builtin.mapfile")]
-        m.insert("mapfile".into(), builtin::<mapfile::MapFileCommand, SE>());
+        shell.register_builtin("mapfile", builtin::<mapfile::MapFileCommand, SE>());
         #[cfg(feature = "builtin.mapfile")]
-        m.insert("readarray".into(), builtin::<mapfile::MapFileCommand, SE>());
+        shell.register_builtin("readarray", builtin::<mapfile::MapFileCommand, SE>());
         #[cfg(all(feature = "builtin.printf", any(unix, windows)))]
-        m.insert("printf".into(), builtin::<printf::PrintfCommand, SE>());
+        shell.register_builtin("printf", builtin::<printf::PrintfCommand, SE>());
         #[cfg(feature = "builtin.shopt")]
-        m.insert("shopt".into(), builtin::<shopt::ShoptCommand, SE>());
+        shell.register_builtin("shopt", builtin::<shopt::ShoptCommand, SE>());
         #[cfg(feature = "builtin.dot")]
-        m.insert("source".into(), builtin::<dot::DotCommand, SE>().special());
+        shell.register_builtin("source", builtin::<dot::DotCommand, SE>().special());
         #[cfg(all(feature = "builtin.suspend", unix))]
-        m.insert("suspend".into(), builtin::<suspend::SuspendCommand, SE>());
+        shell.register_builtin("suspend", builtin::<suspend::SuspendCommand, SE>());
         #[cfg(feature = "builtin.test")]
-        m.insert("test".into(), builtin::<test::TestCommand, SE>());
+        shell.register_builtin("test", builtin::<test::TestCommand, SE>());
         #[cfg(feature = "builtin.test")]
-        m.insert("[".into(), builtin::<test::TestCommand, SE>());
+        shell.register_builtin("[", builtin::<test::TestCommand, SE>());
         #[cfg(feature = "builtin.declare")]
-        m.insert(
-            "typeset".into(),
-            decl_builtin::<declare::DeclareCommand, SE>(),
-        );
+        shell.register_builtin("typeset", decl_builtin::<declare::DeclareCommand, SE>());
 
         // Completion builtins
         #[cfg(feature = "builtin.complete")]
-        m.insert(
-            "complete".into(),
-            builtin::<complete::CompleteCommand, SE>(),
-        );
+        shell.register_builtin("complete", builtin::<complete::CompleteCommand, SE>());
         #[cfg(feature = "builtin.compgen")]
-        m.insert("compgen".into(), builtin::<complete::CompGenCommand, SE>());
+        shell.register_builtin("compgen", builtin::<complete::CompGenCommand, SE>());
         #[cfg(feature = "builtin.compopt")]
-        m.insert("compopt".into(), builtin::<complete::CompOptCommand, SE>());
+        shell.register_builtin("compopt", builtin::<complete::CompOptCommand, SE>());
 
         // Dir stack builtins
         #[cfg(feature = "builtin.dirs")]
-        m.insert("dirs".into(), builtin::<dirs::DirsCommand, SE>());
+        shell.register_builtin("dirs", builtin::<dirs::DirsCommand, SE>());
         #[cfg(feature = "builtin.popd")]
-        m.insert("popd".into(), builtin::<popd::PopdCommand, SE>());
+        shell.register_builtin("popd", builtin::<popd::PopdCommand, SE>());
         #[cfg(feature = "builtin.pushd")]
-        m.insert("pushd".into(), builtin::<pushd::PushdCommand, SE>());
+        shell.register_builtin("pushd", builtin::<pushd::PushdCommand, SE>());
 
         // Input configuration builtins
         #[cfg(feature = "builtin.bind")]
-        m.insert("bind".into(), builtin::<bind::BindCommand, SE>());
+        shell.register_builtin("bind", builtin::<bind::BindCommand, SE>());
 
         // History
         #[cfg(feature = "builtin.history")]
-        m.insert("history".into(), builtin::<history::HistoryCommand, SE>());
+        shell.register_builtin("history", builtin::<history::HistoryCommand, SE>());
 
         #[cfg(feature = "builtin.caller")]
-        m.insert("caller".into(), builtin::<caller::CallerCommand, SE>());
+        shell.register_builtin("caller", builtin::<caller::CallerCommand, SE>());
 
         // TODO(disown): implement disown builtin
-        m.insert(
-            "disown".into(),
-            builtin::<unimp::UnimplementedCommand, SE>(),
-        );
+        shell.register_builtin("disown", builtin::<unimp::UnimplementedCommand, SE>());
 
         // TODO(logout): implement logout builtin
-        m.insert(
-            "logout".into(),
-            builtin::<unimp::UnimplementedCommand, SE>(),
-        );
+        shell.register_builtin("logout", builtin::<unimp::UnimplementedCommand, SE>());
     }
-
-    m
 }

--- a/brush-builtins/src/fc.rs
+++ b/brush-builtins/src/fc.rs
@@ -35,6 +35,7 @@ pub(crate) struct FcCommand {
 }
 
 impl builtins::Command for FcCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/fc.rs
+++ b/brush-builtins/src/fc.rs
@@ -36,6 +36,7 @@ pub(crate) struct FcCommand {
 
 impl builtins::Command for FcCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/fg.rs
+++ b/brush-builtins/src/fg.rs
@@ -11,6 +11,7 @@ pub(crate) struct FgCommand {
 }
 
 impl builtins::Command for FgCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/fg.rs
+++ b/brush-builtins/src/fg.rs
@@ -12,6 +12,7 @@ pub(crate) struct FgCommand {
 
 impl builtins::Command for FgCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/getopts.rs
+++ b/brush-builtins/src/getopts.rs
@@ -2,7 +2,24 @@ use std::{collections::HashMap, io::Write};
 
 use clap::Parser;
 
-use brush_core::{ExecutionResult, builtins, env, variables};
+use brush_core::{ExecutionResult, builtins, variables};
+
+const DEFAULT_NEXT_CHAR_INDEX: usize = 1;
+
+#[derive(Clone, Debug)]
+pub(crate) struct GetOptsState {
+    next_char_index: usize,
+    last_optind: Option<i32>,
+}
+
+impl Default for GetOptsState {
+    fn default() -> Self {
+        Self {
+            next_char_index: DEFAULT_NEXT_CHAR_INDEX,
+            last_optind: None,
+        }
+    }
+}
 
 /// Parse command options.
 #[derive(Parser)]
@@ -18,36 +35,20 @@ pub(crate) struct GetOptsCommand {
     args: Vec<String>,
 }
 
-// We track cross-call state in special variables. They are hidden from enumeration
-// (e.g. `set`, `declare`) so they don't leak into scripts' environments.
-const VAR_GETOPTS_NEXT_CHAR_INDEX: &str = "__GETOPTS_NEXT_CHAR";
-const VAR_GETOPTS_LAST_OPTIND: &str = "__GETOPTS_LAST_OPTIND";
-const DEFAULT_NEXT_CHAR_INDEX: usize = 1;
-
 /// The result of processing one option from the argument list.
 struct GetOptsResult {
-    /// The value to assign to the target variable (the option char, `?`, or `:`).
     variable_value: String,
-    /// The value for OPTARG, if any (option's argument or, on error, the offending char).
     optarg: Option<String>,
-    /// The new value for OPTIND after this call.
     optind: usize,
-    /// Exit code: success (0) if an option was found, general error (1) when done.
     exit_code: ExecutionResult,
 }
 
 /// Parsed representation of the optstring (e.g., `":a:bc"`).
 struct OptionSpec {
-    /// Maps each option character to whether it requires an argument.
     defs: HashMap<char, bool>,
-    /// True when the optstring has a leading `:`, suppressing error messages
-    /// and reporting errors via `?`/`:` in the variable and OPTARG instead.
     silent_errors: bool,
 }
 
-/// Parses the optstring into an [`OptionSpec`]. A leading `:` enables silent error
-/// mode. Each letter defines an option; a `:` immediately after a letter means it
-/// takes an argument. Duplicate letters are ignored (first definition wins).
 fn parse_option_spec(spec: &str) -> OptionSpec {
     let mut defs = HashMap::<char, bool>::new();
     let mut silent_errors = false;
@@ -58,7 +59,6 @@ fn parse_option_spec(spec: &str) -> OptionSpec {
             if let Some(last_char) = last_char {
                 defs.insert(last_char, true);
             } else if defs.is_empty() {
-                // First character is ':' — request silent error reporting.
                 silent_errors = true;
             }
             continue;
@@ -68,8 +68,6 @@ fn parse_option_spec(spec: &str) -> OptionSpec {
             e.insert(false);
             last_char = Some(c);
         } else {
-            // Duplicate option char; first definition wins.
-            // Clear last_char so a trailing colon doesn't modify the first definition.
             last_char = None;
         }
     }
@@ -81,11 +79,9 @@ fn parse_option_spec(spec: &str) -> OptionSpec {
 }
 
 impl builtins::Command for GetOptsCommand {
+    type State = GetOptsState;
     type Error = brush_core::Error;
 
-    /// Override the default [`builtins::Command::new`] function to handle clap's limitation related
-    /// to `--`. See [`builtins::parse_known`] for more information
-    /// TODO(command): we can safely remove this after the issue is resolved
     fn new<I>(args: I) -> Result<Self, clap::Error>
     where
         I: IntoIterator<Item = String>,
@@ -101,8 +97,7 @@ impl builtins::Command for GetOptsCommand {
         &self,
         mut context: brush_core::ExecutionContext<'_, SE>,
     ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        // Validate the target variable name.
-        if !env::valid_variable_name(&self.variable_name) {
+        if !brush_core::env::valid_variable_name(&self.variable_name) {
             writeln!(
                 context.stderr(),
                 "{}: `{}': not a valid identifier",
@@ -114,31 +109,24 @@ impl builtins::Command for GetOptsCommand {
 
         let spec = parse_option_spec(&self.options_string);
 
-        // If unset or non-numeric, assume OPTIND is 1.
         let next_index_signed = context
             .shell
             .env_str("OPTIND")
             .and_then(|s| brush_core::int_utils::parse::<i32>(s.as_ref(), 10).ok())
             .unwrap_or(1);
 
-        // Detect external OPTIND modifications (e.g., `OPTIND=1` to restart
-        // parsing). If the current OPTIND differs from what we last set, clear
-        // the internal char index so we don't resume mid-arg.
-        let last_optind = context
-            .shell
-            .env_str(VAR_GETOPTS_LAST_OPTIND)
-            .and_then(|s| s.parse::<i32>().ok());
-        if last_optind != Some(next_index_signed) {
-            context.shell.env_mut().unset(VAR_GETOPTS_NEXT_CHAR_INDEX)?;
-        }
-
-        #[allow(clippy::cast_sign_loss)] // .max(1) guarantees positive
+        #[allow(clippy::cast_sign_loss)]
         let next_index = next_index_signed.max(1) as usize;
 
-        // Select the arguments to parse. If none were explicitly provided, we
-        // default to using the shell's current positional parameters.
-        // Clone positional params to avoid borrowing context immutably while we
-        // also need it mutably in parse_next_option.
+        let mut next_char_index = {
+            let state = self.state(&context)?;
+            if state.last_optind == Some(next_index_signed) {
+                state.next_char_index
+            } else {
+                DEFAULT_NEXT_CHAR_INDEX
+            }
+        };
+
         let owned_args;
         let args_to_parse = if !self.args.is_empty() {
             &self.args
@@ -147,29 +135,37 @@ impl builtins::Command for GetOptsCommand {
             &owned_args
         };
 
-        let result = parse_next_option(&mut context, &spec, args_to_parse, next_index)?;
+        let result = parse_next_option(
+            &context,
+            &spec,
+            args_to_parse,
+            next_index,
+            &mut next_char_index,
+        )?;
 
-        update_variables(&mut context, &self.variable_name, result)
+        update_variables(&mut context, &self.variable_name, &result)?;
+
+        {
+            let state = self.state_mut(&mut context)?;
+            state.next_char_index = next_char_index;
+            state.last_optind = Some(i32::try_from(result.optind).unwrap_or(i32::MAX));
+        }
+
+        Ok(result.exit_code)
     }
 }
 
-/// Extracts the next option from `args_to_parse` starting at 1-based position
-/// `next_index`. Handles combined flags (e.g., `-abc`), option arguments (both
-/// `-pVALUE` and `-p VALUE` forms), and error reporting for unknown options or
-/// missing arguments. Tracks position within combined flags via the
-/// `__GETOPTS_NEXT_CHAR` shell variable.
 fn parse_next_option<SE: brush_core::ShellExtensions>(
-    context: &mut brush_core::ExecutionContext<'_, SE>,
+    context: &brush_core::ExecutionContext<'_, SE>,
     spec: &OptionSpec,
     args_to_parse: &[String],
     mut next_index: usize,
+    next_char_index: &mut usize,
 ) -> Result<GetOptsResult, brush_core::Error> {
-    // See if there are any args left to parse.
     if next_index > args_to_parse.len() {
         return Ok(GetOptsResult {
             variable_value: String::from("?"),
             optarg: None,
-            // Normalize OPTIND to one past the last argument.
             optind: args_to_parse.len() + 1,
             exit_code: ExecutionResult::general_error(),
         });
@@ -177,9 +173,7 @@ fn parse_next_option<SE: brush_core::ShellExtensions>(
 
     let arg = args_to_parse[next_index - 1].as_str();
 
-    // See if this is an option.
     if !arg.starts_with('-') || arg == "--" || arg == "-" {
-        // Not an option. If it was "--", skip past it.
         return Ok(GetOptsResult {
             variable_value: String::from("?"),
             optarg: None,
@@ -192,23 +186,12 @@ fn parse_next_option<SE: brush_core::ShellExtensions>(
         });
     }
 
-    // Figure out how far into this option we are.
-    let mut next_char_index = context
-        .shell
-        .env_str(VAR_GETOPTS_NEXT_CHAR_INDEX)
-        .map_or(DEFAULT_NEXT_CHAR_INDEX, |s| {
-            s.parse().unwrap_or(DEFAULT_NEXT_CHAR_INDEX)
-        });
-
-    // Find the char. If the index is stale (exceeds this arg's length),
-    // reset to the default index, mirroring bash behavior.
-    let mut c = arg.chars().nth(next_char_index);
+    let mut c = arg.chars().nth(*next_char_index);
     if c.is_none() {
-        next_char_index = DEFAULT_NEXT_CHAR_INDEX;
-        c = arg.chars().nth(next_char_index);
+        *next_char_index = DEFAULT_NEXT_CHAR_INDEX;
+        c = arg.chars().nth(*next_char_index);
     }
     let Some(c) = c else {
-        // Arg is too short even at default index.
         return Ok(GetOptsResult {
             variable_value: String::from("?"),
             optarg: None,
@@ -218,51 +201,43 @@ fn parse_next_option<SE: brush_core::ShellExtensions>(
     };
 
     let arg_char_count = arg.chars().count();
-    let mut is_last_char_in_option = next_char_index == arg_char_count - 1;
+    let mut is_last_char_in_option = *next_char_index == arg_char_count - 1;
 
     let mut variable_value;
     let optarg;
 
-    // Look up the char in the option spec.
     if let Some(takes_arg) = spec.defs.get(&c) {
         variable_value = String::from(c);
 
         if *takes_arg {
-            (variable_value, optarg, is_last_char_in_option, next_index) = resolve_option_argument(
+            let (vv, oa, last, ni) = resolve_option_argument(
                 context,
                 spec,
                 c,
                 arg,
                 args_to_parse,
-                next_char_index,
+                *next_char_index,
                 is_last_char_in_option,
                 next_index,
             )?;
+            variable_value = vv;
+            optarg = oa;
+            is_last_char_in_option = last;
+            next_index = ni;
         } else {
             optarg = None;
         }
     } else {
-        (variable_value, optarg) = report_unknown_option(context, spec, c)?;
+        let (vv, oa) = report_unknown_option(context, spec, c)?;
+        variable_value = vv;
+        optarg = oa;
     }
 
     let optind = if is_last_char_in_option {
-        // We're done with this argument, so unset the internal char index variable
-        // and request an update to OPTIND.
-        context.shell.env_mut().unset(VAR_GETOPTS_NEXT_CHAR_INDEX)?;
+        *next_char_index = DEFAULT_NEXT_CHAR_INDEX;
         next_index + 1
     } else {
-        // We have more to go in this argument, so update the internal char index
-        // and request that OPTIND not be updated.
-        context.shell.env_mut().update_or_add(
-            VAR_GETOPTS_NEXT_CHAR_INDEX,
-            variables::ShellValueLiteral::Scalar((next_char_index + 1).to_string()),
-            |v| {
-                v.hide_from_enumeration();
-                Ok(())
-            },
-            brush_core::env::EnvironmentLookup::Anywhere,
-            brush_core::env::EnvironmentScope::Global,
-        )?;
+        *next_char_index += 1;
         next_index
     };
 
@@ -274,8 +249,6 @@ fn parse_next_option<SE: brush_core::ShellExtensions>(
     })
 }
 
-/// Resolves the argument for an option that takes a value. Returns the updated
-/// `(variable_value, optarg, is_last_char, next_index)` tuple.
 #[allow(clippy::too_many_arguments)]
 fn resolve_option_argument<SE: brush_core::ShellExtensions>(
     context: &brush_core::ExecutionContext<'_, SE>,
@@ -287,11 +260,8 @@ fn resolve_option_argument<SE: brush_core::ShellExtensions>(
     is_last_char_in_option: bool,
     mut next_index: usize,
 ) -> Result<(String, Option<String>, bool, usize), brush_core::Error> {
-    // If this is the last character in the token, the argument value comes from
-    // the next token. Otherwise, the remainder of the current token is the value.
     if is_last_char_in_option {
         if next_index >= args_to_parse.len() {
-            // Missing required argument.
             let (variable_value, optarg) = if spec.silent_errors {
                 (String::from(":"), Some(String::from(c)))
             } else {
@@ -319,7 +289,6 @@ fn resolve_option_argument<SE: brush_core::ShellExtensions>(
     }
 }
 
-/// Handles an unknown option character, reporting an error if appropriate.
 fn report_unknown_option<SE: brush_core::ShellExtensions>(
     context: &brush_core::ExecutionContext<'_, SE>,
     spec: &OptionSpec,
@@ -338,27 +307,23 @@ fn report_unknown_option<SE: brush_core::ShellExtensions>(
     Ok((String::from("?"), optarg))
 }
 
-/// Writes the parsing result back into shell variables: the target variable,
-/// OPTARG, OPTIND, and the internal `__GETOPTS_LAST_OPTIND` tracker.
 fn update_variables<SE: brush_core::ShellExtensions>(
     context: &mut brush_core::ExecutionContext<'_, SE>,
     variable_name: &str,
-    result: GetOptsResult,
-) -> Result<ExecutionResult, brush_core::Error> {
-    // Update variable value.
+    result: &GetOptsResult,
+) -> Result<(), brush_core::Error> {
     context.shell.env_mut().update_or_add(
         variable_name,
-        variables::ShellValueLiteral::Scalar(result.variable_value),
+        variables::ShellValueLiteral::Scalar(result.variable_value.clone()),
         |_| Ok(()),
         brush_core::env::EnvironmentLookup::Anywhere,
         brush_core::env::EnvironmentScope::Global,
     )?;
 
-    // Update OPTARG
-    if let Some(optarg) = result.optarg {
+    if let Some(optarg) = &result.optarg {
         context.shell.env_mut().update_or_add(
             "OPTARG",
-            variables::ShellValueLiteral::Scalar(optarg),
+            variables::ShellValueLiteral::Scalar(optarg.clone()),
             |_| Ok(()),
             brush_core::env::EnvironmentLookup::Anywhere,
             brush_core::env::EnvironmentScope::Global,
@@ -367,31 +332,18 @@ fn update_variables<SE: brush_core::ShellExtensions>(
         context.shell.env_mut().unset("OPTARG")?;
     }
 
-    // Update OPTIND and record it so we can detect external modifications.
     let optind_str = result.optind.to_string();
     context.shell.env_mut().update_or_add(
         "OPTIND",
-        variables::ShellValueLiteral::Scalar(optind_str.clone()),
+        variables::ShellValueLiteral::Scalar(optind_str),
         |_| Ok(()),
         brush_core::env::EnvironmentLookup::Anywhere,
         brush_core::env::EnvironmentScope::Global,
     )?;
-    context.shell.env_mut().update_or_add(
-        VAR_GETOPTS_LAST_OPTIND,
-        variables::ShellValueLiteral::Scalar(optind_str),
-        |v| {
-            v.hide_from_enumeration();
-            Ok(())
-        },
-        brush_core::env::EnvironmentLookup::Anywhere,
-        brush_core::env::EnvironmentScope::Global,
-    )?;
 
-    Ok(result.exit_code)
+    Ok(())
 }
 
-/// Returns whether OPTERR is enabled (i.e., getopts should print error messages).
-/// OPTERR defaults to 1; any nonzero value means errors are enabled.
 fn is_opterr_enabled<SE: brush_core::ShellExtensions>(
     context: &brush_core::ExecutionContext<'_, SE>,
 ) -> bool {

--- a/brush-builtins/src/getopts.rs
+++ b/brush-builtins/src/getopts.rs
@@ -80,6 +80,7 @@ fn parse_option_spec(spec: &str) -> OptionSpec {
 
 impl builtins::Command for GetOptsCommand {
     type State = GetOptsState;
+    type SharedState = ();
     type Error = brush_core::Error;
 
     fn new<I>(args: I) -> Result<Self, clap::Error>

--- a/brush-builtins/src/hash.rs
+++ b/brush-builtins/src/hash.rs
@@ -31,6 +31,7 @@ pub(crate) struct HashCommand {
 
 impl builtins::Command for HashCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/hash.rs
+++ b/brush-builtins/src/hash.rs
@@ -30,6 +30,7 @@ pub(crate) struct HashCommand {
 }
 
 impl builtins::Command for HashCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/help.rs
+++ b/brush-builtins/src/help.rs
@@ -23,6 +23,7 @@ pub(crate) struct HelpCommand {
 }
 
 impl builtins::Command for HelpCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/help.rs
+++ b/brush-builtins/src/help.rs
@@ -24,6 +24,7 @@ pub(crate) struct HelpCommand {
 
 impl builtins::Command for HelpCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -55,6 +55,7 @@ struct HistoryConfig {
 
 impl builtins::Command for HistoryCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/history.rs
+++ b/brush-builtins/src/history.rs
@@ -54,6 +54,7 @@ struct HistoryConfig {
 }
 
 impl builtins::Command for HistoryCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/jobs.rs
+++ b/brush-builtins/src/jobs.rs
@@ -33,6 +33,7 @@ pub(crate) struct JobsCommand {
 
 impl builtins::Command for JobsCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/jobs.rs
+++ b/brush-builtins/src/jobs.rs
@@ -32,6 +32,7 @@ pub(crate) struct JobsCommand {
 }
 
 impl builtins::Command for JobsCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/kill.rs
+++ b/brush-builtins/src/kill.rs
@@ -28,6 +28,7 @@ pub(crate) struct KillCommand {
 
 impl builtins::Command for KillCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/kill.rs
+++ b/brush-builtins/src/kill.rs
@@ -27,6 +27,7 @@ pub(crate) struct KillCommand {
 }
 
 impl builtins::Command for KillCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/let_.rs
+++ b/brush-builtins/src/let_.rs
@@ -12,6 +12,7 @@ pub(crate) struct LetCommand {
 }
 
 impl builtins::Command for LetCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/let_.rs
+++ b/brush-builtins/src/let_.rs
@@ -13,6 +13,7 @@ pub(crate) struct LetCommand {
 
 impl builtins::Command for LetCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/lib.rs
+++ b/brush-builtins/src/lib.rs
@@ -111,8 +111,8 @@ mod builder;
 mod factory;
 mod unimp;
 
-pub use builder::ShellBuilderExt;
-pub use factory::{BuiltinSet, default_builtins};
+pub use builder::ShellExt;
+pub use factory::{BuiltinSet, register_default_builtins};
 
 /// Macro to define a struct that represents a shell built-in flag argument that can be
 /// enabled or disabled by specifying an option with a leading '+' or '-' character.

--- a/brush-builtins/src/mapfile.rs
+++ b/brush-builtins/src/mapfile.rs
@@ -45,6 +45,7 @@ pub(crate) struct MapFileCommand {
 }
 
 impl builtins::Command for MapFileCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/mapfile.rs
+++ b/brush-builtins/src/mapfile.rs
@@ -46,6 +46,7 @@ pub(crate) struct MapFileCommand {
 
 impl builtins::Command for MapFileCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/popd.rs
+++ b/brush-builtins/src/popd.rs
@@ -14,6 +14,7 @@ pub(crate) struct PopdCommand {
 
 impl builtins::Command for PopdCommand {
     type State = ();
+    type SharedState = ();
     type Error = crate::dirs::DirError;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/popd.rs
+++ b/brush-builtins/src/popd.rs
@@ -13,6 +13,7 @@ pub(crate) struct PopdCommand {
 }
 
 impl builtins::Command for PopdCommand {
+    type State = ();
     type Error = crate::dirs::DirError;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/printf.rs
+++ b/brush-builtins/src/printf.rs
@@ -24,6 +24,7 @@ pub(crate) struct PrintfCommand {
 
 impl builtins::Command for PrintfCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/printf.rs
+++ b/brush-builtins/src/printf.rs
@@ -23,6 +23,7 @@ pub(crate) struct PrintfCommand {
 }
 
 impl builtins::Command for PrintfCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/pushd.rs
+++ b/brush-builtins/src/pushd.rs
@@ -17,6 +17,7 @@ pub(crate) struct PushdCommand {
 
 impl builtins::Command for PushdCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/pushd.rs
+++ b/brush-builtins/src/pushd.rs
@@ -16,6 +16,7 @@ pub(crate) struct PushdCommand {
 }
 
 impl builtins::Command for PushdCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/pwd.rs
+++ b/brush-builtins/src/pwd.rs
@@ -16,6 +16,7 @@ pub(crate) struct PwdCommand {
 
 impl builtins::Command for PwdCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/pwd.rs
+++ b/brush-builtins/src/pwd.rs
@@ -15,6 +15,7 @@ pub(crate) struct PwdCommand {
 }
 
 impl builtins::Command for PwdCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -77,6 +77,7 @@ pub(crate) struct ReadCommand {
 }
 
 impl builtins::Command for ReadCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -78,6 +78,7 @@ pub(crate) struct ReadCommand {
 
 impl builtins::Command for ReadCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/return_.rs
+++ b/brush-builtins/src/return_.rs
@@ -12,6 +12,7 @@ pub(crate) struct ReturnCommand {
 
 impl builtins::Command for ReturnCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/return_.rs
+++ b/brush-builtins/src/return_.rs
@@ -11,6 +11,7 @@ pub(crate) struct ReturnCommand {
 }
 
 impl builtins::Command for ReturnCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/set.rs
+++ b/brush-builtins/src/set.rs
@@ -186,6 +186,7 @@ impl builtins::Command for SetCommand {
     }
 
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     #[expect(clippy::too_many_lines)]

--- a/brush-builtins/src/set.rs
+++ b/brush-builtins/src/set.rs
@@ -185,6 +185,7 @@ impl builtins::Command for SetCommand {
         Ok(this)
     }
 
+    type State = ();
     type Error = brush_core::Error;
 
     #[expect(clippy::too_many_lines)]

--- a/brush-builtins/src/shift.rs
+++ b/brush-builtins/src/shift.rs
@@ -10,6 +10,7 @@ pub(crate) struct ShiftCommand {
 }
 
 impl builtins::Command for ShiftCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/shift.rs
+++ b/brush-builtins/src/shift.rs
@@ -11,6 +11,7 @@ pub(crate) struct ShiftCommand {
 
 impl builtins::Command for ShiftCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/shopt.rs
+++ b/brush-builtins/src/shopt.rs
@@ -32,6 +32,7 @@ pub(crate) struct ShoptCommand {
 }
 
 impl builtins::Command for ShoptCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     #[allow(clippy::too_many_lines)]

--- a/brush-builtins/src/shopt.rs
+++ b/brush-builtins/src/shopt.rs
@@ -33,6 +33,7 @@ pub(crate) struct ShoptCommand {
 
 impl builtins::Command for ShoptCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     #[allow(clippy::too_many_lines)]

--- a/brush-builtins/src/suspend.rs
+++ b/brush-builtins/src/suspend.rs
@@ -12,6 +12,7 @@ pub(crate) struct SuspendCommand {
 }
 
 impl builtins::Command for SuspendCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/suspend.rs
+++ b/brush-builtins/src/suspend.rs
@@ -13,6 +13,7 @@ pub(crate) struct SuspendCommand {
 
 impl builtins::Command for SuspendCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/test.rs
+++ b/brush-builtins/src/test.rs
@@ -14,6 +14,7 @@ pub(crate) struct TestCommand {
 }
 
 impl builtins::Command for TestCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     /// Override the default [`builtins::Command::new`] function to handle clap's limitation related

--- a/brush-builtins/src/test.rs
+++ b/brush-builtins/src/test.rs
@@ -15,6 +15,7 @@ pub(crate) struct TestCommand {
 
 impl builtins::Command for TestCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     /// Override the default [`builtins::Command::new`] function to handle clap's limitation related

--- a/brush-builtins/src/times.rs
+++ b/brush-builtins/src/times.rs
@@ -8,6 +8,7 @@ use brush_core::{ExecutionResult, builtins, timing};
 pub(crate) struct TimesCommand {}
 
 impl builtins::Command for TimesCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/times.rs
+++ b/brush-builtins/src/times.rs
@@ -9,6 +9,7 @@ pub(crate) struct TimesCommand {}
 
 impl builtins::Command for TimesCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/trap.rs
+++ b/brush-builtins/src/trap.rs
@@ -19,6 +19,7 @@ pub(crate) struct TrapCommand {
 }
 
 impl builtins::Command for TrapCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/trap.rs
+++ b/brush-builtins/src/trap.rs
@@ -20,6 +20,7 @@ pub(crate) struct TrapCommand {
 
 impl builtins::Command for TrapCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -43,6 +43,7 @@ enum ResolvedType<'a> {
 }
 
 impl builtins::Command for TypeCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -44,6 +44,7 @@ enum ResolvedType<'a> {
 
 impl builtins::Command for TypeCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/ulimit.rs
+++ b/brush-builtins/src/ulimit.rs
@@ -435,6 +435,7 @@ pub(crate) struct ULimitCommand {
 
 impl builtins::Command for ULimitCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/ulimit.rs
+++ b/brush-builtins/src/ulimit.rs
@@ -434,6 +434,7 @@ pub(crate) struct ULimitCommand {
 }
 
 impl builtins::Command for ULimitCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/umask.rs
+++ b/brush-builtins/src/umask.rs
@@ -21,6 +21,7 @@ pub(crate) struct UmaskCommand {
 }
 
 impl builtins::Command for UmaskCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/umask.rs
+++ b/brush-builtins/src/umask.rs
@@ -22,6 +22,7 @@ pub(crate) struct UmaskCommand {
 
 impl builtins::Command for UmaskCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/unalias.rs
+++ b/brush-builtins/src/unalias.rs
@@ -16,6 +16,7 @@ pub(crate) struct UnaliasCommand {
 
 impl builtins::Command for UnaliasCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/unalias.rs
+++ b/brush-builtins/src/unalias.rs
@@ -15,6 +15,7 @@ pub(crate) struct UnaliasCommand {
 }
 
 impl builtins::Command for UnaliasCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/unimp.rs
+++ b/brush-builtins/src/unimp.rs
@@ -14,6 +14,7 @@ pub(crate) struct UnimplementedCommand {
 
 impl builtins::Command for UnimplementedCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/unimp.rs
+++ b/brush-builtins/src/unimp.rs
@@ -13,6 +13,7 @@ pub(crate) struct UnimplementedCommand {
 }
 
 impl builtins::Command for UnimplementedCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/unset.rs
+++ b/brush-builtins/src/unset.rs
@@ -37,6 +37,7 @@ impl UnsetNameInterpretation {
 }
 
 impl builtins::Command for UnsetCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/unset.rs
+++ b/brush-builtins/src/unset.rs
@@ -38,6 +38,7 @@ impl UnsetNameInterpretation {
 
 impl builtins::Command for UnsetCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/wait.rs
+++ b/brush-builtins/src/wait.rs
@@ -24,6 +24,7 @@ pub(crate) struct WaitCommand {
 }
 
 impl builtins::Command for WaitCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-builtins/src/wait.rs
+++ b/brush-builtins/src/wait.rs
@@ -25,6 +25,7 @@ pub(crate) struct WaitCommand {
 
 impl builtins::Command for WaitCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-core/examples/custom-builtin.rs
+++ b/brush-core/examples/custom-builtin.rs
@@ -81,6 +81,7 @@ struct GreetCommand {
 //
 
 impl builtins::Command for GreetCommand {
+    type State = ();
     // Specify the error type you will use; this will either be your custom type or
     // the default-provided `brush_core::Error` type.
     type Error = GreetError;

--- a/brush-core/examples/custom-builtin.rs
+++ b/brush-core/examples/custom-builtin.rs
@@ -82,6 +82,7 @@ struct GreetCommand {
 
 impl builtins::Command for GreetCommand {
     type State = ();
+    type SharedState = ();
     // Specify the error type you will use; this will either be your custom type or
     // the default-provided `brush_core::Error` type.
     type Error = GreetError;

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -2,8 +2,9 @@
 
 use clap::builder::styling;
 pub use futures::future::BoxFuture;
-use std::any::Any;
+use std::any::{Any, TypeId, type_name};
 use std::io::Write;
+use std::marker::PhantomData;
 
 use crate::{BuiltinError, CommandArg, commands, error, extensions, results};
 
@@ -53,6 +54,22 @@ impl Clone for Box<dyn AnyState> {
     }
 }
 
+/// Marker type indicating that a [`Registration`] has not yet been given a
+/// custom local-state override via [`Registration::with_state`].
+///
+/// The phantom parameter `St` carries the builtin's `State` type so that
+/// `with_state(state)` can enforce the correct argument type at compile time.
+pub struct NeedsLocalState<St>(PhantomData<St>);
+
+/// Marker type indicating that a [`Registration`] is in its storage/terminal
+/// form.
+///
+/// Either local state was provided via [`Registration::with_state`], or the
+/// registration was produced by [`simple_builtin`] (which has no local state
+/// concept). In this state, [`with_state`](Registration::with_state) is not
+/// available, preventing double-provision.
+pub struct HasLocalState;
+
 /// Type of a function implementing a built-in command.
 ///
 /// # Arguments
@@ -91,6 +108,21 @@ pub trait Command: clap::Parser {
     /// [`Shell::builtin_state_of`] / [`Shell::builtin_state_mut_of`].
     type State: Clone + Default + Send + Sync + 'static;
 
+    /// The type of shared state that this builtin accesses in coordination with
+    /// other builtins registered through the same [`SharedBuilder`].
+    ///
+    /// Unlike [`State`](Command::State), shared state is **not** per-builtin —
+    /// it is keyed by type (`TypeId`) and shared across all builtins registered
+    /// through the same builder. The default `()` means "no shared state".
+    ///
+    /// Use `Arc<T>` when state should survive `Shell::clone()` (subshells
+    /// share the same underlying data). Use a bare `T` when each subshell
+    /// should get an independent copy (via `T::clone`).
+    ///
+    /// To mutate shared state, `T` must provide interior mutability (e.g.
+    /// `Mutex`, `papaya::HashMap`, atomics).
+    type SharedState: Clone + Send + Sync + 'static;
+
     /// Returns a shared reference to this builtin's persistent state.
     ///
     /// This is a convenience wrapper around
@@ -117,6 +149,18 @@ pub trait Command: clap::Parser {
         context: &'a mut commands::ExecutionContext<'_, SE>,
     ) -> Result<&'a mut Self::State, error::Error> {
         context.builtin_state_mut::<Self>()
+    }
+
+    /// Returns a shared reference to this builtin's shared state.
+    ///
+    /// This is a convenience wrapper around
+    /// [`ExecutionContext::shared`] that infers the shared-state type
+    /// from `Self::SharedState`, so no turbofish is needed.
+    fn shared<'a, SE: extensions::ShellExtensions>(
+        &self,
+        context: &'a commands::ExecutionContext<'_, SE>,
+    ) -> Result<&'a Self::SharedState, error::Error> {
+        context.shared::<Self::SharedState>()
     }
 
     /// Instantiates the built-in command with the given arguments.
@@ -233,8 +277,27 @@ pub struct ContentOptions {
 }
 
 /// Encapsulates a registration for a built-in command.
-#[derive(Clone)]
-pub struct Registration<SE: extensions::ShellExtensions> {
+///
+/// # Type parameters
+///
+/// * `SE` — the [`ShellExtensions`](extensions::ShellExtensions) type.
+/// * `S`  — the **shared-state** phantom. `S = ()` (default) means this
+///   registration can be passed directly to
+///   [`Shell::register_builtin`](crate::Shell::register_builtin). Any other
+///   `S` (e.g. `Arc<RepoCache>`) means it must go through
+///   [`SharedBuilder`] or [`SharedHandle`].
+/// * `L`  — the **local-state** phantom, governing
+///   [`with_state`](Registration::with_state) availability:
+///   - [`NeedsLocalState<St>`] — `with_state` is available, takes `St`.
+///   - [`HasLocalState`] — `with_state` is not available (terminal/storage form).
+///
+/// # Stored form
+///
+/// `Registration<SE>` (using both defaults) is the **stored form** used by
+/// `Shell.builtins` and `ShellBuilder`. It is produced by calling
+/// [`into_storage`](Registration::into_storage) on a freshly-created
+/// registration.
+pub struct Registration<SE: extensions::ShellExtensions, S = (), L = HasLocalState> {
     /// Function to execute the builtin.
     pub execute_func: CommandExecuteFunc<SE>,
 
@@ -251,21 +314,123 @@ pub struct Registration<SE: extensions::ShellExtensions> {
     pub declaration_builtin: bool,
 
     /// Factory function that creates the default state for this builtin.
-    /// Called by [`Shell::register_builtin`] to seed the per-builtin state map.
+    /// Called by [`Shell::register_builtin`](crate::Shell::register_builtin)
+    /// to seed the per-builtin state map.
     pub state_init: fn() -> Box<dyn AnyState>,
+
+    /// Explicit local-state override set by [`with_state`](Registration::with_state).
+    /// `None` means "use `state_init`".
+    pub local_override: Option<Box<dyn AnyState>>,
+
+    /// Shared-state phantom (`()` for stored form).
+    pub _shared: PhantomData<S>,
+    /// Local-state phantom (`HasLocalState` for stored form).
+    pub _local: PhantomData<L>,
 }
 
-impl<SE: extensions::ShellExtensions> Registration<SE> {
-    /// Updates the given registration to mark it for a special builtin.
-    #[must_use]
-    pub const fn special(self) -> Self {
+impl<SE: extensions::ShellExtensions, S, L> Clone for Registration<SE, S, L> {
+    fn clone(&self) -> Self {
         Self {
-            special_builtin: true,
             execute_func: self.execute_func,
             content_func: self.content_func,
             disabled: self.disabled,
+            special_builtin: self.special_builtin,
             declaration_builtin: self.declaration_builtin,
             state_init: self.state_init,
+            local_override: self.local_override.clone(),
+            _shared: PhantomData,
+            _local: PhantomData,
+        }
+    }
+}
+
+impl<SE: extensions::ShellExtensions, S, L> Registration<SE, S, L> {
+    /// Updates the given registration to mark it for a special builtin.
+    #[must_use]
+    pub fn special(self) -> Self {
+        Self {
+            special_builtin: true,
+            ..self
+        }
+    }
+
+    /// Convert to the stored form (`Registration<SE, (), HasLocalState>`).
+    ///
+    /// This erases the shared-state phantom and transitions the local-state
+    /// phantom to [`HasLocalState`], while preserving any
+    /// [`with_state`](Registration::with_state) override in
+    /// `local_override`.
+    ///
+    /// Called by [`stored_builtin`], [`stored_decl_builtin`],
+    /// [`stored_raw_arg_builtin`], and
+    /// [`ShellBuilder::builtin`](crate::ShellBuilder::builtin).
+    pub(crate) fn into_storage(self) -> Registration<SE> {
+        Registration {
+            execute_func: self.execute_func,
+            content_func: self.content_func,
+            disabled: self.disabled,
+            special_builtin: self.special_builtin,
+            declaration_builtin: self.declaration_builtin,
+            state_init: self.state_init,
+            local_override: self.local_override,
+            _shared: PhantomData,
+            _local: PhantomData,
+        }
+    }
+
+    /// Destruct into (stored registration, local-state override, `state_init` fn).
+    ///
+    /// For internal use by registration methods in `Shell` and
+    /// [`SharedBuilder`]/[`SharedHandle`].
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        Registration<SE>,
+        Option<Box<dyn AnyState>>,
+        fn() -> Box<dyn AnyState>,
+    ) {
+        let state_init = self.state_init;
+        let local_override = self.local_override;
+        let stored = Registration {
+            execute_func: self.execute_func,
+            content_func: self.content_func,
+            disabled: self.disabled,
+            special_builtin: self.special_builtin,
+            declaration_builtin: self.declaration_builtin,
+            state_init,
+            local_override: None,
+            _shared: PhantomData,
+            _local: PhantomData,
+        };
+        (stored, local_override, state_init)
+    }
+}
+
+impl<SE: extensions::ShellExtensions, S, St: Clone + Send + Sync + 'static>
+    Registration<SE, S, NeedsLocalState<St>>
+{
+    /// Provide a custom initial value for this builtin's local state,
+    /// replacing the default produced by `B::State::default()`.
+    ///
+    /// The argument type is exactly `St` (= `B::State`), enforced at compile
+    /// time by the [`NeedsLocalState<St>`] phantom.
+    ///
+    /// This method is only available once. After calling it the registration
+    /// transitions to [`HasLocalState`] and `with_state` is no longer
+    /// available.
+    #[must_use]
+    pub fn with_state(self, state: St) -> Registration<SE, S, HasLocalState> {
+        Registration {
+            execute_func: self.execute_func,
+            content_func: self.content_func,
+            disabled: self.disabled,
+            special_builtin: self.special_builtin,
+            declaration_builtin: self.declaration_builtin,
+            state_init: self.state_init,
+            local_override: Some(Box::new(state)),
+            _shared: self._shared,
+            _local: PhantomData,
         }
     }
 }
@@ -467,6 +632,9 @@ pub trait SimpleCommand {
 
 /// Returns a built-in command registration, given an implementation of the
 /// `SimpleCommand` trait.
+///
+/// The returned [`Registration`] is in its stored form (`HasLocalState`)
+/// because `SimpleCommand` has no per-builtin state concept.
 pub fn simple_builtin<B: SimpleCommand + Send + Sync, SE: extensions::ShellExtensions>()
 -> Registration<SE> {
     Registration {
@@ -476,12 +644,20 @@ pub fn simple_builtin<B: SimpleCommand + Send + Sync, SE: extensions::ShellExten
         special_builtin: false,
         declaration_builtin: false,
         state_init: default_state_fn::<()>,
+        local_override: None,
+        _shared: PhantomData,
+        _local: PhantomData,
     }
 }
 
 /// Returns a built-in command registration, given an implementation of the
 /// `Command` trait.
-pub fn builtin<B: Command + Send + Sync, SE: extensions::ShellExtensions>() -> Registration<SE> {
+///
+/// The phantom types encode:
+/// * `S = B::SharedState` — gates which registration method can be used.
+/// * `L = NeedsLocalState<B::State>` — enables [`with_state`](Registration::with_state).
+pub fn builtin<B: Command + Send + Sync, SE: extensions::ShellExtensions>()
+-> Registration<SE, B::SharedState, NeedsLocalState<B::State>> {
     Registration {
         execute_func: exec_builtin::<B, SE>,
         content_func: get_builtin_content::<B>,
@@ -489,14 +665,20 @@ pub fn builtin<B: Command + Send + Sync, SE: extensions::ShellExtensions>() -> R
         special_builtin: false,
         declaration_builtin: false,
         state_init: default_state_fn::<B::State>,
+        local_override: None,
+        _shared: PhantomData,
+        _local: PhantomData,
     }
 }
 
+/// Like [`builtin`], but returns the stored form directly (`HasLocalState`).
+///
+/// Use this in `default_builtins`-style factory functions where
 /// Returns a built-in command registration, given an implementation of the
 /// `DeclarationCommand` trait. Used for select commands that can take parsed
 /// declarations as arguments.
 pub fn decl_builtin<B: DeclarationCommand + Send + Sync, SE: extensions::ShellExtensions>()
--> Registration<SE> {
+-> Registration<SE, B::SharedState, NeedsLocalState<B::State>> {
     Registration {
         execute_func: exec_declaration_builtin::<B, SE>,
         content_func: get_builtin_content::<B>,
@@ -504,6 +686,9 @@ pub fn decl_builtin<B: DeclarationCommand + Send + Sync, SE: extensions::ShellEx
         special_builtin: false,
         declaration_builtin: true,
         state_init: default_state_fn::<B::State>,
+        local_override: None,
+        _shared: PhantomData,
+        _local: PhantomData,
     }
 }
 
@@ -517,7 +702,7 @@ pub fn decl_builtin<B: DeclarationCommand + Send + Sync, SE: extensions::ShellEx
 pub fn raw_arg_builtin<
     B: DeclarationCommand + Default + Send + Sync,
     SE: extensions::ShellExtensions,
->() -> Registration<SE> {
+>() -> Registration<SE, B::SharedState, NeedsLocalState<B::State>> {
     Registration {
         execute_func: exec_raw_arg_builtin::<B, SE>,
         content_func: get_builtin_content::<B>,
@@ -525,6 +710,9 @@ pub fn raw_arg_builtin<
         special_builtin: false,
         declaration_builtin: true,
         state_init: default_state_fn::<B::State>,
+        local_override: None,
+        _shared: PhantomData,
+        _local: PhantomData,
     }
 }
 
@@ -670,6 +858,102 @@ async fn call_builtin(
         .map_err(|e| error::ErrorKind::BuiltinError(Box::new(e), builtin_name))?;
 
     Ok(result)
+}
+
+/// Consuming builder that registers multiple builtins sharing a single
+/// typed state value.
+///
+/// # Subshell cloning behaviour
+///
+/// When [`Shell::clone()`](crate::Shell::clone) is called, shared state is
+/// cloned via [`AnyState::clone_box`]. With `Arc<T>` the clone is a cheap
+/// refcount bump (all subshells see the same data). With a bare `T` each
+/// subshell gets an independent deep copy.
+///
+/// # Interior mutability
+///
+/// The accessor [`ExecutionContext::shared`] returns `&T`. To mutate through
+/// an `Arc<T>`, `T` itself must provide interior mutability (e.g. `Mutex`,
+/// `papaya::HashMap`, atomics).
+///
+/// # Type uniqueness
+///
+/// Shared state is keyed by [`TypeId`]. Two unrelated uses of the same
+/// generic type (e.g. `HashMap<String, String>`) would collide. Use newtype
+/// wrappers for isolation.
+///
+/// # Example
+///
+/// ```ignore
+/// let cache = SharedBuilder::new(Arc::new(RepoCache::default()))
+///     .builtin("inherit", builtin::<InheritCommand, _>());
+/// shell.register_shared(cache);
+/// ```
+pub struct SharedBuilder<T, SE: extensions::ShellExtensions = extensions::DefaultShellExtensions> {
+    /// The shared state value to be seeded into `Shell::shared_states`.
+    pub(crate) value: T,
+    /// Builtins to register alongside the shared state.
+    pub(crate) builtins: Vec<(String, Registration<SE, T>)>,
+}
+
+impl<T: Clone + Send + Sync + 'static, SE: extensions::ShellExtensions> SharedBuilder<T, SE> {
+    /// Create a new builder that will share `value` across all added builtins.
+    pub const fn new(value: T) -> Self {
+        Self {
+            value,
+            builtins: Vec::new(),
+        }
+    }
+
+    /// Add a builtin that shares state type `T`.
+    ///
+    /// Compile error if the registration's shared-state phantom is not `T`.
+    #[must_use]
+    pub fn builtin(mut self, name: impl Into<String>, reg: Registration<SE, T>) -> Self {
+        self.builtins.push((name.into(), reg));
+        self
+    }
+}
+
+/// Borrowing handle that registers builtins against an **existing** shared
+/// state entry on a [`Shell`](crate::Shell).
+///
+/// Obtained via [`Shell::shared_handle`](crate::Shell::shared_handle).
+/// Each call to [`builtin`](SharedHandle::builtin) registers immediately.
+pub struct SharedHandle<'a, T, SE: extensions::ShellExtensions> {
+    pub(crate) shell: &'a mut crate::Shell<SE>,
+    pub(crate) _phantom: PhantomData<T>,
+}
+
+impl<T: Clone + Send + Sync + 'static, SE: extensions::ShellExtensions> SharedHandle<'_, T, SE> {
+    /// Register a builtin against the existing shared state of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the shared state has not been seeded (i.e. if
+    /// [`register_shared`](crate::Shell::register_shared) or
+    /// [`set_shared`](crate::Shell::set_shared) has not been called for `T`).
+    pub fn builtin(&mut self, name: impl Into<String>, reg: Registration<SE, T>) {
+        assert!(
+            self.shell.shared_states().contains_key(&TypeId::of::<T>()),
+            "SharedHandle::builtin called but shared state for {} has not been seeded",
+            type_name::<T>(),
+        );
+        let key = name.into();
+        let (stored, local_override, state_init) = reg.into_parts();
+        self.shell.builtins.insert(key.clone(), stored);
+        match local_override {
+            Some(state) => {
+                self.shell.builtin_states.insert(key, state);
+            }
+            None => {
+                self.shell
+                    .builtin_states
+                    .entry(key)
+                    .or_insert_with(state_init);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/brush-core/src/builtins.rs
+++ b/brush-core/src/builtins.rs
@@ -2,9 +2,56 @@
 
 use clap::builder::styling;
 pub use futures::future::BoxFuture;
+use std::any::Any;
 use std::io::Write;
 
 use crate::{BuiltinError, CommandArg, commands, error, extensions, results};
+
+/// A type-erased, cloneable container for per-builtin state stored on the shell.
+///
+/// Any `T: Clone + Send + Sync + 'static` automatically implements this trait
+/// thanks to a blanket impl.
+///
+/// # Important: calling methods on `Box<dyn AnyState>`
+///
+/// Because `Box<dyn AnyState>` itself satisfies `Clone + Send + Sync + 'static`,
+/// the blanket impl also applies to it. When calling `as_any`, `as_any_mut`, or
+/// `clone_box` on a `Box<dyn AnyState>`, you **must** explicitly dereference
+/// first (e.g. `(&**state).as_any()`) so that dispatch goes through the vtable to
+/// the concrete inner type, rather than the blanket impl on `Box<dyn AnyState>`
+/// itself. The accessors on [`Shell`](crate::Shell) and
+/// [`ExecutionContext`](crate::commands::ExecutionContext) already handle this
+/// correctly.
+pub trait AnyState: Send + Sync + 'static {
+    /// Deep-clone the state into a new heap allocation.
+    fn clone_box(&self) -> Box<dyn AnyState>;
+
+    /// Downcast to `&dyn Any` for typed access.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Downcast to `&mut dyn Any` for typed mutable access.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T: Clone + Send + Sync + 'static> AnyState for T {
+    fn clone_box(&self) -> Box<dyn AnyState> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl Clone for Box<dyn AnyState> {
+    fn clone(&self) -> Self {
+        (**self).clone_box()
+    }
+}
 
 /// Type of a function implementing a built-in command.
 ///
@@ -33,6 +80,44 @@ pub type CommandContentFunc =
 pub trait Command: clap::Parser {
     /// The error type returned by the command.
     type Error: BuiltinError + 'static;
+
+    /// The type of persistent state carried by this builtin across invocations.
+    ///
+    /// Stateful builtins override this with a custom type that implements
+    /// `Clone + Default + Send + Sync + 'static`. The shell allocates a default
+    /// instance at registration time and stores it keyed by the builtin's
+    /// registered name. Builtins access state through
+    /// [`ExecutionContext::builtin_state_mut`] and external code uses
+    /// [`Shell::builtin_state_of`] / [`Shell::builtin_state_mut_of`].
+    type State: Clone + Default + Send + Sync + 'static;
+
+    /// Returns a shared reference to this builtin's persistent state.
+    ///
+    /// This is a convenience wrapper around
+    /// [`ExecutionContext::builtin_state`] that infers the command type
+    /// from `&self`, so no turbofish is needed.
+    fn state<'a, SE: extensions::ShellExtensions>(
+        &self,
+        context: &'a commands::ExecutionContext<'_, SE>,
+    ) -> Result<&'a Self::State, error::Error> {
+        context.builtin_state::<Self>()
+    }
+
+    /// Returns an exclusive reference to this builtin's persistent state.
+    ///
+    /// This is a convenience wrapper around
+    /// [`ExecutionContext::builtin_state_mut`] that infers the command type
+    /// from `&self`, so no turbofish is needed.
+    ///
+    /// The caller must drop the returned reference before calling any other
+    /// `&mut Shell` method (including `source_script`), so that re-entrant
+    /// builtin invocations can access state independently.
+    fn state_mut<'a, SE: extensions::ShellExtensions>(
+        &self,
+        context: &'a mut commands::ExecutionContext<'_, SE>,
+    ) -> Result<&'a mut Self::State, error::Error> {
+        context.builtin_state_mut::<Self>()
+    }
 
     /// Instantiates the built-in command with the given arguments.
     ///
@@ -164,6 +249,10 @@ pub struct Registration<SE: extensions::ShellExtensions> {
 
     /// Is this builtin one that takes specially handled declarations?
     pub declaration_builtin: bool,
+
+    /// Factory function that creates the default state for this builtin.
+    /// Called by [`Shell::register_builtin`] to seed the per-builtin state map.
+    pub state_init: fn() -> Box<dyn AnyState>,
 }
 
 impl<SE: extensions::ShellExtensions> Registration<SE> {
@@ -172,7 +261,11 @@ impl<SE: extensions::ShellExtensions> Registration<SE> {
     pub const fn special(self) -> Self {
         Self {
             special_builtin: true,
-            ..self
+            execute_func: self.execute_func,
+            content_func: self.content_func,
+            disabled: self.disabled,
+            declaration_builtin: self.declaration_builtin,
+            state_init: self.state_init,
         }
     }
 }
@@ -382,6 +475,7 @@ pub fn simple_builtin<B: SimpleCommand + Send + Sync, SE: extensions::ShellExten
         disabled: false,
         special_builtin: false,
         declaration_builtin: false,
+        state_init: default_state_fn::<()>,
     }
 }
 
@@ -394,6 +488,7 @@ pub fn builtin<B: Command + Send + Sync, SE: extensions::ShellExtensions>() -> R
         disabled: false,
         special_builtin: false,
         declaration_builtin: false,
+        state_init: default_state_fn::<B::State>,
     }
 }
 
@@ -408,6 +503,7 @@ pub fn decl_builtin<B: DeclarationCommand + Send + Sync, SE: extensions::ShellEx
         disabled: false,
         special_builtin: false,
         declaration_builtin: true,
+        state_init: default_state_fn::<B::State>,
     }
 }
 
@@ -428,7 +524,12 @@ pub fn raw_arg_builtin<
         disabled: false,
         special_builtin: false,
         declaration_builtin: true,
+        state_init: default_state_fn::<B::State>,
     }
+}
+
+fn default_state_fn<S: Clone + Default + Send + Sync + 'static>() -> Box<dyn AnyState> {
+    Box::new(S::default())
 }
 
 fn get_builtin_content<T: Command + Send + Sync>(
@@ -569,4 +670,64 @@ async fn call_builtin(
         .map_err(|e| error::ErrorKind::BuiltinError(Box::new(e), builtin_name))?;
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    struct Counter {
+        value: usize,
+    }
+
+    #[test]
+    fn any_state_clone_roundtrips() {
+        let original: Box<dyn AnyState> = Box::new(Counter { value: 42 });
+        let cloned = original.clone();
+        let downcasted = (*cloned).as_any().downcast_ref::<Counter>().unwrap();
+        assert_eq!(downcasted.value, 42);
+    }
+
+    #[test]
+    fn any_state_mut_roundtrip() {
+        let mut state: Box<dyn AnyState> = Box::new(Counter { value: 0 });
+        (*state)
+            .as_any_mut()
+            .downcast_mut::<Counter>()
+            .unwrap()
+            .value += 1;
+        assert_eq!(
+            (*state).as_any().downcast_ref::<Counter>().unwrap().value,
+            1
+        );
+    }
+
+    #[test]
+    fn any_state_wrong_type_returns_none() {
+        let state: Box<dyn AnyState> = Box::new(Counter { value: 1 });
+        assert!((*state).as_any().downcast_ref::<String>().is_none());
+    }
+
+    #[test]
+    fn any_state_as_any_mut_downcast() {
+        let mut state: Box<dyn AnyState> = Box::new(Counter { value: 5 });
+        let c = (*state).as_any_mut().downcast_mut::<Counter>();
+        assert!(c.is_some(), "downcast_mut to Counter should succeed");
+        assert_eq!(c.unwrap().value, 5);
+    }
+
+    #[test]
+    fn any_state_complex_type() {
+        let mut state: Box<dyn AnyState> = Box::new(Counter { value: 5 });
+        (*state)
+            .as_any_mut()
+            .downcast_mut::<Counter>()
+            .unwrap()
+            .value += 1;
+        assert_eq!(
+            (*state).as_any().downcast_ref::<Counter>().unwrap().value,
+            6
+        );
+    }
 }

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -72,6 +72,39 @@ impl<SE: ShellExtensions> ExecutionContext<'_, SE> {
     pub fn iter_fds(&self) -> impl Iterator<Item = (ShellFd, openfiles::OpenFile)> {
         self.params.iter_fds(self.shell)
     }
+
+    /// Returns a shared reference to the state of the currently executing builtin.
+    ///
+    /// Uses `self.command_name` as the lookup key and `B::State` as the expected
+    /// type. Returns `Err` if no state is registered for this builtin name, which
+    /// should be structurally impossible when the builtin was registered via
+    /// [`Shell::register_builtin`].
+    pub fn builtin_state<B: builtins::Command>(&self) -> Result<&B::State, error::Error> {
+        self.shell
+            .builtin_state_of::<B>(&self.command_name)
+            .ok_or_else(|| {
+                error::ErrorKind::BuiltinStateNotRegistered(self.command_name.clone()).into()
+            })
+    }
+
+    /// Returns an exclusive reference to the state of the currently executing builtin.
+    ///
+    /// Uses `self.command_name` as the lookup key and `B::State` as the expected
+    /// type. Returns `Err` if no state is registered for this builtin name, which
+    /// should be structurally impossible when the builtin was registered via
+    /// [`Shell::register_builtin`].
+    ///
+    /// The caller must drop the returned reference before calling any other
+    /// `&mut Shell` method (including `source_script`), so that re-entrant
+    /// builtin invocations can access state independently.
+    pub fn builtin_state_mut<B: builtins::Command>(
+        &mut self,
+    ) -> Result<&mut B::State, error::Error> {
+        let name = self.command_name.clone();
+        self.shell
+            .builtin_state_mut_of::<B>(&name)
+            .ok_or_else(|| error::ErrorKind::BuiltinStateNotRegistered(name).into())
+    }
 }
 
 /// An argument to a command.

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -105,6 +105,15 @@ impl<SE: ShellExtensions> ExecutionContext<'_, SE> {
             .builtin_state_mut_of::<B>(&name)
             .ok_or_else(|| error::ErrorKind::BuiltinStateNotRegistered(name).into())
     }
+
+    /// Returns a shared reference to the cross-builtin shared state of type `T`.
+    ///
+    /// Returns `Err` if no shared state of that type has been registered.
+    /// Use interior mutability (e.g. `Mutex`, `papaya::HashMap`, atomics)
+    /// if you need to mutate through the returned reference.
+    pub fn shared<T: Clone + Send + Sync + 'static>(&self) -> Result<&T, error::Error> {
+        self.shell.get_shared::<T>()
+    }
 }
 
 /// An argument to a command.

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -322,6 +322,10 @@ pub enum ErrorKind {
     /// The requested builtin state was not registered for the given builtin name.
     #[error("builtin state not registered for '{0}'")]
     BuiltinStateNotRegistered(String),
+
+    /// The requested shared state type was not registered on the shell.
+    #[error("shared state not registered for '{0}'")]
+    SharedStateNotRegistered(String),
 }
 
 /// Trait implementable by built-in commands to represent errors.

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -318,6 +318,10 @@ pub enum ErrorKind {
     /// A glob pattern failed to match any files (failglob).
     #[error("no match: {0}")]
     NoMatch(String),
+
+    /// The requested builtin state was not registered for the given builtin name.
+    #[error("builtin state not registered for '{0}'")]
+    BuiltinStateNotRegistered(String),
 }
 
 /// Trait implementable by built-in commands to represent errors.

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -124,11 +124,16 @@ pub struct Shell<SE: extensions::ShellExtensions = extensions::DefaultShellExten
 
     /// Shell built-in commands.
     #[cfg_attr(feature = "serde", serde(skip))]
-    builtins: HashMap<String, builtins::Registration<SE>>,
+    pub(crate) builtins: HashMap<String, builtins::Registration<SE>>,
 
     /// Per-builtin state, keyed by registration name.
     #[cfg_attr(feature = "serde", serde(skip, default))]
-    builtin_states: HashMap<String, Box<dyn builtins::AnyState>>,
+    pub(crate) builtin_states: HashMap<String, Box<dyn builtins::AnyState>>,
+
+    /// Cross-builtin shared state, keyed by `TypeId` of the shared value.
+    /// Seeded via [`Shell::register_shared`] or [`Shell::set_shared`].
+    #[cfg_attr(feature = "serde", serde(skip, default))]
+    pub(crate) shared_states: HashMap<std::any::TypeId, Box<dyn builtins::AnyState>>,
 
     /// Shell program location cache.
     program_location_cache: pathcache::PathCache,
@@ -186,6 +191,11 @@ impl<SE: extensions::ShellExtensions> Clone for Shell<SE> {
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
+            shared_states: self
+                .shared_states
+                .iter()
+                .map(|(k, v)| (*k, v.clone()))
+                .collect(),
             program_location_cache: self.program_location_cache.clone(),
             last_stopwatch_time: self.last_stopwatch_time,
             last_stopwatch_offset: self.last_stopwatch_offset,
@@ -237,7 +247,16 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
         };
 
         for (name, reg) in options.builtins {
-            shell.register_builtin(name, reg);
+            let (stored, local_override, state_init) = reg.into_parts();
+            shell.builtins.insert(name.clone(), stored);
+            match local_override {
+                Some(state) => {
+                    shell.builtin_states.insert(name, state);
+                }
+                None => {
+                    shell.builtin_states.entry(name).or_insert_with(state_init);
+                }
+            }
         }
 
         // Add in any open files provided.

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -126,6 +126,10 @@ pub struct Shell<SE: extensions::ShellExtensions = extensions::DefaultShellExten
     #[cfg_attr(feature = "serde", serde(skip))]
     builtins: HashMap<String, builtins::Registration<SE>>,
 
+    /// Per-builtin state, keyed by registration name.
+    #[cfg_attr(feature = "serde", serde(skip, default))]
+    builtin_states: HashMap<String, Box<dyn builtins::AnyState>>,
+
     /// Shell program location cache.
     program_location_cache: pathcache::PathCache,
 
@@ -177,6 +181,11 @@ impl<SE: extensions::ShellExtensions> Clone for Shell<SE> {
             directory_stack: self.directory_stack.clone(),
             completion_config: self.completion_config.clone(),
             builtins: self.builtins.clone(),
+            builtin_states: self
+                .builtin_states
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
             program_location_cache: self.program_location_cache.clone(),
             last_stopwatch_time: self.last_stopwatch_time,
             last_stopwatch_offset: self.last_stopwatch_offset,
@@ -221,11 +230,15 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
             version: options.shell_version,
             product_display_str: options.shell_product_display_str,
             working_dir: options.working_dir.map_or_else(std::env::current_dir, Ok)?,
-            builtins: options.builtins,
+            builtins: HashMap::default(),
             parser_impl: options.parser,
             key_bindings: options.key_bindings,
             ..Self::default()
         };
+
+        for (name, reg) in options.builtins {
+            shell.register_builtin(name, reg);
+        }
 
         // Add in any open files provided.
         shell.open_files.update_from(options.fds.into_iter());

--- a/brush-core/src/shell/builder.rs
+++ b/brush-core/src/shell/builder.rs
@@ -259,6 +259,7 @@ impl<SE: extensions::ShellExtensions> Default for Shell<SE> {
             directory_stack: vec![],
             completion_config: completion::Config::default(),
             builtins: HashMap::default(),
+            builtin_states: HashMap::default(),
             program_location_cache: pathcache::PathCache::default(),
             last_stopwatch_time: std::time::SystemTime::now(),
             last_stopwatch_offset: 0,

--- a/brush-core/src/shell/builder.rs
+++ b/brush-core/src/shell/builder.rs
@@ -86,12 +86,16 @@ impl<SE: extensions::ShellExtensions, S: shell_builder::State> ShellBuilder<SE, 
     }
 
     /// Add a single builtin registration
-    pub fn builtin(mut self, name: impl Into<String>, reg: builtins::Registration<SE>) -> Self {
-        self.builtins.insert(name.into(), reg);
+    pub fn builtin<L>(
+        mut self,
+        name: impl Into<String>,
+        reg: builtins::Registration<SE, (), L>,
+    ) -> Self {
+        self.builtins.insert(name.into(), reg.into_storage());
         self
     }
 
-    /// Add many builtin registrations
+    /// Add many builtin registrations (stored form).
     pub fn builtins(
         mut self,
         builtins: impl IntoIterator<Item = (String, builtins::Registration<SE>)>,
@@ -260,6 +264,7 @@ impl<SE: extensions::ShellExtensions> Default for Shell<SE> {
             completion_config: completion::Config::default(),
             builtins: HashMap::default(),
             builtin_states: HashMap::default(),
+            shared_states: HashMap::default(),
             program_location_cache: pathcache::PathCache::default(),
             last_stopwatch_time: std::time::SystemTime::now(),
             last_stopwatch_offset: 0,

--- a/brush-core/src/shell/builtin_registry.rs
+++ b/brush-core/src/shell/builtin_registry.rs
@@ -8,16 +8,53 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
     /// Register a builtin to the shell's environment, replacing any existing
     /// registration with the same name.
     ///
+    /// Also seeds the per-builtin state map with a default-constructed
+    /// `B::State` (via the registration's `state_init` function), so that
+    /// [`Self::builtin_state_of`] / [`Self::builtin_state_mut_of`] can
+    /// always find an entry.
+    ///
     /// # Arguments
     ///
     /// * `name` - The in-shell name of the builtin.
     /// * `registration` - The registration handle for the builtin.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn register_builtin<S: Into<String>>(
         &mut self,
         name: S,
         registration: builtins::Registration<SE>,
     ) {
-        self.builtins.insert(name.into(), registration);
+        let key = name.into();
+        self.builtins.insert(key.clone(), registration.clone());
+        self.builtin_states
+            .entry(key)
+            .or_insert_with(registration.state_init);
+    }
+
+    /// Register a builtin with an explicit initial state, replacing any
+    /// existing registration and state with the same name.
+    ///
+    /// Use this when the builtin's default state is not the `Default::default()`
+    /// value — for example, when the state needs to reference external data or
+    /// have non-trivial initialization.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The in-shell name of the builtin.
+    /// * `registration` - The registration handle for the builtin.
+    /// * `state` - The initial state value.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn register_builtin_with_state<S, T>(
+        &mut self,
+        name: S,
+        registration: builtins::Registration<SE>,
+        state: T,
+    ) where
+        S: Into<String>,
+        T: Clone + Send + Sync + 'static,
+    {
+        let key = name.into();
+        self.builtins.insert(key.clone(), registration);
+        self.builtin_states.insert(key, Box::new(state));
     }
 
     /// Register a builtin only if no builtin with that name is already registered.
@@ -26,12 +63,17 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
     ///
     /// * `name` - The in-shell name of the builtin.
     /// * `registration` - The registration handle for the builtin.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn register_builtin_if_unset<S: Into<String>>(
         &mut self,
         name: S,
         registration: builtins::Registration<SE>,
     ) {
-        self.builtins.entry(name.into()).or_insert(registration);
+        let key = name.into();
+        if self.builtins.contains_key(&key) {
+            return;
+        }
+        self.register_builtin(key, registration);
     }
 
     /// Tries to retrieve a mutable reference to an existing builtin registration.
@@ -47,5 +89,50 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
     /// Returns the registered builtins for the shell.
     pub const fn builtins(&self) -> &HashMap<String, builtins::Registration<SE>> {
         &self.builtins
+    }
+
+    // -- Typed state accessors (by Command type) --
+
+    /// Returns a shared reference to the state of the named builtin, using
+    /// `B::State` as the expected type.
+    ///
+    /// Returns `None` if no state has been registered for that name, or if the
+    /// stored state is not of type `B::State`.
+    pub fn builtin_state_of<B: builtins::Command>(&self, name: &str) -> Option<&B::State> {
+        let state = self.builtin_states.get(name)?;
+        (**state).as_any().downcast_ref::<B::State>()
+    }
+
+    /// Returns an exclusive reference to the state of the named builtin, using
+    /// `B::State` as the expected type.
+    ///
+    /// Returns `None` if no state has been registered for that name, or if the
+    /// stored state is not of type `B::State`.
+    pub fn builtin_state_mut_of<B: builtins::Command>(
+        &mut self,
+        name: &str,
+    ) -> Option<&mut B::State> {
+        let state = self.builtin_states.get_mut(name)?;
+        (**state).as_any_mut().downcast_mut::<B::State>()
+    }
+
+    // -- Raw typed state accessors (by concrete type) --
+
+    /// Returns a shared reference to the state of the named builtin.
+    ///
+    /// Returns `None` if no state has been registered for that name, or if the
+    /// stored state is not of the requested type `T`.
+    pub fn builtin_state<T: 'static>(&self, name: &str) -> Option<&T> {
+        let state = self.builtin_states.get(name)?;
+        (**state).as_any().downcast_ref::<T>()
+    }
+
+    /// Returns an exclusive reference to the state of the named builtin.
+    ///
+    /// Returns `None` if no state has been registered for that name, or if the
+    /// stored state is not of the requested type `T`.
+    pub fn builtin_state_mut<T: 'static>(&mut self, name: &str) -> Option<&mut T> {
+        let state = self.builtin_states.get_mut(name)?;
+        (**state).as_any_mut().downcast_mut::<T>()
     }
 }

--- a/brush-core/src/shell/builtin_registry.rs
+++ b/brush-core/src/shell/builtin_registry.rs
@@ -1,60 +1,45 @@
 //! Builtin command management for shell instances.
 
+use std::any::TypeId;
 use std::collections::HashMap;
 
-use crate::{builtins, extensions};
+use crate::{builtins, error, extensions};
 
 impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
     /// Register a builtin to the shell's environment, replacing any existing
     /// registration with the same name.
     ///
     /// Also seeds the per-builtin state map with a default-constructed
-    /// `B::State` (via the registration's `state_init` function), so that
+    /// `B::State` (via the registration's `state_init` function), or with the
+    /// custom state provided via [`Registration::with_state`], so that
     /// [`Self::builtin_state_of`] / [`Self::builtin_state_mut_of`] can
     /// always find an entry.
     ///
+    /// Only accepts `Registration<SE, (), _>` — i.e. builtins whose
+    /// `SharedState` is `()`. Use [`Self::register_shared`] for builtins
+    /// that share state.
+    ///
     /// # Arguments
     ///
     /// * `name` - The in-shell name of the builtin.
     /// * `registration` - The registration handle for the builtin.
     #[allow(clippy::needless_pass_by_value)]
-    pub fn register_builtin<S: Into<String>>(
+    pub fn register_builtin<L>(
         &mut self,
-        name: S,
-        registration: builtins::Registration<SE>,
+        name: impl Into<String>,
+        registration: builtins::Registration<SE, (), L>,
     ) {
         let key = name.into();
-        self.builtins.insert(key.clone(), registration.clone());
-        self.builtin_states
-            .entry(key)
-            .or_insert_with(registration.state_init);
-    }
-
-    /// Register a builtin with an explicit initial state, replacing any
-    /// existing registration and state with the same name.
-    ///
-    /// Use this when the builtin's default state is not the `Default::default()`
-    /// value — for example, when the state needs to reference external data or
-    /// have non-trivial initialization.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The in-shell name of the builtin.
-    /// * `registration` - The registration handle for the builtin.
-    /// * `state` - The initial state value.
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn register_builtin_with_state<S, T>(
-        &mut self,
-        name: S,
-        registration: builtins::Registration<SE>,
-        state: T,
-    ) where
-        S: Into<String>,
-        T: Clone + Send + Sync + 'static,
-    {
-        let key = name.into();
-        self.builtins.insert(key.clone(), registration);
-        self.builtin_states.insert(key, Box::new(state));
+        let (stored, local_override, state_init) = registration.into_parts();
+        self.builtins.insert(key.clone(), stored);
+        match local_override {
+            Some(state) => {
+                self.builtin_states.insert(key, state);
+            }
+            None => {
+                self.builtin_states.entry(key).or_insert_with(state_init);
+            }
+        }
     }
 
     /// Register a builtin only if no builtin with that name is already registered.
@@ -64,16 +49,91 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
     /// * `name` - The in-shell name of the builtin.
     /// * `registration` - The registration handle for the builtin.
     #[allow(clippy::needless_pass_by_value)]
-    pub fn register_builtin_if_unset<S: Into<String>>(
+    pub fn register_builtin_if_unset<L>(
         &mut self,
-        name: S,
-        registration: builtins::Registration<SE>,
+        name: impl Into<String>,
+        registration: builtins::Registration<SE, (), L>,
     ) {
         let key = name.into();
         if self.builtins.contains_key(&key) {
             return;
         }
         self.register_builtin(key, registration);
+    }
+
+    /// Bulk-register builtins that share a single typed state value.
+    ///
+    /// Seeds `shared_states[TypeId::of::<T>()]` with the builder's value,
+    /// then registers each builtin in the builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `builder` - A [`SharedBuilder`](builtins::SharedBuilder) produced by
+    ///   chaining `.builtin(name, reg)` calls.
+    pub fn register_shared<T>(&mut self, builder: builtins::SharedBuilder<T, SE>)
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.shared_states
+            .insert(TypeId::of::<T>(), Box::new(builder.value));
+        for (name, reg) in builder.builtins {
+            let key = name;
+            let (stored, local_override, state_init) = reg.into_parts();
+            self.builtins.insert(key.clone(), stored);
+            match local_override {
+                Some(state) => {
+                    self.builtin_states.insert(key, state);
+                }
+                None => {
+                    self.builtin_states.entry(key).or_insert_with(state_init);
+                }
+            }
+        }
+    }
+
+    /// Returns a borrowing handle for registering additional builtins against
+    /// an **existing** shared state entry of type `T`.
+    ///
+    /// Each call to [`SharedHandle::builtin`] registers immediately.
+    ///
+    /// # Panics
+    ///
+    /// Methods on the returned handle panic if shared state for `T` has not
+    /// been seeded (i.e. [`register_shared`](Self::register_shared) or
+    /// [`set_shared`](Self::set_shared) has not been called for `T`).
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn shared_handle<T>(&mut self) -> builtins::SharedHandle<'_, T, SE>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        builtins::SharedHandle {
+            shell: self,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Directly insert or replace a shared state value, keyed by `TypeId::of::<T>()`.
+    ///
+    /// This is intended for use outside of builtins (e.g. by embedders
+    /// preparing a shell before handing it to user code). Builtins should
+    /// prefer [`register_shared`](Self::register_shared) which atomically
+    /// seeds shared state and registers builtins.
+    pub fn set_shared<T: Clone + Send + Sync + 'static>(&mut self, state: T) {
+        self.shared_states
+            .insert(TypeId::of::<T>(), Box::new(state));
+    }
+
+    /// Returns a shared reference to the shared state of type `T`, or `None`
+    /// if not registered.
+    pub fn shared<T: 'static>(&self) -> Option<&T> {
+        self.shared_states
+            .get(&TypeId::of::<T>())
+            .and_then(|s| (**s).as_any().downcast_ref::<T>())
+    }
+
+    /// Returns the raw shared-states map (for internal use by `SharedHandle`).
+    pub(crate) fn shared_states(&self) -> &HashMap<TypeId, Box<dyn builtins::AnyState>> {
+        &self.shared_states
     }
 
     /// Tries to retrieve a mutable reference to an existing builtin registration.
@@ -134,5 +194,18 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
     pub fn builtin_state_mut<T: 'static>(&mut self, name: &str) -> Option<&mut T> {
         let state = self.builtin_states.get_mut(name)?;
         (**state).as_any_mut().downcast_mut::<T>()
+    }
+
+    /// Retrieves a shared reference to the cross-builtin shared state of type `T`.
+    ///
+    /// Returns `Err` if no shared state of that type has been registered.
+    pub fn get_shared<T: Clone + Send + Sync + 'static>(&self) -> Result<&T, error::Error> {
+        self.shared_states
+            .get(&TypeId::of::<T>())
+            .and_then(|s| (**s).as_any().downcast_ref::<T>())
+            .ok_or_else(|| {
+                error::ErrorKind::SharedStateNotRegistered(std::any::type_name::<T>().to_string())
+                    .into()
+            })
     }
 }

--- a/brush-experimental-builtins/src/lib.rs
+++ b/brush-experimental-builtins/src/lib.rs
@@ -4,30 +4,12 @@
 mod save;
 
 #[allow(unused_imports, reason = "not all builtins are used in all configs")]
-use brush_core::builtins::{self, builtin, decl_builtin, raw_arg_builtin, simple_builtin};
+use brush_core::builtins::{self, builtin};
 
-/// Returns the set of experimental built-in commands.
-pub fn experimental_builtins<SE: brush_core::extensions::ShellExtensions>()
--> std::collections::HashMap<String, builtins::Registration<SE>> {
-    let mut m = std::collections::HashMap::<String, builtins::Registration<SE>>::new();
-
+/// Registers experimental built-in commands on the given shell.
+pub fn register_experimental_builtins<SE: brush_core::extensions::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
+) {
     #[cfg(feature = "builtin.save")]
-    m.insert("save".into(), builtin::<save::SaveCommand, SE>());
-
-    m
-}
-
-/// Extension trait that simplifies adding experimental builtins to a shell builder.
-pub trait ShellBuilderExt {
-    /// Add experimental builtins to the shell being built.
-    #[must_use]
-    fn experimental_builtins(self) -> Self;
-}
-
-impl<SE: brush_core::extensions::ShellExtensions, S: brush_core::ShellBuilderState> ShellBuilderExt
-    for brush_core::ShellBuilder<SE, S>
-{
-    fn experimental_builtins(self) -> Self {
-        self.builtins(crate::experimental_builtins())
-    }
+    shell.register_builtin("save", builtin::<save::SaveCommand, SE>());
 }

--- a/brush-experimental-builtins/src/save.rs
+++ b/brush-experimental-builtins/src/save.rs
@@ -9,6 +9,7 @@ use std::io::Write;
 pub(crate) struct SaveCommand {}
 
 impl builtins::Command for SaveCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-experimental-builtins/src/save.rs
+++ b/brush-experimental-builtins/src/save.rs
@@ -10,6 +10,7 @@ pub(crate) struct SaveCommand {}
 
 impl builtins::Command for SaveCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-shell/benches/shell.rs
+++ b/brush-shell/benches/shell.rs
@@ -5,27 +5,26 @@
 
 #[cfg(unix)]
 mod unix {
-    use brush_builtins::ShellBuilderExt;
+    use brush_builtins::ShellExt;
     use brush_parser::SourceSpan;
     use criterion::Criterion;
     use std::hint::black_box;
 
     async fn instantiate_shell() -> brush_core::Shell {
-        brush_core::Shell::builder()
-            .default_builtins(brush_builtins::BuiltinSet::BashMode)
-            .build()
-            .await
-            .unwrap()
+        let mut shell = brush_core::Shell::builder().build().await.unwrap();
+        shell.register_default_builtins(brush_builtins::BuiltinSet::BashMode);
+        shell
     }
 
     async fn instantiate_shell_with_init_scripts() -> brush_core::Shell {
-        brush_core::Shell::builder()
+        let mut shell = brush_core::Shell::builder()
             .interactive(true)
             .read_commands_from_stdin(true)
-            .default_builtins(brush_builtins::BuiltinSet::BashMode)
             .build()
             .await
-            .unwrap()
+            .unwrap();
+        shell.register_default_builtins(brush_builtins::BuiltinSet::BashMode);
+        shell
     }
 
     async fn run_one_command(shell: &mut brush_core::Shell, command: &str) {

--- a/brush-shell/src/brushctl.rs
+++ b/brush-shell/src/brushctl.rs
@@ -4,28 +4,20 @@ use std::io::Write;
 
 use crate::events;
 
-/// Extension trait for adding brush-specific built-in commands to a shell builder.
-pub(crate) trait ShellBuilderBrushBuiltinExt {
-    /// Add brush-specific builtins to a shell being built.
-    #[must_use]
-    fn brush_builtins(self) -> Self;
-}
-
-impl<SE: brush_core::extensions::ShellExtensions, S: brush_core::ShellBuilderState>
-    ShellBuilderBrushBuiltinExt for brush_core::ShellBuilder<SE, S>
-{
-    fn brush_builtins(self) -> Self {
-        // For compatibility with previous releases, we register the command under both
-        // `brushctl` and `brushinfo` names. It will behave identically across the two.
-        self.builtin(
-            "brushctl",
-            brush_core::builtins::builtin::<BrushCtlCommand, SE>(),
-        )
-        .builtin(
-            "brushinfo",
-            brush_core::builtins::builtin::<BrushCtlCommand, SE>(),
-        )
-    }
+/// Register brush-specific built-in commands on a shell.
+pub(crate) fn register_brush_builtins<SE: brush_core::extensions::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
+) {
+    // For compatibility with previous releases, we register the command under both
+    // `brushctl` and `brushinfo` names. It will behave identically across the two.
+    shell.register_builtin(
+        "brushctl",
+        brush_core::builtins::builtin::<BrushCtlCommand, SE>(),
+    );
+    shell.register_builtin(
+        "brushinfo",
+        brush_core::builtins::builtin::<BrushCtlCommand, SE>(),
+    );
 }
 
 /// Configure the running brush shell.
@@ -113,6 +105,7 @@ enum ProcessCommand {
 
 impl brush_core::builtins::Command for BrushCtlCommand {
     type State = ();
+    type SharedState = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-shell/src/brushctl.rs
+++ b/brush-shell/src/brushctl.rs
@@ -112,6 +112,7 @@ enum ProcessCommand {
 }
 
 impl brush_core::builtins::Command for BrushCtlCommand {
+    type State = ();
     type Error = brush_core::Error;
 
     async fn execute<SE: brush_core::ShellExtensions>(

--- a/brush-shell/src/bundled.rs
+++ b/brush-shell/src/bundled.rs
@@ -272,6 +272,9 @@ fn shim_registration<SE: ShellExtensions>() -> Registration<SE> {
         special_builtin: false,
         declaration_builtin: false,
         state_init: || Box::new(()),
+        local_override: None,
+        _shared: std::marker::PhantomData,
+        _local: std::marker::PhantomData,
     }
 }
 

--- a/brush-shell/src/bundled.rs
+++ b/brush-shell/src/bundled.rs
@@ -271,6 +271,7 @@ fn shim_registration<SE: ShellExtensions>() -> Registration<SE> {
         disabled: false,
         special_builtin: false,
         declaration_builtin: false,
+        state_init: || Box::new(()),
     }
 }
 

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -2,15 +2,11 @@
 
 use crate::args::CommandLineArgs;
 use crate::args::InputBackendType;
-use crate::brushctl::ShellBuilderBrushBuiltinExt as _;
 use crate::bundled;
 use crate::config;
 use crate::error_formatter;
 use crate::events;
 use crate::productinfo;
-use brush_builtins::ShellBuilderExt as _;
-#[cfg(feature = "experimental-builtins")]
-use brush_experimental_builtins::ShellBuilderExt as _;
 use clap::CommandFactory;
 use std::sync::LazyLock;
 use std::{path::Path, sync::Arc};
@@ -459,17 +455,12 @@ fn instantiate_shell_from_file(
         brush_builtins::BuiltinSet::BashMode
     };
 
-    let builtins = brush_builtins::default_builtins(builtin_set);
-
-    for (builtin_name, builtin) in builtins {
-        shell.register_builtin(&builtin_name, builtin);
-    }
+    brush_builtins::register_default_builtins(&mut shell, builtin_set);
+    crate::brushctl::register_brush_builtins(&mut shell);
 
     // Add experimental builtins (if enabled).
     #[cfg(feature = "experimental-builtins")]
-    for (builtin_name, builtin) in brush_experimental_builtins::experimental_builtins() {
-        shell.register_builtin(&builtin_name, builtin);
-    }
+    brush_experimental_builtins::register_experimental_builtins(&mut shell);
 
     Ok(shell)
 }
@@ -573,15 +564,16 @@ async fn instantiate_shell_from_args(
         .error_formatter(new_error_behavior(args))
         .shell_version(env!("CARGO_PKG_VERSION").to_string());
 
+    // Build the shell.
+    let mut shell = shell.build().await?;
+
     // Add builtins.
-    let shell = shell.default_builtins(builtin_set).brush_builtins();
+    brush_builtins::register_default_builtins(&mut shell, builtin_set);
+    crate::brushctl::register_brush_builtins(&mut shell);
 
     // Add experimental builtins (if enabled).
     #[cfg(feature = "experimental-builtins")]
-    let shell = shell.experimental_builtins();
-
-    // Build the shell.
-    let mut shell = shell.build().await?;
+    brush_experimental_builtins::register_experimental_builtins(&mut shell);
 
     // Make adjustments.
     if let Some(xtrace_file_path) = &args.xtrace_file_path {

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Result;
 use assert_fs::prelude::*;
-use brush_builtins::ShellBuilderExt;
+use brush_builtins::ShellExt;
 use std::path::PathBuf;
 
 struct TestShellWithBashCompletion {
@@ -22,9 +22,9 @@ impl TestShellWithBashCompletion {
         let mut shell = brush_core::Shell::builder()
             .profile(brush_core::ProfileLoadBehavior::Skip)
             .rc(brush_core::RcLoadBehavior::Skip)
-            .default_builtins(brush_builtins::BuiltinSet::BashMode)
             .build()
             .await?;
+        shell.register_default_builtins(brush_builtins::BuiltinSet::BashMode);
 
         let temp_dir = assert_fs::TempDir::new()?;
         let bash_completion_script_path = Self::find_bash_completion_script()?;
@@ -416,9 +416,9 @@ async fn interactive_completion_sets_comp_key_and_comp_type() -> Result<()> {
     let mut shell = brush_core::Shell::builder()
         .profile(brush_core::ProfileLoadBehavior::Skip)
         .rc(brush_core::RcLoadBehavior::Skip)
-        .default_builtins(brush_builtins::BuiltinSet::BashMode)
         .build()
         .await?;
+    shell.register_default_builtins(brush_builtins::BuiltinSet::BashMode);
 
     // Register a completion function that captures COMP_KEY and COMP_TYPE.
     let exec_params = shell.default_exec_params();
@@ -474,9 +474,9 @@ impl TestShellNative {
         let mut shell = brush_core::Shell::builder()
             .profile(brush_core::ProfileLoadBehavior::Skip)
             .rc(brush_core::RcLoadBehavior::Skip)
-            .default_builtins(brush_builtins::BuiltinSet::BashMode)
             .build()
             .await?;
+        shell.register_default_builtins(brush_builtins::BuiltinSet::BashMode);
 
         let temp_dir = assert_fs::TempDir::new()?;
         shell.set_working_dir(temp_dir.path())?;

--- a/docs/design-shared-state.md
+++ b/docs/design-shared-state.md
@@ -1,0 +1,464 @@
+# Shared State for brush-core Builtins
+
+## Goal
+
+Add type-safe shared state to brush-core's builtin system, allowing multiple
+builtins (e.g. `inherit`, `has_version`) to share state (e.g. an eclass AST
+cache) across a shell and its clones.
+
+## Current State
+
+- `Command::State` — per-builtin, string-keyed, seeded by `state_init` fn pointer
+- `Registration<SE>` — carries `state_init`, no shared state concept
+- `register_builtin` / `register_builtin_with_state` — two registration paths
+- Shared state not needed by existing brush builtins; needed by portage-repo
+
+## Command Trait (updated)
+
+```rust
+pub trait Command: clap::Parser {
+    type Error: BuiltinError + 'static;
+    type State: Clone + Default + Send + Sync + 'static = ();
+    type SharedState: Clone + Send + Sync + 'static = ();
+    // ... existing methods ...
+
+    // New convenience method
+    fn shared<'a, SE: ShellExtensions>(
+        &self,
+        ctx: &'a ExecutionContext<'_, SE>,
+    ) -> Result<&'a Self::SharedState, Error> {
+        ctx.shared::<Self::SharedState>()
+    }
+}
+```
+
+- `SharedState` does NOT require `Default` — value always provided by caller
+- `SharedState = ()` (the default) means "no shared state"
+
+## Factory Function
+
+```rust
+pub fn builtin<B, SE>() -> Registration<SE, B::SharedState>
+where
+    B: Command + Send + Sync,
+    SE: ShellExtensions,
+```
+
+The return type's phantom parameter encodes `B::SharedState`:
+- `B::SharedState = ()` → `Registration<SE, ()>` → accepted by `register_builtin`
+- `B::SharedState = Arc<RepoCache>` → `Registration<SE, Arc<RepoCache>>` → **rejected** by `register_builtin`
+
+Same for `simple_builtin`, `decl_builtin`, `raw_arg_builtin` — all gain the phantom.
+
+## Registration Type
+
+```rust
+pub struct Registration<SE: ShellExtensions, S = ()> {
+    pub execute_func: CommandExecuteFunc<SE>,
+    pub content_func: CommandContentFunc,
+    pub disabled: bool,
+    pub special_builtin: bool,
+    pub declaration_builtin: bool,
+    pub state_init: fn() -> Box<dyn AnyState>,
+    _shared: PhantomData<S>,
+}
+```
+
+The phantom `S` is for compile-time routing only. When stored in
+`Shell.builtins`, the phantom is erased (see Storage section below).
+
+### Clone impl
+
+```rust
+impl<SE: ShellExtensions, S> Clone for Registration<SE, S> {
+    fn clone(&self) -> Self {
+        Self {
+            execute_func: self.execute_func,
+            content_func: self.content_func,
+            disabled: self.disabled,
+            special_builtin: self.special_builtin,
+            declaration_builtin: self.declaration_builtin,
+            state_init: self.state_init,
+            _shared: PhantomData,
+        }
+    }
+}
+```
+
+### `.special()` preserved
+
+```rust
+impl<SE: ShellExtensions, S> Registration<SE, S> {
+    pub const fn special(self) -> Self { /* same fields, PhantomData */ }
+}
+```
+
+## Storage on Shell
+
+```rust
+// shell.rs
+pub struct Shell<SE: ShellExtensions = DefaultShellExtensions> {
+    // ... existing fields ...
+    builtins: HashMap<String, ErasedRegistration<SE>>,
+    builtin_states: HashMap<String, Box<dyn AnyState>>,
+    shared_states: HashMap<TypeId, Box<dyn AnyState>>,  // NEW
+}
+```
+
+### ErasedRegistration
+
+Since `builtins` stores registrations after the phantom is erased:
+
+```rust
+// Type-erased registration for storage
+pub struct ErasedRegistration<SE: ShellExtensions> {
+    pub execute_func: CommandExecuteFunc<SE>,
+    pub content_func: CommandContentFunc,
+    pub disabled: bool,
+    pub special_builtin: bool,
+    pub declaration_builtin: bool,
+}
+```
+
+Or simpler: just keep `Registration<SE, ()>` as the stored type (phantom = ()
+means nothing). The phantom is only meaningful at the factory/registration
+boundary.
+
+**Decision needed**: `ErasedRegistration` vs `Registration<SE, ()>` for storage.
+
+### Shell::clone()
+
+```rust
+// shared_states cloned via Box<dyn AnyState>::clone_box()
+// Arc<T> clones cheaply (bumps refcount)
+shared_states: self.shared_states
+    .iter()
+    .map(|(k, v)| (k.clone(), v.clone()))
+    .collect(),
+```
+
+## Shell Registration Methods
+
+```rust
+impl<SE: ShellExtensions> Shell<SE> {
+    /// Register a builtin with no shared state.
+    /// Only accepts Registration<SE, ()>.
+    pub fn register_builtin<S>(&mut self, name: S, reg: Registration<SE, ()>)
+    where S: Into<String>
+    {
+        let key = name.into();
+        self.builtins.insert(key.clone(), reg.into_erased());
+        self.builtin_states
+            .entry(key)
+            .or_insert_with(reg.state_init);
+    }
+
+    /// Register a builtin only if no builtin with that name is already registered.
+    pub fn register_builtin_if_unset<S>(&mut self, name: S, reg: Registration<SE, ()>)
+    where S: Into<String>
+    {
+        let key = name.into();
+        if self.builtins.contains_key(&key) { return; }
+        self.register_builtin(key, reg);
+    }
+
+    /// Bulk-register builtins that share state.
+    pub fn register_shared<T>(&mut self, builder: SharedBuilder<T, SE>)
+    where T: Clone + Send + Sync + 'static
+    {
+        self.shared_states.insert(TypeId::of::<T>(), Box::new(builder.value));
+        for (name, reg, local_state) in builder.builtins {
+            let key = name;
+            self.builtins.insert(key.clone(), reg.into_erased());
+            match local_state {
+                Some(state) => { self.builtin_states.insert(key, state); }
+                None => { self.builtin_states.entry(key).or_insert_with(reg.state_init); }
+            }
+        }
+    }
+
+    /// Get a handle to register more builtins against an existing shared state.
+    pub fn shared_handle<T>(&mut self) -> SharedHandle<'_, T, SE>
+    where T: Clone + Send + Sync + 'static
+    {
+        SharedHandle { shell: self, _phantom: PhantomData }
+    }
+}
+```
+
+### Removed methods
+
+- `register_builtin_with_state` — unnecessary. Local state is seeded by
+  `state_init` (default). Custom local state for shared builtins goes through
+  `SharedBuilder::builtin_with_state`.
+
+## SharedBuilder (consuming, like ShellBuilder)
+
+```rust
+pub struct SharedBuilder<T, SE: ShellExtensions = DefaultShellExtensions> {
+    value: T,
+    builtins: Vec<(String, Registration<SE, T>, Option<Box<dyn AnyState>>)>,
+}
+
+impl<T: Clone + Send + Sync + 'static, SE: ShellExtensions> SharedBuilder<T, SE> {
+    pub fn new(value: T) -> Self {
+        Self { value, builtins: Vec::new() }
+    }
+
+    /// Add a builtin that shares state type T.
+    /// Compile error if Registration's shared type != T.
+    pub fn builtin(mut self, name: impl Into<String>, reg: Registration<SE, T>) -> Self {
+        self.builtins.push((name.into(), reg, None));
+        self
+    }
+
+    /// Add a builtin with a custom local state override.
+    pub fn builtin_with_state<S>(
+        mut self,
+        name: impl Into<String>,
+        reg: Registration<SE, T>,
+        state: S,
+    ) -> Self
+    where S: Clone + Send + Sync + 'static
+    {
+        self.builtins.push((name.into(), reg, Some(Box::new(state))));
+        self
+    }
+}
+```
+
+Consumed by `shell.register_shared(builder)`. No `let mut` needed.
+
+## SharedHandle (&mut shell, registers immediately)
+
+```rust
+pub struct SharedHandle<'a, T, SE: ShellExtensions> {
+    shell: &'a mut Shell<SE>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Clone + Send + Sync + 'static, SE: ShellExtensions> SharedHandle<'_, T, SE> {
+    /// Register a builtin against an existing shared state.
+    pub fn builtin(&mut self, name: impl Into<String>, reg: Registration<SE, T>) {
+        let key = name.into();
+        self.shell.builtins.insert(key.clone(), reg.into_erased());
+        self.shell.builtin_states
+            .entry(key)
+            .or_insert_with(reg.state_init);
+    }
+
+    /// Register a builtin with custom local state.
+    pub fn builtin_with_state<S>(
+        &mut self,
+        name: impl Into<String>,
+        reg: Registration<SE, T>,
+        state: S,
+    ) where S: Clone + Send + Sync + 'static
+    {
+        let key = name.into();
+        self.shell.builtins.insert(key.clone(), reg.into_erased());
+        self.shell.builtin_states.insert(key, Box::new(state));
+    }
+}
+```
+
+No terminal method — registers immediately on each call.
+
+## ExecutionContext Accessors
+
+```rust
+impl<SE: ShellExtensions> ExecutionContext<'_, SE> {
+    pub fn shared<T: Clone + Send + Sync + 'static>(&self) -> Result<&T, Error> {
+        self.shell.shared_states
+            .get(&TypeId::of::<T>())
+            .and_then(|s| (**s).as_any().downcast_ref::<T>())
+            .ok_or_else(|| ErrorKind::SharedStateNotRegistered(type_name::<T>()).into())
+    }
+
+    pub fn shared_mut<T: Clone + Send + Sync + 'static>(&mut self) -> Result<&mut T, Error> {
+        let name = type_name::<T>().to_string();
+        self.shell.shared_states
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|s| (**s).as_any_mut().downcast_mut::<T>())
+            .ok_or_else(|| ErrorKind::SharedStateNotRegistered(name).into())
+    }
+}
+```
+
+## Shell Raw Accessors (for direct use, not through builtins)
+
+```rust
+fn set_shared<T: Clone + Send + Sync + 'static>(&mut self, state: T) {
+    self.shared_states.insert(TypeId::of::<T>(), Box::new(state));
+}
+
+fn shared<T: 'static>(&self) -> Option<&T> {
+    self.shared_states
+        .get(&TypeId::of::<T>())
+        .and_then(|s| (**s).as_any().downcast_ref::<T>())
+}
+
+fn shared_mut<T: 'static>(&mut self) -> Option<&mut T> {
+    self.shared_states
+        .get_mut(&TypeId::of::<T>())
+        .and_then(|s| (**s).as_any_mut().downcast_mut::<T>())
+}
+```
+
+## Compile-time Guarantees
+
+| Code | Result |
+|---|---|
+| `register_builtin("die", builtin::<DieCommand, _>())` | ✓ `Registration<SE, ()>` accepted |
+| `register_builtin("inherit", builtin::<InheritCommand, _>())` | ✗ `Registration<SE, Arc<RepoCache>>` rejected — type mismatch |
+| `SharedBuilder.builtin("inherit", builtin::<InheritCommand, _>())` | ✓ types match |
+| `SharedBuilder.builtin("die", builtin::<DieCommand, _>())` | ✗ `Registration<SE, ()>` ≠ `T` — type mismatch |
+| `shared_handle.builtin("inherit", builtin::<InheritCommand, _>())` | ✓ types match |
+| `shared_handle.builtin("die", builtin::<DieCommand, _>())` | ✗ type mismatch |
+
+## Usage in portage-repo
+
+### InheritCommand
+
+```rust
+impl Command for InheritCommand {
+    type State = InheritState;              // per-invocation: inherited list
+    type SharedState = Arc<RepoCache>;      // cross-builtin: eclass AST cache
+
+    async fn execute<SE>(&self, mut ctx: ExecutionContext<'_, SE>) -> ... {
+        let state = self.state_mut::<SE>(&mut ctx)?;
+        let cache = self.shared::<SE>(&ctx)?;
+        // ...
+    }
+}
+```
+
+### Shell setup
+
+```rust
+let cache = SharedBuilder::new(Arc::new(RepoCache::default()))
+    .builtin("inherit", builtin::<InheritCommand, _>());
+//  .builtin("has_version", builtin::<HasVersionCommand, _>());
+shell.register_shared(cache);
+
+shell.register_builtin("die", builtin::<DieCommand, _>());
+shell.register_builtin("use", builtin::<UseCommand, _>());
+// ...
+```
+
+### Subshell behavior
+
+`Arc<RepoCache>` in `shared_states` — `Shell::clone()` calls
+`AnyState::clone_box()` which clones the `Arc` (cheap refcount bump).
+All subshells share the same underlying cache. Interior mutability
+via papaya's lock-free maps.
+
+## Error Type
+
+```rust
+// error.rs
+pub enum ErrorKind {
+    // ... existing variants ...
+    SharedStateNotRegistered(String),
+}
+```
+
+## Documentation Requirements
+
+Heavy doc comments on:
+- `SharedBuilder` — purpose, subshell cloning behavior (`T::clone()`),
+  `Arc<T>` for sharing, interior mutability requirements, newtype pattern
+  for uniqueness
+- `register_shared` — seeds shared state + registers builtins atomically
+- `shared`/`shared_mut` — runtime error if type not registered
+- `set_shared` — for direct use, can override shared state
+- Module-level note: `builtin_states` (per-builtin, string-keyed) vs
+  `shared_states` (cross-builtin, type-keyed via `SharedBuilder`)
+
+### Footguns to document
+
+1. **Bare `T` vs `Arc<T>`**: bare `T` deep-copies on `Shell::clone()` (each
+   subshell gets independent state). `Arc<T>` shares. Use `Arc<T>` when state
+   should be visible across subshells.
+2. **Interior mutability**: `Arc<T>` only gives shared references. To mutate
+   through it, `T` needs interior mutability (e.g., `Mutex`, `papaya::HashMap`,
+   atomics).
+3. **Uniqueness by type**: `TypeId::of::<T>()` is the key. Two unrelated uses
+   of the same generic type (e.g., `HashMap<String, String>`) would collide.
+   Use newtype wrappers for isolation.
+4. **Ordering**: `register_shared` must be called before builtins execute.
+   Accessing unregistered shared state returns a runtime error.
+5. **Re-entrancy**: same rules as `builtin_state_mut` — drop the `&mut`
+   reference before calling back into the shell.
+
+## Tests
+
+- `SharedBuilder::new` + `register_shared` seeds shared state
+- `shared::<T>()` retrieves correct type
+- Two builtins registered through same builder see same shared state
+- `Shell::clone()` shares `Arc<T>` (Arc strong count increases)
+- Type isolation: two `SharedBuilder<T>` with different `T` don't collide
+- Runtime error: accessing unregistered type returns `Err`
+- `set_shared` overwrites previously seeded value
+- `shared_handle` registers against existing shared state
+- `register_builtin` rejects `Registration<SE, NonUnitType>` (compile-time test)
+
+## Files to Modify in brush-core
+
+| File | Change |
+|---|---|
+| `builtins.rs` | `Registration<SE, S>` phantom, factory functions return typed phantoms, add `SharedBuilder`, add `SharedHandle`, `ErasedRegistration` or equivalent |
+| `shell.rs` | `shared_states` field, update `new()` and `clone()`, update `builtins` field type |
+| `shell/builtin_registry.rs` | `register_builtin` accepts `Registration<SE, ()>`, add `register_shared`, `shared_handle`, `set_shared`/`shared`/`shared_mut` |
+| `commands.rs` | `shared`/`shared_mut` on `ExecutionContext` |
+| `shell/builder.rs` | Update `builtins` field type from `HashMap<String, Registration<SE>>` to `HashMap<String, Registration<SE, ()>>` |
+| `error.rs` | `SharedStateNotRegistered` variant |
+| `lib.rs` | Export `SharedBuilder`, `SharedHandle`, `ErasedRegistration` |
+
+## Files to Modify in portage-repo
+
+| File | Change |
+|---|---|
+| `src/shell.rs` | Use `SharedBuilder` for inherit, `register_builtin` for others |
+| `src/inherit.rs` | Remove cache from `InheritState`, use `context.shared()` |
+| New `src/cache.rs` | `RepoCache` struct |
+
+## Backward Compatibility Concerns
+
+- `default_builtins()` returns `HashMap<String, Registration<SE, ()>>` instead
+  of `HashMap<String, Registration<SE>>`. All callers must be updated.
+- `ShellBuilder::builtin(name, reg)` — `builtins` field type changes.
+- `ShellBuilder::builtins(iter)` — same.
+- `.clone()` on `Registration` — phantom must be preserved.
+- All `impl Command` blocks that set `type SharedState = ()` explicitly —
+  not needed, `()` is the default. But if they already exist (from the
+  stateful-builtins PR), they're fine.
+
+## What Was Removed
+
+- `register_builtin_with_state` — unnecessary. Local state seeded by `state_init`
+  (default). Custom local state for shared builtins goes through
+  `SharedBuilder::builtin_with_state`.
+- `with_shared()` on Registration — loophole that bypasses SharedBuilder.
+- `with_state()` on Registration — not needed. Custom local state goes through
+  `SharedBuilder::builtin_with_state` or `SharedHandle::builtin_with_state`.
+- `NeedsLocal` typestate — local state is always optional, handled by
+  `state_init` default or explicit override in SharedBuilder/SharedHandle.
+- `local_state_override` field on Registration — carried internally by
+  SharedBuilder instead.
+
+## Key Decisions
+
+1. **Phantom on `Registration`** encodes shared state type for compile-time
+   routing. Stored erased in `Shell.builtins`.
+2. **`SharedBuilder` is consuming** (like `ShellBuilder`) — no `let mut`.
+3. **`SharedHandle` borrows `&mut Shell`** — registers immediately, no terminal
+   method.
+4. **No `with_shared()`** — forces all shared-state registration through
+   `SharedBuilder` or `SharedHandle`.
+5. **No `register_builtin_with_state`** — local state always seeded by default
+   or through builder/handle methods.
+6. **`AnyState` trait unchanged** — blanket impl handles all types including
+   `Arc<T>`.
+7. **`TypeId` as key** — not `type_name`. Zero-cost, collision-free.
+   But doesn't support trait objects (acceptable).


### PR DESCRIPTION
## Summary

Closes #1149

Adds a per-builtin state mechanism so builtins can carry typed Rust state that persists across invocations within a shell instance, without resorting to hidden shell variables or global mutable state.

### Infrastructure (`bb64b510`)

- **`AnyState` trait** with blanket impl for `Clone + Send + Sync + 'static` types — any suitable struct can be stored as builtin state with zero boilerplate
- **`Command::State` associated type** on the existing `Command` trait — defaults to `()` for all 53 existing builtins (no behavior change)
- **`Command::state()` / `state_mut()` ergonomic helpers** — builtins call `self.state(&context)?` with no turbofish
- **`state_init` fn pointer on `Registration`** — seeded automatically when builtins are registered via `Shell::register_builtin` or `Shell::new`
- **`builtin_states: HashMap<String, Box<dyn AnyState>>`** on `Shell` with typed accessors (`builtin_state_of::<B>`, `builtin_state_mut::<B>`, `builtin_state::<T>`, `builtin_state_mut::<T>`)
- **`ExecutionContext` helpers** — `context.builtin_state::<Self>()` / `context.builtin_state_mut::<Self>()`
- **`BuiltinStateNotRegistered` error variant**

> **Note:** `Box<dyn AnyState>` itself satisfies the blanket impl bounds, so all accessors use explicit deref (`**state`) to dispatch through the vtable. The `Clone` impl for `Box<dyn AnyState>` uses the same pattern to avoid infinite recursion. This is documented on the trait.

### Smoke test: getopts conversion (`1e2ed4a3`)

Converts `getopts` from hidden shell variables (`__GETOPTS_NEXT_CHAR`, `__GETOPTS_LAST_OPTIND`) to a typed `GetOptsState` struct:

```rust
#[derive(Clone, Debug)]
pub(crate) struct GetOptsState {
    next_char_index: usize,
    last_optind: Option<i32>,
}
```

Usage pattern — borrow state, copy out, release, do work, borrow mutably, write back:

```rust
let mut next_char_index = {
    let state = self.state(&context)?;
    if state.last_optind == Some(next_index_signed) {
        state.next_char_index
    } else {
        DEFAULT_NEXT_CHAR_INDEX
    }
};
// ... parsing work ...
let state = self.state_mut(&mut context)?;
state.next_char_index = next_char_index;
state.last_optind = Some(result.optind as i32);
```

**Net result:** 48 fewer lines, no hidden variables leaking into the shell environment, type-safe state access.

## Testing

- All 2434 integration tests pass (including 41 getopts compat tests)
- 5 new `AnyState` unit tests (clone roundtrip, mut roundtrip, wrong type, downcast, complex type)
- `cargo clippy`, `cargo fmt --check`, schema check — all clean