### PR TITLE
fix(prompt): apply double-quote escape rules in prompt expansion

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -25,6 +25,27 @@ use crate::variables::ShellValueUnsetType;
 use crate::variables::ShellVariable;
 use crate::variables::{self, ShellValue};
 
+/// Controls how the expander handles a backslash-escape sequence (`\X`)
+/// when it appears outside any explicit quoting (single, double, ANSI-C).
+/// Inside actual double-quoted text, the parser's own escape rules apply
+/// and this setting is ignored.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum UnquotedBackslashHandling {
+    /// Default unquoted shell semantics: the backslash is consumed and `X`
+    /// is preserved literally.
+    #[default]
+    Strip,
+    /// The backslash and `X` are both preserved verbatim. Useful in pattern
+    /// contexts where the matcher will interpret the backslash itself.
+    Preserve,
+    /// Treat `\X` as if it were inside a double-quoted string: the backslash
+    /// is consumed only when `X` is one of the characters that double-quote
+    /// syntax treats as escapable; otherwise both characters are preserved.
+    /// A backslash followed by a literal newline is a line continuation
+    /// (both characters are consumed). Used by prompt-string expansion.
+    DoubleQuoted,
+}
+
 /// Options to customize the behavior of the word expander.
 pub(crate) struct ExpanderOptions {
     /// Whether to perform tilde-expansion.
@@ -37,6 +58,9 @@ pub(crate) struct ExpanderOptions {
     /// Whether to perform pathname expansion (globbing). If disabled, glob patterns
     /// are returned as literal strings.
     pub pathname_expand: bool,
+    /// How to handle backslash-escape sequences encountered outside of any
+    /// explicit quoting. See [`UnquotedBackslashHandling`] for details.
+    pub unquoted_backslash_handling: UnquotedBackslashHandling,
 }
 
 impl Default for ExpanderOptions {
@@ -46,9 +70,17 @@ impl Default for ExpanderOptions {
             brace_expand: true,
             execute_command_substitutions: true,
             pathname_expand: true,
+            unquoted_backslash_handling: UnquotedBackslashHandling::default(),
         }
     }
 }
+
+/// The set of characters that, when preceded by a backslash inside a
+/// double-quoted string, form a valid escape sequence (the backslash is
+/// consumed). Any other character's backslash is preserved literally.
+/// Newline is a special case: `\<newline>` is a line continuation and
+/// consumes both characters, leaving nothing.
+pub(crate) const DOUBLE_QUOTED_ESCAPE_CHARS: &[char] = &['\\', '$', '`', '"', '\n'];
 
 #[derive(Debug)]
 struct Expansion {
@@ -333,11 +365,13 @@ pub(crate) async fn basic_expand_pattern(
     params: &ExecutionParameters,
     word_str: impl AsRef<str>,
 ) -> Result<patterns::Pattern, error::Error> {
-    let mut expander = WordExpander::new(shell, params);
-
     // When expanding patterns, we do not want backslash removal to occur in unquoted
     // contexts, as that would interfere with pattern syntax.
-    expander.disable_unquoted_backslash_removal = true;
+    let options = ExpanderOptions {
+        unquoted_backslash_handling: UnquotedBackslashHandling::Preserve,
+        ..Default::default()
+    };
+    let mut expander = WordExpander::new_from_options(shell, params, &options);
 
     expander.basic_expand_pattern(word_str.as_ref()).await
 }
@@ -504,10 +538,11 @@ struct WordExpander<'a, SE: extensions::ShellExtensions> {
     disable_brace_expansion: bool,
     /// Whether to disable command substitutions.
     disable_command_substitutions: bool,
-    /// Whether to disable backslash removal in unquoted contexts.
-    disable_unquoted_backslash_removal: bool,
     /// Whether to disable pathname expansion (globbing).
     disable_pathname_expansion: bool,
+    /// How to handle backslash-escape sequences encountered outside of any
+    /// explicit quoting. See [`UnquotedBackslashHandling`] for details.
+    unquoted_backslash_handling: UnquotedBackslashHandling,
     /// Whether we are currently expanding inside a double-quoted context.
     in_double_quotes: bool,
     /// Whether to use heredoc expansion semantics (literal quotes, no brace expansion).
@@ -523,8 +558,8 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
             parser_options,
             disable_brace_expansion: false,
             disable_command_substitutions: false,
-            disable_unquoted_backslash_removal: false,
             disable_pathname_expansion: false,
+            unquoted_backslash_handling: UnquotedBackslashHandling::Strip,
             in_double_quotes: false,
             heredoc_mode: false,
         }
@@ -548,8 +583,8 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
             parser_options,
             disable_brace_expansion: !options.brace_expand,
             disable_command_substitutions: !options.execute_command_substitutions,
-            disable_unquoted_backslash_removal: false,
             disable_pathname_expansion: !options.pathname_expand,
+            unquoted_backslash_handling: options.unquoted_backslash_handling,
             in_double_quotes: false,
             heredoc_mode: false,
         }
