### PR TITLE
feat(core): add CommandInterceptor exec/open hook to ShellExtensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bon",
+ "brush-builtins",
  "brush-parser",
  "cached",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bon",
+ "brush-builtins",
  "brush-parser",
  "cached",
  "cfg-if",

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -85,5 +85,10 @@ uuid = { version = "1.23.1", features = ["js"] }
 
 [dev-dependencies]
 anyhow = "1.0.102"
+# Used only by integration tests that need a realistically-populated builtin
+# table (e.g. `echo`, `.`/`source`) to exercise the capability-interceptor
+# hooks. This is a dev-dependency cycle (brush-builtins depends on brush-core),
+# which Cargo permits for dev-dependencies.
+brush-builtins = { version = "^0.2.0", path = "../brush-builtins" }
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 tempfile = "3.27.0"

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -579,6 +579,23 @@ pub(crate) fn execute_external_command(
         })
         .collect::<Vec<_>>();
 
+    // Give the configured command interceptor (capability confinement) a chance
+    // to deny this external spawn. This site is the single funnel for *all*
+    // external commands, including the path-separator branch (e.g. `/bin/rm`,
+    // `./x`) that bypasses PATH and the builtin table, so a policy here cannot
+    // be circumvented by spelling the command differently.
+    {
+        use crate::extensions::CommandInterceptor as _;
+        let hook_args: Vec<String> = cmd_args.iter().map(|s| (*s).clone()).collect();
+        if let extensions::ExecDecision::Deny(reason) = context
+            .shell
+            .command_interceptor()
+            .before_exec(executable_path, hook_args.as_slice())
+        {
+            return Err(error::ErrorKind::ExecDenied(context.command_name.clone(), reason).into());
+        }
+    }
+
     // Before we lose ownership of the open files, figure out if stdin will be a terminal.
     let child_stdin_is_terminal = context
         .try_fd(openfiles::OpenFiles::STDIN_FD)

--- a/brush-core/src/error.rs
+++ b/brush-core/src/error.rs
@@ -318,6 +318,12 @@ pub enum ErrorKind {
     /// A glob pattern failed to match any files (failglob).
     #[error("no match: {0}")]
     NoMatch(String),
+
+    /// Execution of an external command was denied by the configured
+    /// command interceptor (capability confinement). The first field is the
+    /// program; the second is the reason supplied by the interceptor.
+    #[error("{0}: execution denied: {1}")]
+    ExecDenied(String, String),
 }
 
 /// Trait implementable by built-in commands to represent errors.
@@ -363,6 +369,7 @@ impl From<&ErrorKind> for results::ExecutionExitCode {
             ErrorKind::FunctionParseError(..) => Self::InvalidUsage,
             ErrorKind::TestCommandParseError(..) => Self::InvalidUsage,
             ErrorKind::FailedToExecuteCommand(..) => Self::CannotExecute,
+            ErrorKind::ExecDenied(..) => Self::CannotExecute,
             ErrorKind::FunctionNameShadowsSpecialBuiltin { .. } => Self::InvalidUsage,
             ErrorKind::IoError(io_err) => io_err.into(),
             ErrorKind::BuiltinError(inner, ..) => inner.as_exit_code(),

--- a/brush-core/src/extensions.rs
+++ b/brush-core/src/extensions.rs
@@ -1,5 +1,7 @@
 //! Definition of shell behavior traits and defaults.
 
+use std::path::Path;
+
 use crate::{Shell, error, extensions};
 
 /// Trait for static shell extensions. Collects all associated types needed to
@@ -7,21 +9,33 @@ use crate::{Shell, error, extensions};
 pub trait ShellExtensions: Clone + Default + Send + Sync + 'static {
     /// Type of the error behavior implementation.
     type ErrorFormatter: ErrorFormatter;
+
+    /// Type of the command-interceptor (capability-confinement) implementation.
+    ///
+    /// This component allows an embedding host to observe — and optionally
+    /// *deny* — external command execution and file opens as they happen,
+    /// in-process. See [`CommandInterceptor`] for the available hooks.
+    type CommandInterceptor: CommandInterceptor;
 }
 
 /// Shell extensions implementation constructed from component types.
 #[derive(Clone, Default)]
