### PR TITLE
fix: syntax highlighting in light mode

### DIFF
--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -5,7 +5,7 @@ mod styles {
     use super::{Color, Style};
 
     pub fn default() -> Style {
-        Style::new().fg(Color::White)
+        Style::new().fg(Color::Default)
     }
 
     pub fn comment() -> Style {
@@ -29,7 +29,7 @@ mod styles {
     }
 
     pub fn operator() -> Style {
-        Style::new().fg(Color::White).italic()
+        Style::new().fg(Color::Default).italic()
     }
 
     pub fn assignment() -> Style {
@@ -37,7 +37,7 @@ mod styles {
     }
 
     pub fn hyphen_option() -> Style {
-        Style::new().fg(Color::White).italic()
+        Style::new().fg(Color::Default).italic()
     }
 
     pub fn function() -> Style {
@@ -65,7 +65,7 @@ mod styles {
     }
 
     pub fn unknown_command() -> Style {
-        Style::new().bold().fg(Color::White)
+        Style::new().bold().fg(Color::Default)
     }
 }
 


### PR DESCRIPTION
Fixes unreadable text in light mode (sue me!) by changing from `Color::White` to `Color::Default`:
<img width="1095" height="379" alt="image" src="https://github.com/user-attachments/assets/a41ff279-6542-4f3d-a7fa-c04567eb85db" />

Dark mode still works as before:
<img width="1095" height="379" alt="image" src="https://github.com/user-attachments/assets/012fed0e-d9e9-45d8-a5ef-4645bbbccdb3" />