@@ -933,19 +968,43 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                 Expansion::from(ExpansionPiece::Splittable(cmd_output))
             }
             brush_parser::word::WordPiece::EscapeSequence(s) => {
-                if let Some(escaped) = s.strip_prefix('\\') {
-                    // If we are *not* in a double-quoted context and we were requested to skip
-                    // unquoted backslash removal, then we need to skip removing backslashes here.
-                    if !self.in_double_quotes && self.disable_unquoted_backslash_removal {
-                        return Ok(Expansion::from(ExpansionPiece::Splittable(s)));
-                    }
-
-                    // Otherwise, we expect a backslash here; remove it.
-                    Expansion::from(ExpansionPiece::Unsplittable(escaped.to_owned()))
-                } else {
+                let Some(escaped) = s.strip_prefix('\\') else {
                     // We don't ever expect this case, as it breaks our invariant--but
                     // we handle it to avoid panicking.
-                    Expansion::from(ExpansionPiece::Unsplittable(s))
+                    return Ok(Expansion::from(ExpansionPiece::Unsplittable(s)));
+                };
+
+                // Inside actual double-quoted text, the parser only emits an
+                // EscapeSequence for `\X` where X is double-quote-escapable;
+                // we always strip the backslash there.
+                if self.in_double_quotes {
+                    return Ok(Expansion::from(ExpansionPiece::Unsplittable(
+                        escaped.to_owned(),
+                    )));
+                }
+
+                match self.unquoted_backslash_handling {
+                    UnquotedBackslashHandling::Strip => {
+                        // Default unquoted semantics: consume the backslash.
+                        Expansion::from(ExpansionPiece::Unsplittable(escaped.to_owned()))
+                    }
+                    UnquotedBackslashHandling::Preserve => {
+                        // Preserve `\X` verbatim (e.g., for pattern syntax).
+                        Expansion::from(ExpansionPiece::Splittable(s))
+                    }
+                    UnquotedBackslashHandling::DoubleQuoted => {
+                        // `\<newline>` is a line continuation: both characters
+                        // are consumed.
+                        if escaped.starts_with('\n') {
+                            Expansion::from(ExpansionPiece::Unsplittable(String::new()))
+                        } else if escaped.starts_with(DOUBLE_QUOTED_ESCAPE_CHARS) {
+                            // Consume the backslash; preserve the next char.
+                            Expansion::from(ExpansionPiece::Unsplittable(escaped.to_owned()))
+                        } else {
+                            // Preserve both characters.
+                            Expansion::from(ExpansionPiece::Unsplittable(s))
+                        }
+                    }
                 }
             }
             brush_parser::word::WordPiece::ArithmeticExpression(e) => Expansion::from(

--- a/brush-core/src/prompt.rs
+++ b/brush-core/src/prompt.rs
@@ -20,15 +20,19 @@ pub(crate) async fn expand_prompt(
     // Now, render each piece.
     let mut formatted_prompt = String::new();
     for piece in prompt_pieces {
-        let needs_escaping = matches!(
-            piece,
-            brush_parser::prompt::PromptPiece::EscapedSequence(_)
-                | brush_parser::prompt::PromptPiece::DollarOrPound
-        );
+        // Pieces that semantically represent a literal char (e.g. user wrote
+        // `\$` meaning a literal `$`, not input for pass-2 expansion). We
+        // prepend a `\` so pass 2 consumes it and leaves the char alone.
+        let semantically_literal = matches!(piece, brush_parser::prompt::PromptPiece::DollarOrPound);
 
         let formatted_piece = format_prompt_piece(shell, piece)?;
 
-        if shell.options().expand_prompt_strings && needs_escaping {
+        // Only useful when pass 2 actually consumes a `\` for that leading
+        // byte; otherwise the `\` would leak through.
+        if shell.options().expand_prompt_strings
+            && semantically_literal
+            && formatted_piece.starts_with(expansion::DOUBLE_QUOTED_ESCAPE_CHARS)
+        {
             formatted_prompt.push('\\');
         }
 
@@ -37,8 +41,12 @@ pub(crate) async fn expand_prompt(
 
     if shell.options().expand_prompt_strings {
         // Now expand any remaining escape sequences, but without tilde-expansion.
+        // Use double-quote escape rules so that backslashes emitted in the
+        // previous step survive intact unless they precede a character that
+        // would also be escapable inside a double-quoted string.
         let options = expansion::ExpanderOptions {
             tilde_expand: false,
+            unquoted_backslash_handling: expansion::UnquotedBackslashHandling::DoubleQuoted,
             ..Default::default()
         };
         formatted_prompt =

--- a/brush-core/src/prompt.rs
+++ b/brush-core/src/prompt.rs
@@ -23,7 +23,8 @@ pub(crate) async fn expand_prompt(
         // Pieces that semantically represent a literal char (e.g. user wrote
         // `\$` meaning a literal `$`, not input for pass-2 expansion). We
         // prepend a `\` so pass 2 consumes it and leaves the char alone.
-        let semantically_literal = matches!(piece, brush_parser::prompt::PromptPiece::DollarOrPound);
+        let semantically_literal =
+            matches!(piece, brush_parser::prompt::PromptPiece::DollarOrPound);
 
         let formatted_piece = format_prompt_piece(shell, piece)?;
 

--- a/brush-shell/tests/cases/compat/prompt.yaml
+++ b/brush-shell/tests/cases/compat/prompt.yaml
@@ -198,3 +198,138 @@ cases:
     stdin: |
       prompt='\[$var\]\u > '
       echo "Prompt: ${prompt@P}"
+
+  # The following cases exercise double-quote escape semantics in the second
+  # pass of prompt expansion: a backslash only escapes (and is consumed by)
+  # one of the same characters it would escape inside a double-quoted string;
+  # for any other character, the backslash is preserved literally.
+  #
+  # We pipe the expansion result through hexdump -C to get a deterministic
+  # byte-level view, avoiding any divergence in `printf '%q'` formatting.
+  - name: "Backslash-CR survives prompt expansion (issue #1119)"
+    stdin: |
+      # OSC 133;C followed by ST (\e\\) and CR. The ST must end with a literal
+      # backslash byte (0x5c); without it, the OSC is malformed and terminals
+      # may eat the first character of subsequent output.
+      prompt='\e]133;C\e\\\r'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Backslash before non-special char preserves backslash"
+    stdin: |
+      # Under double-quote escape rules, a backslash before a non-special
+      # character is preserved literally. \\X (raw) = '\' + 'X' should expand
+      # to literal '\X'.
+      prompt='\\X'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      prompt='\\Z'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      prompt='\\n'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      prompt=$'\\\\\t'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Backslash before dollar escapes parameter expansion"
+    stdin: |
+      # `\\$VAR` (PS0 raw chars: \\, $, V, A, R) → step 1 produces \$VAR, then
+      # step 2's `\$` consumes the backslash and leaves a literal $, so $VAR
+      # remains literal (not expanded).
+      var=hello
+      prompt='\\$var'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Double backslash before dollar yields backslash + expansion"
+    stdin: |
+      # `\\\\$VAR` → step 1 produces \\$VAR, then step 2's `\\` reduces to a
+      # literal `\` and `$VAR` is expanded normally.
+      var=hello
+      prompt='\\\\$var'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Backslash before escaped dollar"
+    stdin: |
+      # `\\\$` → step 1 produces \$ (Backslash + DollarOrPound). Step 2 keeps
+      # the literal backslash and the literal $, so the result is `\$`.
+      prompt='\\\$'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Many backslashes before non-special"
+    stdin: |
+      # Each `\\` in step 1 produces a literal `\`. Step 2 reduces consecutive
+      # backslashes pairwise.
+      prompt='\\\\\\\\X'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      prompt=$'\\\\\\\\\r'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Backslash before newline is line continuation"
+    stdin: |
+      # `\\\n` produces (Backslash, Newline) → \<LF> in formatted prompt.
+      # In double-quote escape rules, \<newline> is line continuation and
+      # consumes both characters.
+      prompt='\\\n'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      # Same expected behavior when the LF byte is supplied directly.
+      prompt=$'\\\\\n'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Trailing literal backslash survives"
+    stdin: |
+      # `\\` at end of prompt should produce a single literal backslash.
+      prompt='\\'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      # `\\X\\` should produce `\X\`.
+      prompt='\\X\\'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Backslash followed by working-dir prompt piece"
+    stdin: |
+      # Make sure prompt pieces whose formatted output happens to contain `\`
+      # (e.g., AsciiCharacter for octal `\134`) survive intact.
+      prompt='\134'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      # `\\\w` should yield `\<cwd>`. Use a fixed cwd so brush vs. oracle
+      # output is deterministic.
+      cd /
+      prompt='\\\w'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+  - name: "Bare \\$ leaves no protective backslash (issue #1167)"
+    stdin: |
+      # `\$` alone must format to a bare `$` or `#` — pass 1's protective `\`
+      # must not leak when the resulting char (e.g. `#` for root) isn't
+      # double-quote-escapable.
+      prompt='\$'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      # Same in a context where promptvars would otherwise re-expand a bare $:
+      var=SHOULD_NOT_APPEAR
+      prompt='\$var'
+      shopt -s promptvars
+      printf '%s' "${prompt@P}" | hexdump -C
+      shopt -u promptvars
+
+  - name: "Backslash adjacent to unrecognized escape sequence"
+    stdin: |
+      # `\\\X` (Backslash + EscapedSequence(\X)) must reduce to a single `\X`.
+      # An over-eager protective `\` on the EscapedSequence would leak (X
+      # isn't dq-escapable) and emit `\\X`.
+      prompt='\\\X'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      prompt='\\\?'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      # X here is dq-escapable, so pass 2 consumes the EscapedSequence's own
+      # `\` and emits just the literal char.
+      prompt='\"'
+      printf '%s' "${prompt@P}" | hexdump -C
+
+      prompt='\`'
+      printf '%s' "${prompt@P}" | hexdump -C


### PR DESCRIPTION
When expanding prompt strings (i.e., `PS0`/`PS1`/`PS2`/`PS4` and `${var@P}`), the second pass that handles `$var`, etc. should follow double-quote escape rules.

Fixes: #1119 