-pub struct ShellExtensionsImpl<EF: ErrorFormatter = DefaultErrorFormatter> {
-    _marker: std::marker::PhantomData<EF>,
+pub struct ShellExtensionsImpl<
+    EF: ErrorFormatter = DefaultErrorFormatter,
+    CI: CommandInterceptor = DefaultCommandInterceptor,
+> {
+    _marker: std::marker::PhantomData<(EF, CI)>,
 }
 
-impl<EF: ErrorFormatter> ShellExtensions for ShellExtensionsImpl<EF> {
+impl<EF: ErrorFormatter, CI: CommandInterceptor> ShellExtensions for ShellExtensionsImpl<EF, CI> {
     type ErrorFormatter = EF;
+    type CommandInterceptor = CI;
 }
 
 /// Default shell extensions implementation.
 /// This is a type alias for the most common shell configuration.
-pub type DefaultShellExtensions = ShellExtensionsImpl<DefaultErrorFormatter>;
+pub type DefaultShellExtensions =
+    ShellExtensionsImpl<DefaultErrorFormatter, DefaultCommandInterceptor>;
 
 /// Trait for defining shell error behaviors.
 pub trait ErrorFormatter: Clone + Default + Send + Sync + 'static {
@@ -46,6 +60,89 @@ pub trait ErrorFormatter: Clone + Default + Send + Sync + 'static {
 pub struct DefaultErrorFormatter;
 
 impl ErrorFormatter for DefaultErrorFormatter {}
+
+/// Decision returned by [`CommandInterceptor::before_exec`] to control whether
+/// an external command is allowed to spawn.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExecDecision {
+    /// Allow the external command to be spawned (the default).
+    Allow,
+    /// Deny the external command. The contained string explains why; it is
+    /// surfaced to the shell as an [`error::Error`] and the command does not
+    /// run.
+    Deny(String),
+}
+
+/// Decision returned by [`CommandInterceptor::before_open`] to control whether
+/// a file may be opened.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OpenDecision {
+    /// Allow the file to be opened (the default).
+    Allow,
+    /// Deny opening the file. The contained string explains why; it is surfaced
+    /// to the shell as an [`error::Error`] and the file is not opened.
+    Deny(String),
+}
+
+/// Trait for intercepting potentially-sensitive shell operations so an
+/// embedding host can apply capability confinement (object-capability style
+/// authority attenuation) *in-process*.
+///
+/// The default implementation ([`DefaultCommandInterceptor`]) allows
+/// everything, making it byte-for-byte equivalent to a shell with no
+/// interceptor at all. Embedders supply their own implementation via the
+/// [`ShellExtensions::CommandInterceptor`] associated type to enforce a policy.
+///
+/// # Why this exists
+///
+/// Without these hooks, a hosting process cannot reliably confine command
+/// execution in-process: a command whose name contains a path separator (e.g.
+/// `/bin/rm` or `./script`) bypasses both the `PATH` search and the builtin
+/// table and is executed directly. [`before_exec`](Self::before_exec) is called
+/// at *every* external-spawn site — including that path-separator branch — so a
+/// policy here cannot be circumvented by spelling the command differently.
+pub trait CommandInterceptor: Clone + Default + Send + Sync + 'static {
+    /// Called immediately before an external command is spawned, at every spawn
+    /// site (including the path-separator branch that bypasses `PATH` and the
+    /// builtin table). Returning [`ExecDecision::Deny`] prevents the command
+    /// from running and fails it with an error.
+    ///
+    /// # Arguments
+    ///
+    /// * `program` - The program that is about to be executed. For commands
+    ///   resolved via `PATH` this is the resolved absolute path; for
+    ///   path-separator commands it is the path as written by the user.
+    /// * `args` - The argument strings that would be passed to the program
+    ///   (not including `argv[0]`).
+    fn before_exec(&self, program: &str, args: &[String]) -> ExecDecision {
+        let _ = (program, args);
+        ExecDecision::Allow
+    }
+
+    /// Called immediately before a file is opened via a filesystem path
+    /// (redirections and `source`/`.`). Returning [`OpenDecision::Deny`]
+    /// prevents the file from being opened and fails the operation with an
+    /// error.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The absolute path that is about to be opened.
+    /// * `write` - Whether the open requests write access (`true`) or is
+    ///   read-only (`false`).
+    fn before_open(&self, path: &Path, write: bool) -> OpenDecision {
+        let _ = (path, write);
+        OpenDecision::Allow
+    }
+}
+
+/// Default command-interceptor implementation: allows all execs and opens.
+///
+/// A shell configured with this interceptor behaves identically to a shell with
+/// no interception at all.
+#[derive(Clone, Default)]
+pub struct DefaultCommandInterceptor;
+
+impl CommandInterceptor for DefaultCommandInterceptor {}
 
 /// Trait for placeholder behavior (stub for future extension).
 pub trait PlaceholderBehavior: Clone + Default + Send + Sync + 'static {}

--- a/brush-core/src/extensions.rs
+++ b/brush-core/src/extensions.rs
@@ -73,6 +73,68 @@ pub enum ExecDecision {
     Deny(String),
 }
 
+/// The access an open request is asking for.
+///
+/// This is the shell's *declared* intent for the open, derived at the call site
+/// (e.g. from the [`brush_parser::ast::IoFileRedirectKind`] of a redirection),
+/// not reverse-engineered from the resulting [`std::fs::OpenOptions`]. It is the
+/// axis a confinement policy selects on: read authority versus write authority.
+///
+/// [`brush_parser::ast::IoFileRedirectKind`]: ../../brush_parser/ast/enum.IoFileRedirectKind.html
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenAccess {
+    /// The file is opened for reading only (`< file`, `source`/`.`).
+    Read,
+    /// The file is opened for writing only, whether by truncation or append
+    /// (`> file`, `>> file`, `>| file`, `&> file`).
+    Write,
+    /// The file is opened for both reading and writing (`<> file`).
+    ReadWrite,
+}
+
+impl OpenAccess {
+    /// Returns whether this access grants the ability to read the file.
+    #[must_use]
+    pub const fn reads(self) -> bool {
+        matches!(self, Self::Read | Self::ReadWrite)
+    }
+
+    /// Returns whether this access grants the ability to modify the file.
+    #[must_use]
+    pub const fn writes(self) -> bool {
+        matches!(self, Self::Write | Self::ReadWrite)
+    }
+}
+
+/// Describes a file open that the shell is about to perform, as presented to
+/// [`CommandInterceptor::before_open`].
+///
+/// The struct is `#[non_exhaustive]` so that further detail can be added later
+/// without breaking implementors; construct one with [`OpenRequest::new`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct OpenRequest<'a> {
+    /// The absolute path that is about to be opened. Already resolved against
+    /// the shell's working directory, but *not* canonicalized — a policy that
+    /// cares about symlink or `..` escapes must canonicalize it itself.
+    pub path: &'a Path,
+    /// The access the shell is requesting.
+    pub access: OpenAccess,
+}
+
+impl<'a> OpenRequest<'a> {
+    /// Creates a new open request.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The absolute path about to be opened.
+    /// * `access` - The access being requested.
+    #[must_use]
+    pub const fn new(path: &'a Path, access: OpenAccess) -> Self {
+        Self { path, access }
+    }
+}
+
 /// Decision returned by [`CommandInterceptor::before_open`] to control whether
 /// a file may be opened.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -126,11 +188,20 @@ pub trait CommandInterceptor: Clone + Default + Send + Sync + 'static {
     ///
     /// # Arguments
     ///
