### PR TITLE
fix: Trailing path filters glob results

### DIFF
--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -261,13 +261,20 @@ impl Pattern {
                 matches!(piece, PatternPiece::Pattern(_))
                     && requires_expansion(piece.as_str(), self.enable_extended_globbing)
             }) {
-                for p in &mut paths_so_far {
+                paths_so_far.retain_mut(|p| {
                     let flattened = component
                         .iter()
                         .map(|piece| piece.as_str())
                         .collect::<String>();
-                    sys::fs::push_path_for_pattern(p, &flattened);
-                }
+                    let path = p.join(&flattened);
+                    if !path.exists() {
+                        // Not a valid result, don't retain
+                        false
+                    } else {
+                        sys::fs::push_path_for_pattern(p, &flattened);
+                        true
+                    }
+                });
                 continue;
             }
 

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -261,22 +261,21 @@ impl Pattern {
                 matches!(piece, PatternPiece::Pattern(_))
                     && requires_expansion(piece.as_str(), self.enable_extended_globbing)
             }) {
+                let flattened = component
+                    .iter()
+                    .map(|piece| piece.as_str())
+                    .collect::<String>();
                 paths_so_far.retain_mut(|p| {
-                    let flattened = component
-                        .iter()
-                        .map(|piece| piece.as_str())
-                        .collect::<String>();
+                    sys::fs::push_path_for_pattern(p, &flattened);
 
-                    let mut candidate = p.clone();
-                    sys::fs::push_path_for_pattern(&mut candidate, &flattened);
-
-                    if !candidate.exists() {
-                        // Not a valid result, remove from paths_so_far
-                        false
-                    } else {
-                        *p = candidate;
-                        true
-                    }
+                    // Drop candidates that don't name an existing directory entry.
+                    // We use `symlink_metadata` (lstat) rather than `exists` (stat) so
+                    // that we match on directory-entry existence -- consistent with the
+                    // `read_dir`-based matching used for glob components below, and with
+                    // bash. In particular this keeps dangling symlinks (which bash
+                    // includes) while still rejecting a literal like `file/` whose
+                    // trailing slash makes lstat fail with ENOTDIR for a regular file.
+                    p.symlink_metadata().is_ok()
                 });
                 continue;
             }

--- a/brush-core/src/patterns.rs
+++ b/brush-core/src/patterns.rs
@@ -266,12 +266,15 @@ impl Pattern {
                         .iter()
                         .map(|piece| piece.as_str())
                         .collect::<String>();
-                    let path = p.join(&flattened);
-                    if !path.exists() {
-                        // Not a valid result, don't retain
+
+                    let mut candidate = p.clone();
+                    sys::fs::push_path_for_pattern(&mut candidate, &flattened);
+
+                    if !candidate.exists() {
+                        // Not a valid result, remove from paths_so_far
                         false
                     } else {
-                        sys::fs::push_path_for_pattern(p, &flattened);
+                        *p = candidate;
                         true
                     }
                 });

--- a/brush-shell/tests/cases/compat/patterns/filename_expansion.yaml
+++ b/brush-shell/tests/cases/compat/patterns/filename_expansion.yaml
@@ -274,6 +274,28 @@ cases:
       echo */banana.txt
       echo */*.txt
 
+  - name: "Trailing literal keeps dangling symlinks but drops missing"
+    test_files:
+      - path: "a/real.txt"
+      - path: "b/real.txt"
+      - path: "c/other.txt"
+    stdin: |
+      # a/link.txt is a *dangling* symlink: bash's glob matches it (directory-entry
+      # existence, via lstat), so brush must too. b and c have no link.txt and must
+      # be dropped.
+      ln -s nonexistent-target a/link.txt
+      echo "link.txt:" */link.txt
+      echo "real.txt:" */real.txt
+
+  - name: "Trailing literal with directory symlinks"
+    test_files:
+      - path: "realdir/file.txt"
+    stdin: |
+      # A symlink to a directory should be traversed like a real directory.
+      ln -s realdir linkdir
+      ln -s nonexistent danglingdir
+      echo "*/file.txt:" */file.txt
+
   - name: "Globstar disabled by default"
     test_files:
       - path: "a/b/c.txt"

--- a/brush-shell/tests/cases/compat/patterns/filename_expansion.yaml
+++ b/brush-shell/tests/cases/compat/patterns/filename_expansion.yaml
@@ -258,7 +258,6 @@ cases:
       echo $x
 
   - name: "Glob with trailing slash matches directories"
-    known_failure: true
     test_files:
       - path: "mydir/file.txt"
       - path: "myfile.txt"
@@ -266,7 +265,6 @@ cases:
       echo */
 
   - name: "Trailing path filters glob results"
-    known_failure: true
     test_files:
       - path: "README.md"
       - path: "photos/photo.png"
@@ -277,7 +275,6 @@ cases:
       echo */*.txt
 
   - name: "Globstar disabled by default"
-    known_failure: true
     test_files:
       - path: "a/b/c.txt"
     stdin: |

--- a/brush-shell/tests/cases/compat/patterns/filename_expansion.yaml
+++ b/brush-shell/tests/cases/compat/patterns/filename_expansion.yaml
@@ -50,6 +50,20 @@ cases:
       shopt -s nullglob
       echo "*.jpg:" *.jpg
 
+  - name: "Expansion with matches and non-matches in directory"
+    test_files:
+      - path: "dir/file.txt"
+      - path: "dir/file.jpg"
+    stdin: "echo dir/*.jpg"
+
+  - name: "Expansion with matches and non-matches in directory + nullglob"
+    test_files:
+      - path: "dir/file.txt"
+      - path: "dir/file.jpg"
+    stdin: |
+      shopt -s nullglob
+      echo "dir/*.jpg:" dir/*.jpg
+
   - name: "Expansion with special characters"
     test_files:
       - path: "file1.txt"
@@ -250,6 +264,17 @@ cases:
       - path: "myfile.txt"
     stdin: |
       echo */
+
+  - name: "Trailing path filters glob results"
+    known_failure: true
+    test_files:
+      - path: "README.md"
+      - path: "photos/photo.png"
+      - path: "a/apple.txt"
+      - path: "b/banana.txt"
+    stdin: |
+      echo */banana.txt
+      echo */*.txt
 
   - name: "Globstar disabled by default"
     known_failure: true

--- a/brush-shell/tests/cases/compat/word_expansion/tilde.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/tilde.yaml
@@ -139,3 +139,13 @@ cases:
       unset myvar3
       echo "Assign colon-tilde: ${myvar3:=~:~/bin}"
       echo "myvar3 after := ${myvar3}"
+
+  - name: "Tilde expansion in list"
+    known_failure: true
+    env:
+      HOME: .
+    test_files:
+      - path: "file.txt"
+      - path: "file.txt.bak"
+    stdin: |
+      echo ~/{file.txt,file.txt.bak}


### PR DESCRIPTION
This PR removes glob results if they are followed up with a literal.
E.g. the star in `*/file.txt` should only match directories that contain a `file.txt`.

Included is a positive test and regression tests to make sure nothing's removed that shouldn't be.

Also fixes the following tests:
- Glob with trailing slash matches directories
- Globstar disabled by default

I've added a failing test for tilde expansion that I didn't get around to fixing. If it's offtopic, I can remove it.