### PR TITLE
fix(completion): complete commands after pipe and other separators

### DIFF
--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -1146,8 +1146,13 @@ impl Config {
         // See if we can find a completion spec matching the current command.
         let mut found_spec: Option<&Spec> = None;
 
+        // After a command separator the next token is in command position,
+        // regardless of its index in the flat token list.
+        let after_separator = context
+            .preceding_token
+            .is_some_and(|t| matches!(t, "|" | "||" | "&&" | ";" | "&"));
         if let Some(command_name) = context.command_name {
-            if context.token_index == 0 {
+            if context.token_index == 0 || after_separator {
                 if let Some(spec) = &self.initial_word {
                     found_spec = Some(spec);
                 }
@@ -1378,21 +1383,27 @@ async fn get_completions_using_basic_lookup(
         return answer;
     }
 
-    // File completions
-    let mut candidates = get_file_completions(shell, token, false).await;
-
-    // If this appears to be the command token (and if there's *some* prefix without
-    // a path separator) then also consider whether we should search the path for
-    // completions too.
-    // TODO(completions): Do a better job than just checking if index == 0.
-    let is_command_position =
-        context.token_index == 0 && !token.is_empty() && !sys::fs::contains_path_separator(token);
+    // A token is in command position if it is the first token on the line or
+    // immediately follows a command separator (|, ||, &&, ;, &). In that case
+    // complete from $PATH (commands, builtins, functions, aliases) rather than
+    // from $PWD files.
+    let after_separator = context
+        .preceding_token
+        .is_some_and(|t| matches!(t, "|" | "||" | "&&" | ";" | "&"));
+    let is_command_position = !token.is_empty()
+        && !sys::fs::contains_path_separator(token)
+        && (context.token_index == 0 || after_separator);
 
     if is_command_position {
+        let mut candidates = vec![];
         add_command_completions(shell, token, &mut candidates);
         candidates.sort();
+        candidates.dedup();
+        return Answer::Candidates(candidates, ProcessingOptions::default());
     }
 
+    // File completions for argument position.
+    let candidates = get_file_completions(shell, token, false).await;
     Answer::Candidates(candidates, ProcessingOptions::default())
 }
 

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -1156,8 +1156,13 @@ impl Config {
         // See if we can find a completion spec matching the current command.
         let mut found_spec: Option<&Spec> = None;
 
+        // After a command separator the next token is in command position,
+        // regardless of its index in the flat token list.
+        let after_separator = context
+            .preceding_token
+            .is_some_and(|t| matches!(t, "|" | "||" | "&&" | ";" | "&"));
         if let Some(command_name) = context.command_name {
-            if context.token_index == 0 {
+            if context.token_index == 0 || after_separator {
                 if let Some(spec) = &self.initial_word {
                     found_spec = Some(spec);
                 }
@@ -1383,21 +1388,27 @@ async fn get_completions_using_basic_lookup(
         return answer;
     }
 
-    // File completions
-    let mut candidates = get_file_completions(shell, token, false).await;
-
-    // If this appears to be the command token (and if there's *some* prefix without
-    // a path separator) then also consider whether we should search the path for
-    // completions too.
-    // TODO(completions): Do a better job than just checking if index == 0.
-    let is_command_position =
-        context.token_index == 0 && !token.is_empty() && !sys::fs::contains_path_separator(token);
+    // A token is in command position if it is the first token on the line or
+    // immediately follows a command separator (|, ||, &&, ;, &). In that case
+    // complete from $PATH (commands, builtins, functions, aliases) rather than
+    // from $PWD files.
+    let after_separator = context
+        .preceding_token
+        .is_some_and(|t| matches!(t, "|" | "||" | "&&" | ";" | "&"));
+    let is_command_position = !token.is_empty()
+        && !sys::fs::contains_path_separator(token)
+        && (context.token_index == 0 || after_separator);
 
     if is_command_position {
+        let mut candidates = vec![];
         add_command_completions(shell, token, &mut candidates);
         candidates.sort();
+        candidates.dedup();
+        return Answer::Candidates(candidates, ProcessingOptions::default());
     }
 
+    // File completions for argument position.
+    let candidates = get_file_completions(shell, token, false).await;
     Answer::Candidates(candidates, ProcessingOptions::default())
 }
 

--- a/brush-shell/tests/completion_tests.rs
+++ b/brush-shell/tests/completion_tests.rs
@@ -582,3 +582,55 @@ async fn native_complete_path_after_variable() -> Result<()> {
 
     Ok(())
 }
+
+/// Tests that command completion works after a pipe operator (|).
+/// The token after | is in command position and should complete from $PATH
+/// (commands/builtins), not from $PWD files.
+#[tokio::test(flavor = "multi_thread")]
+async fn native_complete_command_after_pipe() -> Result<()> {
+    let mut test_shell = TestShellNative::new().await?;
+
+    // Create a file that starts with "ech" to confirm it is NOT returned.
+    test_shell.temp_dir.child("echoing_file").touch()?;
+
+    let completions = test_shell
+        .complete_end_of_line_full("cat /dev/null | ech")
+        .await?;
+    let results: Vec<String> = completions.candidates.into_iter().collect();
+
+    assert!(
+        results.contains(&"echo".to_string()),
+        "expected 'echo' builtin in completions after pipe, got: {results:?}"
+    );
+    assert!(
+        !results.contains(&"echoing_file".to_string()),
+        "expected $PWD file 'echoing_file' NOT to appear in completions after pipe, got: {results:?}"
+    );
+
+    Ok(())
+}
+
+/// Tests that command completion works after the && operator.
+/// Like pipe, the token after && is in command position and should complete
+/// from $PATH, not from $PWD files.
+#[tokio::test(flavor = "multi_thread")]
+async fn native_complete_command_after_and_operator() -> Result<()> {
+    let mut test_shell = TestShellNative::new().await?;
+
+    // Create a file that starts with "ech" to confirm it is NOT returned.
+    test_shell.temp_dir.child("echoing_file").touch()?;
+
+    let completions = test_shell.complete_end_of_line_full("true && ech").await?;
+    let results: Vec<String> = completions.candidates.into_iter().collect();
+
+    assert!(
+        results.contains(&"echo".to_string()),
+        "expected 'echo' builtin in completions after &&, got: {results:?}"
+    );
+    assert!(
+        !results.contains(&"echoing_file".to_string()),
+        "expected $PWD file 'echoing_file' NOT to appear in completions after &&, got: {results:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Treat tokens that follow `|`, `||`, `&&`, `;`, or `&` as command position in `Config::get_completions` and `get_completions_using_basic_lookup`, so they complete from `$PATH` (commands, builtins, functions, aliases) instead of `$PWD` files.
- Previously only the token at index 0 was treated as command position, so `cat /dev/null | ec<TAB>` would offer file matches (e.g. `echoing_file`) rather than `echo`.
- Add integration tests covering completion after `|` and `&&`, asserting that the builtin appears and a same-prefix file in `$PWD` does not.

## Known limitations

- Coloring of these commands is not addressed in this PR.
- Completion still differs from bash in some argument-position cases. For example, `grep ec<TAB>`: bash performs no completion (grep's first argument is a pattern with no completion spec), while brush falls back to `$PATH` completion.


## Validation

- `cargo test -p brush-shell --test brush-completion-tests native_complete_command_after_pipe`
- `cargo test -p brush-shell --test brush-completion-tests native_complete_command_after_and_operator`
- `cargo clippy -p brush-core --all-targets`
- `cargo +nightly fmt -- $(git diff --name-only HEAD -- '*.rs')`

## Manual verification

1. Build this branch: `cargo build --bin brush`.
2. In a directory containing a file like `echoing_file`, launch `./target/debug/brush`.
3. Type `cat /dev/null | ec` and press `<TAB>`, confirm it completes to `echo` and `ecpg`.
4. Type `true && ec` and press `<TAB>`, confirm the same behavior.
5. Type `ec` at the start of a line and press `<TAB>` — confirm `echo` and `ecpg` still complete.