-    /// * `path` - The absolute path that is about to be opened.
-    /// * `write` - Whether the open requests write access (`true`) or is
-    ///   read-only (`false`).
-    fn before_open(&self, path: &Path, write: bool) -> OpenDecision {
-        let _ = (path, write);
+    /// * `request` - What is about to be opened, and with what access. The
+    ///   access is the shell's declared intent, taken from the syntax that
+    ///   requested the open; see [`OpenRequest`].
+    ///
+    /// # Coverage
+    ///
+    /// This fires for every path-based open the shell performs. One documented
+    /// exception exists: platform-specific special files are resolved before
+    /// the path is made absolute, and are not shown to this hook. Today that is
+    /// only `/dev/null` on Windows (mapped to `NUL`); on Unix the special-file
+    /// hook resolves nothing at all. Opens performed by an already-spawned
+    /// external process are outside the shell entirely and never reach here.
+    fn before_open(&self, request: &OpenRequest<'_>) -> OpenDecision {
+        let _ = request;
         OpenDecision::Allow
     }
 }

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -1656,6 +1656,22 @@ pub(crate) async fn setup_redirect(
                         shell.absolute_path(Path::new(expanded_fields.remove(0).as_str()));
 
                     let default_fd_if_unspecified = get_default_fd_for_redirect_kind(kind);
+
+                    // The access this redirection is asking for, taken straight from the
+                    // syntax that requested it. This is what the command interceptor is
+                    // shown; it is deliberately derived from `kind` rather than recovered
+                    // from `options` after the fact.
+                    let access = match kind {
+                        ast::IoFileRedirectKind::Read | ast::IoFileRedirectKind::DuplicateInput => {
+                            extensions::OpenAccess::Read
+                        }
+                        ast::IoFileRedirectKind::Write
+                        | ast::IoFileRedirectKind::Append
+                        | ast::IoFileRedirectKind::Clobber
+                        | ast::IoFileRedirectKind::DuplicateOutput => extensions::OpenAccess::Write,
+                        ast::IoFileRedirectKind::ReadAndWrite => extensions::OpenAccess::ReadWrite,
+                    };
+
                     match kind {
                         ast::IoFileRedirectKind::Read => {
                             options.read(true);
@@ -1705,7 +1721,7 @@ pub(crate) async fn setup_redirect(
                     let fd_num = specified_fd_num.unwrap_or(default_fd_if_unspecified);
 
                     let opened_file = shell
-                        .open_file(&options, &expanded_file_path, params)
+                        .open_file(&options, access, &expanded_file_path, params)
                         .map_err(|err| {
                             error::ErrorKind::RedirectionFailure(
                                 expanded_file_path.to_string_lossy().to_string(),
@@ -1874,7 +1890,12 @@ fn setup_redirect_output_and_error_to(
         .append(append);
 
     let stdout_file = shell
-        .open_file(&file_options, &abs_file_path, params)
+        .open_file(
+            &file_options,
+            extensions::OpenAccess::Write,
+            &abs_file_path,
+            params,
+        )
         .map_err(|err| {
             error::ErrorKind::RedirectionFailure(
                 abs_file_path.to_string_lossy().to_string(),

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -61,6 +61,13 @@ pub struct Shell<SE: extensions::ShellExtensions = extensions::DefaultShellExten
     #[cfg_attr(feature = "serde", serde(skip, default = "default_error_formatter"))]
     error_formatter: SE::ErrorFormatter,
 
+    /// Injected command interceptor (capability confinement) behavior.
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip, default = "default_command_interceptor")
+    )]
+    command_interceptor: SE::CommandInterceptor,
+
     /// Trap handler configuration for the shell.
     traps: crate::traps::TrapHandlerConfig,
 
@@ -151,6 +158,7 @@ impl<SE: extensions::ShellExtensions> Clone for Shell<SE> {
     fn clone(&self) -> Self {
         Self {
             error_formatter: self.error_formatter.clone(),
+            command_interceptor: self.command_interceptor.clone(),
             traps: self.traps.clone(),
             open_files: self.open_files.clone(),
             working_dir: self.working_dir.clone(),
@@ -214,6 +222,7 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
         // Instantiate the shell with some defaults.
         let mut shell = Self {
             error_formatter: options.error_formatter,
+            command_interceptor: options.command_interceptor,
             open_files: openfiles::OpenFiles::new(),
             options: runtime_options,
             name: options.shell_name,
@@ -350,6 +359,14 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
 
     pub(crate) const fn last_exit_status_change_count(&self) -> usize {
         self.last_exit_status_change_count
+    }
+
+    /// Returns a reference to the shell's configured command interceptor
+    /// (capability-confinement) behavior. Hosts rarely need to call this
+    /// directly; the shell consults it automatically before spawning external
+    /// commands and opening files.
+    pub const fn command_interceptor(&self) -> &SE::CommandInterceptor {
+        &self.command_interceptor
     }
 }
 
@@ -550,4 +567,9 @@ impl<SE: extensions::ShellExtensions> ShellState for Shell<SE> {
 #[cfg(feature = "serde")]
 fn default_error_formatter<EF: extensions::ErrorFormatter>() -> EF {
     EF::default()
+}
+
+#[cfg(feature = "serde")]
+fn default_command_interceptor<CI: extensions::CommandInterceptor>() -> CI {
+    CI::default()
 }

--- a/brush-core/src/shell/builder.rs
+++ b/brush-core/src/shell/builder.rs
@@ -146,6 +146,9 @@ pub struct CreateOptions<SE: extensions::ShellExtensions = extensions::DefaultSh
     /// Error behavior implementation.
     #[builder(default)]
     pub error_formatter: SE::ErrorFormatter,
+    /// Command interceptor (capability-confinement) implementation.
+    #[builder(default)]
+    pub command_interceptor: SE::CommandInterceptor,
     /// Disallow overwriting regular files via output redirection.
     #[builder(default)]
     pub disallow_overwriting_regular_files_via_output_redirection: bool,
@@ -239,6 +242,7 @@ impl<SE: extensions::ShellExtensions> Default for Shell<SE> {
     fn default() -> Self {
         Self {
             error_formatter: SE::ErrorFormatter::default(),
+            command_interceptor: SE::CommandInterceptor::default(),
             traps: traps::TrapHandlerConfig::default(),
             open_files: openfiles::OpenFiles::default(),
             working_dir: PathBuf::default(),

--- a/brush-core/src/shell/execution.rs
+++ b/brush-core/src/shell/execution.rs
@@ -86,7 +86,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         options.read(true);
 
         let opened_file: openfiles::OpenFile = self
-            .open_file(&options, path, params)
+            .open_file(&options, crate::extensions::OpenAccess::Read, path, params)
             .map_err(|e| error::ErrorKind::FailedSourcingFile(path.to_owned(), e))?;
 
         if opened_file.is_dir() {

--- a/brush-core/src/shell/fs.rs
+++ b/brush-core/src/shell/fs.rs
@@ -195,6 +195,23 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
 
         let path_to_open = self.absolute_path(path.as_ref());
 
+        // Consult the configured command interceptor (capability confinement)
+        // before opening. This is the single choke point through which all
+        // filesystem-path opens flow (redirections and `source`/`.`), so a
+        // policy applied here covers every path-based open in the shell.
+        {
+            use crate::extensions::CommandInterceptor as _;
+            let write = open_options_request_write(options);
+            if let crate::extensions::OpenDecision::Deny(reason) =
+                self.command_interceptor().before_open(&path_to_open, write)
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!("open denied: {reason}"),
+                ));
+            }
+        }
+
         // See if this is a reference to a file descriptor. These paths should
         // reflect the shell's current execution fds, which can differ from the
         // host process fds after redirections like here-docs.
@@ -240,5 +257,40 @@ fn shell_fd_path_to_fd(path: &Path) -> Option<ShellFd> {
         filename.to_string_lossy().parse::<ShellFd>().ok()
     } else {
         None
+    }
+}
+
+/// Best-effort determination of whether an [`std::fs::OpenOptions`] requests
+/// write access (including append). Used solely to inform the capability
+/// interceptor's `before_open` hook of write-intent.
+///
+/// `std::fs::OpenOptions` exposes no getters for its configured flags, so we
+/// inspect its `Debug` representation, which is documented to render the
+/// `write` and `append` booleans. If the format ever changes such that we
+/// cannot determine intent, we conservatively report `true` (write) so that a
+/// confinement policy never under-reports access.
+fn open_options_request_write(options: &std::fs::OpenOptions) -> bool {
+    let rendered = format!("{options:?}");
+
+    // Reads the boolean value of a `name: <bool>` field from the rendered
+    // debug string without slicing on byte offsets (which could panic on
+    // multi-byte boundaries).
+    let flag = |name: &str| -> Option<bool> {
+        let needle = format!("{name}: ");
+        let tail = rendered.split_once(&needle)?.1;
+        if tail.starts_with("true") {
+            Some(true)
+        } else if tail.starts_with("false") {
+            Some(false)
+        } else {
+            None
+        }
+    };
+
+    match (flag("write"), flag("append")) {
+        // We could read both flags: write access iff either is set.
+        (Some(write), Some(append)) => write || append,
+        // Could not parse the expected fields; fail safe toward "write".
+        _ => true,
     }
 }

--- a/brush-core/src/shell/fs.rs
+++ b/brush-core/src/shell/fs.rs
@@ -177,11 +177,16 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
     /// # Arguments
     ///
     /// * `options` - The options to use opening the file.
+    /// * `access` - The access the caller is requesting. This is the *declared*
+    ///   intent, stated by the caller from the syntax that requested the open;
+    ///   it is what the configured command interceptor is shown. It must agree
+    ///   with `options`.
     /// * `path` - The path to the file to open; may be relative to the shell's working directory.
     /// * `params` - Execution parameters.
     pub(crate) fn open_file(
         &self,
         options: &std::fs::OpenOptions,
+        access: crate::extensions::OpenAccess,
         path: impl AsRef<Path>,
         params: &ExecutionParameters,
     ) -> Result<openfiles::OpenFile, std::io::Error> {
@@ -201,9 +206,9 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         // policy applied here covers every path-based open in the shell.
         {
             use crate::extensions::CommandInterceptor as _;
-            let write = open_options_request_write(options);
+            let request = crate::extensions::OpenRequest::new(&path_to_open, access);
             if let crate::extensions::OpenDecision::Deny(reason) =
-                self.command_interceptor().before_open(&path_to_open, write)
+                self.command_interceptor().before_open(&request)
             {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
@@ -257,40 +262,5 @@ fn shell_fd_path_to_fd(path: &Path) -> Option<ShellFd> {
         filename.to_string_lossy().parse::<ShellFd>().ok()
     } else {
         None
-    }
-}
-
-/// Best-effort determination of whether an [`std::fs::OpenOptions`] requests
-/// write access (including append). Used solely to inform the capability
-/// interceptor's `before_open` hook of write-intent.
-///
-/// `std::fs::OpenOptions` exposes no getters for its configured flags, so we
-/// inspect its `Debug` representation, which is documented to render the
-/// `write` and `append` booleans. If the format ever changes such that we
-/// cannot determine intent, we conservatively report `true` (write) so that a
-/// confinement policy never under-reports access.
-fn open_options_request_write(options: &std::fs::OpenOptions) -> bool {
-    let rendered = format!("{options:?}");
-
-    // Reads the boolean value of a `name: <bool>` field from the rendered
-    // debug string without slicing on byte offsets (which could panic on
-    // multi-byte boundaries).
-    let flag = |name: &str| -> Option<bool> {
-        let needle = format!("{name}: ");
-        let tail = rendered.split_once(&needle)?.1;
-        if tail.starts_with("true") {
-            Some(true)
-        } else if tail.starts_with("false") {
-            Some(false)
-        } else {
-            None
-        }
-    };
-
-    match (flag("write"), flag("append")) {
-        // We could read both flags: write access iff either is set.
-        (Some(write), Some(append)) => write || append,
-        // Could not parse the expected fields; fail safe toward "write".
-        _ => true,
     }
 }

--- a/brush-core/src/shell/history.rs
+++ b/brush-core/src/shell/history.rs
@@ -15,8 +15,12 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         let mut options = std::fs::File::options();
         options.read(true);
 
-        let mut history_file =
-            self.open_file(&options, history_path, &self.default_exec_params())?;
+        let mut history_file = self.open_file(
+            &options,
+            crate::extensions::OpenAccess::Read,
+            history_path,
+            &self.default_exec_params(),
+        )?;
 
         // Check on the file's size.
         if let openfiles::OpenFile::File(file) = &mut history_file {

--- a/brush-core/tests/command_interceptor_tests.rs
+++ b/brush-core/tests/command_interceptor_tests.rs
@@ -1,0 +1,261 @@
+//! Integration tests for the `CommandInterceptor` capability-confinement hooks
+//! on `ShellExtensions` (`before_exec` / `before_open`).
+//!
+//! These tests prove that an embedding host can deny external command execution
+//! and file opens *in-process*, including for commands whose name contains a
+//! path separator (e.g. `/bin/rm`). That path-separator branch historically
+//! bypassed both the PATH search and the builtin table, so confining it is the
+//! whole point of `before_exec`.
+//!
+//! These tests target unix. Denied commands use `/bin/rm` — its existence is
+//! irrelevant because `before_exec` denies it *before* any spawn. Commands that
+//! are actually executed use `/usr/bin/true`, which exists on both Linux and
+//! macOS (note: `/bin/true` is absent on macOS).
+#![cfg(unix)]
+#![cfg(test)]
+#![allow(clippy::panic_in_result_fn)]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use brush_core::extensions::{
+    CommandInterceptor, ErrorFormatter, ExecDecision, OpenDecision, ShellExtensions,
+};
+
+/// An interceptor that denies any external program whose basename is in a deny
+/// list, and denies write-opens of any path that is not under `allowed_write_dir`.
+/// All decisions are recorded so tests can assert the hook actually fired.
+#[derive(Clone, Default)]
+struct PolicyInterceptor {
+    denied_basenames: Arc<Vec<String>>,
+    allowed_write_dir: Arc<Mutex<Option<PathBuf>>>,
+    exec_calls: Arc<Mutex<Vec<String>>>,
+    open_calls: Arc<Mutex<Vec<(PathBuf, bool)>>>,
+}
+
+impl PolicyInterceptor {
+    fn new(denied_basenames: &[&str], allowed_write_dir: Option<PathBuf>) -> Self {
+        Self {
+            denied_basenames: Arc::new(denied_basenames.iter().map(|s| (*s).to_string()).collect()),
+            allowed_write_dir: Arc::new(Mutex::new(allowed_write_dir)),
+            exec_calls: Arc::new(Mutex::new(Vec::new())),
+            open_calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn exec_calls(&self) -> Vec<String> {
+        self.exec_calls.lock().unwrap().clone()
+    }
+
+    fn open_calls(&self) -> Vec<(PathBuf, bool)> {
+        self.open_calls.lock().unwrap().clone()
+    }
+}
+
+impl CommandInterceptor for PolicyInterceptor {
+    fn before_exec(&self, program: &str, _args: &[String]) -> ExecDecision {
+        self.exec_calls.lock().unwrap().push(program.to_string());
+
+        // Match on the basename so that `rm` and `/bin/rm` are both caught.
+        let basename = Path::new(program)
+            .file_name()
+            .map_or_else(|| program.to_string(), |s| s.to_string_lossy().into_owned());
+
+        if self.denied_basenames.iter().any(|d| d == &basename) {
+            ExecDecision::Deny(format!("'{basename}' is not permitted by policy"))
+        } else {
+            ExecDecision::Allow
+        }
+    }
+
+    fn before_open(&self, path: &Path, write: bool) -> OpenDecision {
+        self.open_calls
+            .lock()
+            .unwrap()
+            .push((path.to_path_buf(), write));
+
+        if !write {
+            return OpenDecision::Allow;
+        }
+
+        match self.allowed_write_dir.lock().unwrap().as_ref() {
+            Some(dir) if path.starts_with(dir) => OpenDecision::Allow,
+            Some(_) => OpenDecision::Deny(format!(
+                "writes to {} are outside the permitted directory",
+                path.display()
+            )),
+            None => OpenDecision::Allow,
+        }
+    }
+}
+
+/// Wire `PolicyInterceptor` into a `ShellExtensions` bundle that otherwise uses
+/// brush's default behaviors.
+#[derive(Clone, Default)]
+struct PolicyExtensions;
+
+impl ShellExtensions for PolicyExtensions {
+    type ErrorFormatter = DefaultFormatter;
+    type CommandInterceptor = PolicyInterceptor;
+}
+
+#[derive(Clone, Default)]
+struct DefaultFormatter;
+impl ErrorFormatter for DefaultFormatter {}
+
+/// Builds a shell that uses the provided interceptor, skipping profile/rc and
+/// environment inheritance so the test is hermetic, but with the default
+/// builtin table registered (so `echo`, `.`/`source`, etc. behave normally).
+async fn shell_with_interceptor(
+    interceptor: PolicyInterceptor,
+) -> Result<brush_core::Shell<PolicyExtensions>> {
+    let builtins =
+        brush_builtins::default_builtins::<PolicyExtensions>(brush_builtins::BuiltinSet::BashMode);
+
+    let mut shell = brush_core::Shell::builder_with_extensions::<PolicyExtensions>()
+        .command_interceptor(interceptor)
+        .builtins(builtins)
+        .do_not_inherit_env(true)
+        .skip_well_known_vars(true)
+        .build()
+        .await?;
+
+    // Provide a deterministic PATH so bare-name external commands can resolve.
+    run(&mut shell, "export PATH=/bin:/usr/bin").await?;
+
+    Ok(shell)
+}
+
+async fn run(shell: &mut brush_core::Shell<PolicyExtensions>, cmd: &str) -> Result<u8> {
+    let params = shell.default_exec_params();
+    let result = shell
+        .run_string(cmd, &brush_core::SourceInfo::default(), &params)
+        .await?;
+    Ok(u8::from(result.exit_code))
+}
+
+/// `before_exec` must deny a command referenced by bare name (resolved via PATH).
+#[tokio::test]
+async fn denies_bare_name_command() -> Result<()> {
+    let interceptor = PolicyInterceptor::new(&["rm"], None);
+    let mut shell = shell_with_interceptor(interceptor.clone()).await?;
+
+    let code = run(&mut shell, "rm /tmp/does-not-matter").await?;
+    assert_ne!(code, 0, "denied `rm` must report a non-zero exit code");
+
+    let exec_calls = interceptor.exec_calls();
+    assert!(
+        exec_calls.iter().any(|p| p.ends_with("rm")),
+        "before_exec should have been consulted for `rm`; saw: {exec_calls:?}"
+    );
+    Ok(())
+}
+
+/// The load-bearing test: a command containing a path separator (`/bin/rm`)
+/// historically bypassed PATH and the builtin table. `before_exec` must still
+/// fire for it, proving the bypass is closed.
+#[tokio::test]
+async fn denies_absolute_path_command_closing_path_separator_bypass() -> Result<()> {
+    let interceptor = PolicyInterceptor::new(&["rm"], None);
+    let mut shell = shell_with_interceptor(interceptor.clone()).await?;
+
+    let code = run(&mut shell, "/bin/rm /tmp/does-not-matter").await?;
+    assert_ne!(
+        code, 0,
+        "denied `/bin/rm` (path-separator branch) must report a non-zero exit code"
+    );
+
+    let exec_calls = interceptor.exec_calls();
+    assert!(
+        exec_calls.iter().any(|p| p == "/bin/rm"),
+        "before_exec must be consulted for the path-separator command `/bin/rm`; saw: {exec_calls:?}"
+    );
+    Ok(())
+}
+
+/// A permitted command must still run normally — the default decision is Allow.
+#[tokio::test]
+async fn allows_permitted_command() -> Result<()> {
+    let interceptor = PolicyInterceptor::new(&["rm"], None);
+    let mut shell = shell_with_interceptor(interceptor.clone()).await?;
+
+    // `/usr/bin/true` is a path-separator command too, so this also proves the
+    // Allow path of the path-separator branch. We use `/usr/bin/true` rather than
+    // `/bin/true` because the latter does not exist on macOS (where `true` lives
+    // only at `/usr/bin/true`); `/usr/bin/true` is present on both Linux and macOS.
+    let code = run(&mut shell, "/usr/bin/true").await?;
+    assert_eq!(code, 0, "permitted `/usr/bin/true` should succeed");
+
+    let exec_calls = interceptor.exec_calls();
+    assert!(
+        exec_calls.iter().any(|p| p == "/usr/bin/true"),
+        "before_exec should have observed `/usr/bin/true`; saw: {exec_calls:?}"
+    );
+    Ok(())
+}
+
+/// `before_open` must deny an output redirection that writes outside the
+/// permitted directory, while allowing one inside it.
+#[tokio::test]
+async fn denies_write_outside_allowed_dir() -> Result<()> {
+    let allowed = tempfile::tempdir()?;
+    let forbidden = tempfile::tempdir()?;
+
+    let interceptor = PolicyInterceptor::new(&[], Some(allowed.path().to_path_buf()));
+    let mut shell = shell_with_interceptor(interceptor.clone()).await?;
+
+    // Writing inside the allowed dir is permitted.
+    let allowed_file = allowed.path().join("ok.txt");
+    let code = run(&mut shell, &format!("echo hi > {}", allowed_file.display())).await?;
+    assert_eq!(code, 0, "write inside the allowed dir should succeed");
+    assert!(
+        allowed_file.exists(),
+        "the permitted file should have been created"
+    );
+
+    // Writing outside the allowed dir is denied.
+    let forbidden_file = forbidden.path().join("nope.txt");
+    let code = run(
+        &mut shell,
+        &format!("echo hi > {}", forbidden_file.display()),
+    )
+    .await?;
+    assert_ne!(code, 0, "write outside the allowed dir must fail");
+    assert!(
+        !forbidden_file.exists(),
+        "the forbidden file must NOT have been created"
+    );
+
+    let open_calls = interceptor.open_calls();
+    assert!(
+        open_calls.iter().any(|(p, w)| *w && p == &forbidden_file),
+        "before_open should have been consulted (with write=true) for the forbidden path; saw: {open_calls:?}"
+    );
+    Ok(())
+}
+
+/// Reads must be allowed by this policy (write=false), proving the `write` flag
+/// is threaded correctly and read-only opens aren't accidentally denied.
+#[tokio::test]
+async fn allows_read_open() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let script = dir.path().join("snippet.sh");
+    std::fs::write(&script, "X=hello\n")?;
+
+    // allowed_write_dir is set to a *different* dir, so if reads were
+    // misclassified as writes they would be denied.
+    let other = tempfile::tempdir()?;
+    let interceptor = PolicyInterceptor::new(&[], Some(other.path().to_path_buf()));
+    let mut shell = shell_with_interceptor(interceptor.clone()).await?;
+
+    let code = run(&mut shell, &format!(". {}", script.display())).await?;
+    assert_eq!(code, 0, "sourcing (read-only open) should be permitted");
+
+    let open_calls = interceptor.open_calls();
+    assert!(
+        open_calls.iter().any(|(p, w)| !*w && p == &script),
+        "before_open should have observed a read-only open of the sourced file; saw: {open_calls:?}"
+    );
+    Ok(())
+}

--- a/brush-core/tests/command_interceptor_tests.rs
+++ b/brush-core/tests/command_interceptor_tests.rs
@@ -20,7 +20,8 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use brush_core::extensions::{
-    CommandInterceptor, ErrorFormatter, ExecDecision, OpenDecision, ShellExtensions,
+    CommandInterceptor, ErrorFormatter, ExecDecision, OpenAccess, OpenDecision, OpenRequest,
+    ShellExtensions,
 };
 
 /// An interceptor that denies any external program whose basename is in a deny
@@ -31,7 +32,7 @@ struct PolicyInterceptor {
     denied_basenames: Arc<Vec<String>>,
     allowed_write_dir: Arc<Mutex<Option<PathBuf>>>,
     exec_calls: Arc<Mutex<Vec<String>>>,
-    open_calls: Arc<Mutex<Vec<(PathBuf, bool)>>>,
+    open_calls: Arc<Mutex<Vec<(PathBuf, OpenAccess)>>>,
 }
 
 impl PolicyInterceptor {
@@ -48,7 +49,7 @@ impl PolicyInterceptor {
         self.exec_calls.lock().unwrap().clone()
     }
 
-    fn open_calls(&self) -> Vec<(PathBuf, bool)> {
+    fn open_calls(&self) -> Vec<(PathBuf, OpenAccess)> {
         self.open_calls.lock().unwrap().clone()
     }
 }
@@ -69,13 +70,14 @@ impl CommandInterceptor for PolicyInterceptor {
         }
     }
 
-    fn before_open(&self, path: &Path, write: bool) -> OpenDecision {
+    fn before_open(&self, request: &OpenRequest<'_>) -> OpenDecision {
+        let path = request.path;
         self.open_calls
             .lock()
             .unwrap()
-            .push((path.to_path_buf(), write));
+            .push((path.to_path_buf(), request.access));
 
-        if !write {
+        if !request.access.writes() {
             return OpenDecision::Allow;
         }
 
@@ -229,14 +231,16 @@ async fn denies_write_outside_allowed_dir() -> Result<()> {
 
     let open_calls = interceptor.open_calls();
     assert!(
-        open_calls.iter().any(|(p, w)| *w && p == &forbidden_file),
-        "before_open should have been consulted (with write=true) for the forbidden path; saw: {open_calls:?}"
+        open_calls
+            .iter()
+            .any(|(p, access)| *access == OpenAccess::Write && p == &forbidden_file),
+        "before_open should have been consulted (with OpenAccess::Write) for the forbidden path; saw: {open_calls:?}"
     );
     Ok(())
 }
 
-/// Reads must be allowed by this policy (write=false), proving the `write` flag
-/// is threaded correctly and read-only opens aren't accidentally denied.
+/// Reads must be allowed by this policy, proving the declared access is threaded
+/// correctly and read-only opens aren't accidentally denied.
 #[tokio::test]
 async fn allows_read_open() -> Result<()> {
     let dir = tempfile::tempdir()?;
@@ -254,8 +258,56 @@ async fn allows_read_open() -> Result<()> {
 
     let open_calls = interceptor.open_calls();
     assert!(
-        open_calls.iter().any(|(p, w)| !*w && p == &script),
-        "before_open should have observed a read-only open of the sourced file; saw: {open_calls:?}"
+        open_calls
+            .iter()
+            .any(|(p, access)| *access == OpenAccess::Read && p == &script),
+        "before_open should have observed an OpenAccess::Read open of the sourced file; saw: {open_calls:?}"
     );
+    Ok(())
+}
+
+/// Every redirection kind must report the access its *syntax* asks for.
+///
+/// This is what makes the hook usable as a security contract: a policy that
+/// grants read authority but not write authority has to be able to tell `< f`
+/// from `<> f`, and `>> f` from `> f`, without guessing. Previously the access
+/// was recovered by string-matching the `Debug` rendering of `std::fs::OpenOptions`
+/// — an unstable, platform-varying format — rather than taken from the AST.
+#[tokio::test]
+async fn declared_access_matches_redirection_kind() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let existing = dir.path().join("existing.txt");
+    std::fs::write(&existing, "seed\n")?;
+
+    // No write restriction: we are asserting on the *reported* access, not on
+    // whether the open was permitted.
+    let interceptor = PolicyInterceptor::new(&[], None);
+    let mut shell = shell_with_interceptor(interceptor.clone()).await?;
+
+    let path = existing.display().to_string();
+    for (script, expected) in [
+        (format!("read line < {path}"), OpenAccess::Read),
+        (format!("echo out > {path}"), OpenAccess::Write),
+        (format!("echo more >> {path}"), OpenAccess::Write),
+        (format!("echo clobber >| {path}"), OpenAccess::Write),
+        (format!("exec 7<> {path}; exec 7>&-"), OpenAccess::ReadWrite),
+    ] {
+        let before = interceptor.open_calls().len();
+        let code = run(&mut shell, &script).await?;
+        assert_eq!(
+            code, 0,
+            "`{script}` should succeed under an allow-all policy"
+        );
+
+        let observed: Vec<_> = interceptor.open_calls().split_off(before);
+        assert!(
+            observed
+                .iter()
+                .any(|(p, access)| p == &existing && *access == expected),
+            "`{script}` should report {expected:?} for {}; saw: {observed:?}",
+            existing.display()
+        );
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Addresses #1183.

### What

Adds an optional `CommandInterceptor` component to `ShellExtensions` with two default-allow hooks — `before_exec(program, args)` and `before_open(request)` — letting an embedding host deny external command execution and file opens **in-process**. Default behavior is unchanged.

### Why

See #1183. Embedders cannot currently confine command execution in-process, and the path-separator dispatch branch (`/bin/rm`, `./x`) bypasses `PATH` and the builtin table, defeating any name- or PATH-based gate. This is the minimal seam that closes it.

### How

- New sub-trait `extensions::CommandInterceptor` (mirroring `ErrorFormatter`), collected as `ShellExtensions::CommandInterceptor`, with `DefaultCommandInterceptor` (allow-all). `ShellExtensionsImpl` gains a second type parameter defaulted to `DefaultCommandInterceptor`.
- `Shell<SE>` stores a `command_interceptor: SE::CommandInterceptor` instance (parallel to `error_formatter`), wired through `CreateOptions`/the builder, `new`, `Default`, and `Clone`. New accessor `Shell::command_interceptor()`.
- `before_exec` is invoked once, at the top of `commands::execute_external_command` — the single funnel for **both** dispatch branches. Denials return a new `ErrorKind::ExecDenied(program, reason)`, mapped to exit code 126.
- `before_open` is invoked in `Shell::open_file`, which covers redirections and `source`/`.`. Denials return an `io::Error(PermissionDenied)`, which the existing `RedirectionFailure` / `FailedSourcingFile` wrapping reports cleanly.

### ⚠️ Compatibility: this is **not** purely additive. Please read this part.

An earlier version of this description claimed the change was "purely additive". **That was wrong**, and the correction matters more than the rest of the PR:

* ✅ `type X = ShellExtensionsImpl<MyFormatter>` **keeps compiling** — the new parameter is defaulted.
* ❌ `impl ShellExtensions for MyExtensions { type ErrorFormatter = …; }` **stops compiling.** The trait gains a *required* associated type and Rust has no stable associated-type defaults, so every third-party direct impl fails with `E0046: missing CommandInterceptor in implementation`.

Verified both directions with a throwaway crate depending on `brush-core` by path: the direct-impl form compiles against `main` and fails on this branch; the type-alias form compiles on both. `ShellExtensions` is `pub` and unsealed, so direct impls are legal today. The "Analyze public API" job already reports this under **Removed items**.

**This is unavoidable for any design that adds a required associated type** — it isn't a fixable detail of this patch. See the API question at the bottom; I'll implement whichever shape you prefer.

### Second commit: `before_open` no longer parses `Debug` output

The first cut recovered write-intent with `format!("{options:?}")` on a `std::fs::OpenOptions` and string-matched `write: ` / `append: `. That made a read-vs-write authority decision depend on the `Debug` rendering of a std type — unstable by contract, different on Windows, free to change in any release.

It was also unnecessary: **brush already knows the answer explicitly at all four `Shell::open_file` call sites.** The redirection setup in `interp.rs` matches on `ast::IoFileRedirectKind`; `setup_redirect_output_and_error_to` always creates and writes; `source`/`.` and the history loader open read-only.

So this adds `extensions::OpenAccess { Read, Write, ReadWrite }` and `extensions::OpenRequest { path, access }`, and threads the access through `Shell::open_file` from each call site — in the redirection path derived from the redirect kind itself, not recovered from the options afterwards. `Shell::open_file` is `pub(crate)`, so the extra parameter costs nothing in public API. `OpenRequest` is `#[non_exhaustive]` so more detail can be added later without breaking implementors.

Classification is unchanged for every existing case (`Read`/`DuplicateInput` read; `Write`/`Append`/`Clobber`/`DuplicateOutput` write); `ReadAndWrite` (`<>`) is now reported as `ReadWrite` instead of collapsing to "write".

`before_open`'s rustdoc now also states the one coverage gap: platform-specific special files are resolved before the path is made absolute and are not shown to the hook. Today that is only `/dev/null` on Windows; the Unix special-file hook resolves nothing.

### Test plan

`brush-core/tests/command_interceptor_tests.rs`:

- denies a bare-name command (`rm`, PATH-resolved);
- **denies an absolute-path command (`/bin/rm`)** — the load-bearing case, proving the path-separator branch is hooked;
- allows a permitted command (`/usr/bin/true`);
- denies an output redirection writing outside an allowed directory while allowing one inside it;
- allows a read-only `source` open;
- **new:** `declared_access_matches_redirection_kind` pins the reported access for `<`, `>`, `>>`, `>|` and `<>` — the distinction the `Debug` parse could only approximate.

Validation at head `8456f09` against base `30a3bce`:

```
cargo xtask ci pre-commit
cargo test --test brush-compat-tests
```

- fmt ✅, build ✅, clippy `--workspace --all-features --all-targets` ✅, schema check ✅
- unit — **384 run, 384 passed, 1 skipped**
- integration (nextest `--workspace`) — **2703 run, 2703 passed, 40 skipped**
- compat — `2300 ran: 1844 succeeded, 0 failed, 456 known to fail, 39 skipped`, **identical to clean `main` `30a3bce`**, as a default-allow change should be.

One caveat reported honestly: `cargo deny --all-features check all` reports `advisories FAILED` — but it fails **identically on clean `main`** (yanked `chacha20`, plus a `deny.toml` ignore for `RUSTSEC-2026-0253` that no longer matches anything). Pre-existing, unrelated to this PR, and not something I've touched here.

### The API question — one decision, and I'll do the work

Since a required associated type on a public unsealed trait is breaking no matter how it's written, the choice isn't between four designs. It's one question:

> **Is `ShellExtensions` meant to be implemented directly by third parties, or only obtained through `ShellExtensionsImpl<…>`?**

**If only through `ShellExtensionsImpl`** — keep the associated type and **seal the trait in the same release**. This break then becomes the *last* one: every future component (the `PlaceholderBehavior` slot already in `extensions.rs` is advertised as a "stub for future extension") becomes purely additive, because implementors can only reach `ShellExtensions` via `ShellExtensionsImpl`, whose extra parameters are defaulted. Keeps static dispatch and zero default-path cost. **This is what I'd recommend**, and I'm happy to add the sealing to this PR.

**If it's meant to be directly implementable** — then a required associated type is off the table permanently, and the interceptor should be a runtime field instead: `Option<Arc<dyn CommandInterceptor>>` on `CreateOptions`/`Shell`, `#[builder(default)]`, `serde(skip)`. Fully source-compatible today (per `AGENTS.md`, new defaulted fields on a `Default` struct are fine), object-safe as written, and costs one `Option` branch per spawn/open — nothing next to `fork`/`exec`. The cost is a second extension mechanism sitting alongside `ShellExtensions`.

Either way the `before_open` argument shape above is unaffected, so that part is settled regardless.

Deliberately **out of scope** here, to keep this reviewable: a `before_command` hook (fires per command including builtins; the natural place to observe cancellation, which bounds a pure-builtin runaway like `while true; do :; done` that reaches neither hook) and a notion of a *terminating* error so a denial isn't swallowed as an exit status by an enclosing loop. Both exist in our downstream fork and can follow as separate PRs once the shape here is settled.

### Answers to my own earlier open questions

- Naming: happy to rename `CommandInterceptor` → `SecurityPolicy`/`Sandbox`, or `before_*` → `check_*`. No strong preference; say the word.
- `before_open` denial: still an `io::Error(PermissionDenied)` rather than a dedicated `ErrorKind::OpenDenied`, to fit the existing open-file error flow. Easy to change.
- `(program, args)` has been sufficient for the downstream policy so far.
- Sync has been sufficient; the enforcement points are synchronous.

---

> Per the project's AI Policy: this change was authored with AI assistance and reviewed and tested by a human contributor; both commits carry `Assisted-by:` trailers accordingly.
