### PR TITLE
fix(wait): don't print job status in wait builtin

### DIFF
--- a/brush-builtins/src/wait.rs
+++ b/brush-builtins/src/wait.rs
@@ -64,14 +64,9 @@ impl builtins::Command for WaitCommand {
                 }
             }
         } else {
-            // Wait for all jobs.
-            let jobs = context.shell.jobs_mut().wait_all().await?;
-
-            if context.shell.options().enable_job_control {
-                for job in jobs {
-                    writeln!(context.stdout(), "{job}")?;
-                }
-            }
+            // Wait for all jobs but produce no output. Job notices are emitted
+            // separately by the interactive prompt cycle.
+            let _ = context.shell.jobs_mut().wait_all().await?;
         }
 
         Ok(result)

--- a/brush-shell/tests/cases/compat/builtins/wait.yaml
+++ b/brush-shell/tests/cases/compat/builtins/wait.yaml
@@ -33,6 +33,31 @@ cases:
       wait
       echo "after wait all"
 
+  - name: "wait is silent for top-level background job with job control"
+    args:
+      - "-c"
+      - |
+        set -m
+        echo hello &
+        wait
+        echo after
+
+  - name: "wait is silent for background jobs in a subshell piped to a filter"
+    args:
+      - "-c"
+      - |
+        set -m
+        ( for i in 1 2 3; do echo "item-$i" & done; wait ) | sort
+
+  - name: "wait is silent for backgrounded brace group with job control"
+    args:
+      - "-c"
+      - |
+        set -m
+        { echo grouped; } &
+        wait
+        echo done
+
   - name: "wait -n not implemented"
     known_failure: true # TODO(builtins): wait -n not implemented
     stdin: |


### PR DESCRIPTION
The `wait` builtin printed each completed job to stdout when job control was enabled. bash's `wait` is silent on both stdout and stderr; job-completion notices ("[1]+ Done ...") belong to the interactive prompt cycle, not to `wait`.