### PR TITLE
feat(core): support cooperative SIGINT cancellation

### DIFF
--- a/brush-builtins/src/kill.rs
+++ b/brush-builtins/src/kill.rs
@@ -119,6 +119,15 @@ impl builtins::Command for KillCommand {
                 }
             } else {
                 let pid = brush_core::int_utils::parse(pid_or_job_spec.as_str(), 10)?;
+                let is_self_signal =
+                    i32::try_from(std::process::id()).is_ok_and(|current_pid| current_pid == pid);
+
+                if is_self_signal && context.shell.traps().handles(trap_signal) {
+                    if let Ok(signal_number) = i32::try_from(trap_signal) {
+                        context.params.request_host_signal(signal_number);
+                        return Ok(ExecutionResult::success());
+                    }
+                }
 
                 // It's a pid.
                 sys::signal::kill_process(pid, trap_signal)?;

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -623,6 +623,7 @@ pub(crate) fn execute_external_command(
         if let Some(pgid) = process_group_id {
             cmd.process_group(pgid);
         }
+        cmd.reset_job_control_signals();
     }
 
     // When tracing is enabled, report.

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -614,6 +614,8 @@ pub(crate) fn execute_external_command(
             cmd.process_group(0);
             if child_stdin_is_terminal {
                 cmd.take_foreground();
+            } else {
+                cmd.reset_job_control_signals();
             }
         }
     } else {

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -4,6 +4,12 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicI32, AtomicU8, AtomicU64, Ordering},
+};
+
+use tokio::sync::Notify;
 
 use crate::arithmetic::{self, ExpandAndEvaluate};
 use crate::commands::{self, CommandArg};
@@ -38,9 +44,142 @@ pub struct ExecutionParameters {
     /// Whether `errexit` (exit on error) behavior should be
     /// suppressed in this execution context. Defaults to `false`.
     pub suppress_errexit: bool,
+    /// Pending signal requested by the embedding host.
+    pending_signal: Arc<AtomicI32>,
+    /// Behavior flags for the pending signal.
+    pending_signal_flags: Arc<AtomicU8>,
+    /// Monotonic generation for pending signal requests.
+    pending_signal_generation: Arc<AtomicU64>,
+    /// Wakes execution sites that are blocked waiting for foreground work.
+    pending_signal_notify: Arc<Notify>,
 }
 
+const SIGINT_NUMBER: i32 = 2;
+const PENDING_SIGNAL_FORWARD_TO_CHILD: u8 = 0b0000_0001;
+const PENDING_SIGNAL_BYPASS_TRAPS: u8 = 0b0000_0010;
+
 impl ExecutionParameters {
+    /// Requests cooperative delivery of SIGINT.
+    pub fn request_sigint(&self) {
+        self.request_signal(SIGINT_NUMBER, PENDING_SIGNAL_FORWARD_TO_CHILD);
+    }
+
+    /// Requests interactive cooperative delivery of SIGINT.
+    ///
+    /// This is intended for terminal Ctrl-C handling where the PTY driver has
+    /// already delivered SIGINT to the foreground process group. It still lets
+    /// shell-native loops and traps observe the interrupt without forwarding a
+    /// duplicate signal to external children.
+    pub fn request_interactive_sigint(&self) {
+        self.request_signal(SIGINT_NUMBER, 0);
+    }
+
+    /// Requests cooperative delivery of a host-originated signal.
+    ///
+    /// Foreground child waits forward this signal to their process group, while
+    /// shell-native execution consumes it at checkpoints and honors traps.
+    pub fn request_host_signal(&self, signal_number: i32) {
+        self.request_signal(signal_number, PENDING_SIGNAL_FORWARD_TO_CHILD);
+    }
+
+    /// Requests forced cooperative delivery of a host-originated signal.
+    ///
+    /// Foreground child waits forward this signal to their process group. Shell
+    /// checkpoints bypass traps so embedders can guarantee timeout/kill cleanup
+    /// for shell-native code.
+    pub fn request_forced_signal(&self, signal_number: i32) {
+        self.request_signal(
+            signal_number,
+            PENDING_SIGNAL_FORWARD_TO_CHILD | PENDING_SIGNAL_BYPASS_TRAPS,
+        );
+    }
+
+    fn request_signal(&self, signal_number: i32, flags: u8) {
+        self.pending_signal_flags.store(flags, Ordering::Release);
+        self.pending_signal.store(signal_number, Ordering::Release);
+        self.pending_signal_generation
+            .fetch_add(1, Ordering::AcqRel);
+        self.pending_signal_notify.notify_waiters();
+    }
+
+    /// Clears any pending cooperative signal.
+    pub fn clear_pending_signal(&self) {
+        self.pending_signal.store(0, Ordering::Release);
+        self.pending_signal_flags.store(0, Ordering::Release);
+    }
+
+    pub(crate) fn pending_signal_generation(&self) -> u64 {
+        self.pending_signal_generation.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn wait_for_pending_signal_after(
+        &self,
+        observed_generation: u64,
+    ) -> (u64, i32, bool) {
+        loop {
+            let notified = self.pending_signal_notify.notified();
+            let generation = self.pending_signal_generation.load(Ordering::Acquire);
+            let signal_number = self.pending_signal.load(Ordering::Acquire);
+            let signal_flags = self.pending_signal_flags.load(Ordering::Acquire);
+            if generation != observed_generation && signal_number != 0 {
+                return (
+                    generation,
+                    signal_number,
+                    signal_flags & PENDING_SIGNAL_FORWARD_TO_CHILD != 0,
+                );
+            }
+            notified.await;
+        }
+    }
+
+    async fn consume_pending_signal<SE: extensions::ShellExtensions>(
+        &self,
+        shell: &mut Shell<SE>,
+    ) -> Result<Option<ExecutionResult>, error::Error> {
+        let signal_number = self.pending_signal.swap(0, Ordering::AcqRel);
+        if signal_number == 0 {
+            return Ok(None);
+        }
+        let signal_flags = self.pending_signal_flags.swap(0, Ordering::AcqRel);
+
+        let Ok(signal) = sys::signal::Signal::try_from(signal_number) else {
+            let result = ExecutionResult::signaled(signal_number);
+            shell.set_last_exit_status(result.exit_code.into());
+            return Ok(Some(result));
+        };
+
+        let trap_signal = crate::traps::TrapSignal::Signal(signal);
+        if signal_flags & PENDING_SIGNAL_BYPASS_TRAPS == 0 && shell.traps().handles(trap_signal) {
+            let result = shell.invoke_trap_handler(trap_signal, self).await?;
+            shell.set_last_exit_status(result.exit_code.into());
+            return Ok(Some(result));
+        }
+
+        let result = ExecutionResult::signaled(signal_number);
+        shell.set_last_exit_status(result.exit_code.into());
+        Ok(Some(result))
+    }
+
+    async fn consume_pending_loop_signal<SE: extensions::ShellExtensions>(
+        &self,
+        shell: &mut Shell<SE>,
+        result: &mut ExecutionResult,
+    ) -> Result<bool, error::Error> {
+        let Some(signal_result) = self.consume_pending_signal(shell).await? else {
+            return Ok(false);
+        };
+
+        *result = signal_result;
+        if result.is_return_or_exit() {
+            return Ok(true);
+        }
+
+        let is_break = result.is_break();
+        result.next_control_flow = result.next_control_flow.try_decrement_loop_levels();
+
+        Ok(is_break || result.is_continue() || !result.is_normal_flow())
+    }
+
     /// Returns the standard input file; usable with `write!` et al.
     ///
     /// # Arguments
@@ -192,9 +331,71 @@ pub trait Execute {
     ) -> Result<ExecutionResult, error::Error>;
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SignalCheckpointPolicy {
+    BeforeAndAfter,
+    Manual,
+}
+
+#[async_trait::async_trait]
+trait ExecuteInner {
+    fn signal_checkpoint_policy(&self) -> SignalCheckpointPolicy {
+        SignalCheckpointPolicy::BeforeAndAfter
+    }
+
+    async fn execute_inner(
+        &self,
+        shell: &mut Shell<impl extensions::ShellExtensions>,
+        params: &ExecutionParameters,
+    ) -> Result<ExecutionResult, error::Error>;
+}
+
+#[async_trait::async_trait]
+impl<T> Execute for T
+where
+    T: ExecuteInner + Sync,
+{
+    async fn execute(
+        &self,
+        shell: &mut Shell<impl extensions::ShellExtensions>,
+        params: &ExecutionParameters,
+    ) -> Result<ExecutionResult, error::Error> {
+        match self.signal_checkpoint_policy() {
+            SignalCheckpointPolicy::BeforeAndAfter => {
+                if let Some(result) = params.consume_pending_signal(shell).await?
+                    && !result.is_normal_flow()
+                {
+                    return Ok(result);
+                }
+
+                let result = self.execute_inner(shell, params).await?;
+                Ok(params
+                    .consume_pending_signal(shell)
+                    .await?
+                    .unwrap_or(result))
+            }
+            SignalCheckpointPolicy::Manual => self.execute_inner(shell, params).await,
+        }
+    }
+}
+
 #[async_trait::async_trait]
 trait ExecuteInPipeline<SE: extensions::ShellExtensions> {
     async fn execute_in_pipeline(
+        &self,
+        mut context: PipelineExecutionContext<'_, SE>,
+        params: ExecutionParameters,
+    ) -> Result<ExecutionSpawnResult, error::Error> {
+        if let Some(signal_result) = params.consume_pending_signal(&mut context.shell).await?
+            && !signal_result.is_normal_flow()
+        {
+            return Ok(signal_result.into());
+        }
+
+        self.execute_in_pipeline_inner(context, params).await
+    }
+
+    async fn execute_in_pipeline_inner(
         &self,
         context: PipelineExecutionContext<'_, SE>,
         params: ExecutionParameters,
@@ -202,8 +403,8 @@ trait ExecuteInPipeline<SE: extensions::ShellExtensions> {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::Program {
-    async fn execute(
+impl ExecuteInner for ast::Program {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -237,8 +438,8 @@ impl Execute for ast::Program {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::CompoundList {
-    async fn execute(
+impl ExecuteInner for ast::CompoundList {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -249,6 +450,13 @@ impl Execute for ast::CompoundList {
             let run_async = matches!(sep, ast::SeparatorOperator::Async);
 
             if run_async {
+                if let Some(signal_result) = params.consume_pending_signal(shell).await? {
+                    result = signal_result;
+                    if !result.is_normal_flow() {
+                        break;
+                    }
+                }
+
                 let job = spawn_async_ao_list_in_task(ao_list, shell, params);
                 let job_formatted = job.to_pid_style_string();
 
@@ -257,6 +465,10 @@ impl Execute for ast::CompoundList {
                 }
 
                 result = ExecutionResult::success();
+
+                if let Some(signal_result) = params.consume_pending_signal(shell).await? {
+                    result = signal_result;
+                }
             } else {
                 result = ao_list.execute(shell, params).await?;
 
@@ -305,8 +517,8 @@ fn spawn_async_ao_list_in_task<'a, SE: extensions::ShellExtensions>(
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::AndOrList {
-    async fn execute(
+impl ExecuteInner for ast::AndOrList {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -322,6 +534,13 @@ impl Execute for ast::AndOrList {
         let mut result = self.first.execute(shell, &first_params).await?;
 
         for (index, next_ao) in self.additional.iter().enumerate() {
+            if let Some(signal_result) = params.consume_pending_signal(shell).await? {
+                result = signal_result;
+                if !result.is_normal_flow() {
+                    break;
+                }
+            }
+
             // Check for non-normal control flow.
             if !result.is_normal_flow() {
                 break;
@@ -361,8 +580,8 @@ impl Execute for ast::AndOrList {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::Pipeline {
-    async fn execute(
+impl ExecuteInner for ast::Pipeline {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -549,7 +768,7 @@ async fn wait_for_pipeline_processes_and_update_status(
         let wait_result = if !stopped_children.is_empty() {
             child.poll().await?
         } else {
-            child.wait().await?
+            child.wait_with_params(params).await?
         };
 
         match wait_result {
@@ -608,7 +827,7 @@ async fn wait_for_pipeline_processes_and_update_status(
 
 #[async_trait::async_trait]
 impl<SE: extensions::ShellExtensions> ExecuteInPipeline<SE> for ast::Command {
-    async fn execute_in_pipeline(
+    async fn execute_in_pipeline_inner(
         &self,
         mut pipeline_context: PipelineExecutionContext<'_, SE>,
         mut params: ExecutionParameters,
@@ -671,8 +890,8 @@ enum WhileOrUntil {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::CompoundCommand {
-    async fn execute(
+impl ExecuteInner for ast::CompoundCommand {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -717,8 +936,8 @@ impl Execute for ast::CompoundCommand {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::CoprocessCommand {
-    async fn execute(
+impl ExecuteInner for ast::CoprocessCommand {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -802,8 +1021,12 @@ impl Execute for ast::CoprocessCommand {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::ForClauseCommand {
-    async fn execute(
+impl ExecuteInner for ast::ForClauseCommand {
+    fn signal_checkpoint_policy(&self) -> SignalCheckpointPolicy {
+        SignalCheckpointPolicy::Manual
+    }
+
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -825,6 +1048,13 @@ impl Execute for ast::ForClauseCommand {
         }
 
         for value in expanded_values {
+            if params
+                .consume_pending_loop_signal(shell, &mut result)
+                .await?
+            {
+                break;
+            }
+
             if shell.options().print_commands_and_arguments {
                 if let Some(unexpanded_values) = &self.values {
                     shell
@@ -862,7 +1092,14 @@ impl Execute for ast::ForClauseCommand {
 
             result.next_control_flow = result.next_control_flow.try_decrement_loop_levels();
 
-            if is_break || result.is_continue() {
+            if is_break || result.is_continue() || !result.is_normal_flow() {
+                break;
+            }
+
+            if params
+                .consume_pending_loop_signal(shell, &mut result)
+                .await?
+            {
                 break;
             }
         }
@@ -873,8 +1110,8 @@ impl Execute for ast::ForClauseCommand {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::CaseClauseCommand {
-    async fn execute(
+impl ExecuteInner for ast::CaseClauseCommand {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -940,8 +1177,8 @@ impl Execute for ast::CaseClauseCommand {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::IfClauseCommand {
-    async fn execute(
+impl ExecuteInner for ast::IfClauseCommand {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -993,8 +1230,12 @@ impl Execute for ast::IfClauseCommand {
 }
 
 #[async_trait::async_trait]
-impl Execute for (WhileOrUntil, &ast::WhileOrUntilClauseCommand) {
-    async fn execute(
+impl ExecuteInner for (WhileOrUntil, &ast::WhileOrUntilClauseCommand) {
+    fn signal_checkpoint_policy(&self) -> SignalCheckpointPolicy {
+        SignalCheckpointPolicy::Manual
+    }
+
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -1013,6 +1254,13 @@ impl Execute for (WhileOrUntil, &ast::WhileOrUntilClauseCommand) {
         condition_params.suppress_errexit = true;
 
         loop {
+            if params
+                .consume_pending_loop_signal(shell, &mut result)
+                .await?
+            {
+                break;
+            }
+
             let condition_result = test_condition.execute(shell, &condition_params).await?;
 
             // Update status for condition
@@ -1040,7 +1288,14 @@ impl Execute for (WhileOrUntil, &ast::WhileOrUntilClauseCommand) {
 
             result.next_control_flow = result.next_control_flow.try_decrement_loop_levels();
 
-            if is_break || result.is_continue() {
+            if is_break || result.is_continue() || !result.is_normal_flow() {
+                break;
+            }
+
+            if params
+                .consume_pending_loop_signal(shell, &mut result)
+                .await?
+            {
                 break;
             }
         }
@@ -1051,8 +1306,8 @@ impl Execute for (WhileOrUntil, &ast::WhileOrUntilClauseCommand) {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::ArithmeticCommand {
-    async fn execute(
+impl ExecuteInner for ast::ArithmeticCommand {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -1071,8 +1326,12 @@ impl Execute for ast::ArithmeticCommand {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::ArithmeticForClauseCommand {
-    async fn execute(
+impl ExecuteInner for ast::ArithmeticForClauseCommand {
+    fn signal_checkpoint_policy(&self) -> SignalCheckpointPolicy {
+        SignalCheckpointPolicy::Manual
+    }
+
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         params: &ExecutionParameters,
@@ -1083,6 +1342,13 @@ impl Execute for ast::ArithmeticForClauseCommand {
         }
 
         loop {
+            if params
+                .consume_pending_loop_signal(shell, &mut result)
+                .await?
+            {
+                break;
+            }
+
             if let Some(condition) = &self.condition {
                 // An empty condition (e.g., `for (( ; ; ))`) means "always true".
                 if !condition.value.is_empty() && condition.eval(shell, params, true).await? == 0 {
@@ -1099,12 +1365,19 @@ impl Execute for ast::ArithmeticForClauseCommand {
 
             result.next_control_flow = result.next_control_flow.try_decrement_loop_levels();
 
-            if is_break || result.is_continue() {
+            if is_break || result.is_continue() || !result.is_normal_flow() {
                 break;
             }
 
             if let Some(updater) = &self.updater {
                 updater.eval(shell, params, true).await?;
+            }
+
+            if params
+                .consume_pending_loop_signal(shell, &mut result)
+                .await?
+            {
+                break;
             }
         }
 
@@ -1114,8 +1387,8 @@ impl Execute for ast::ArithmeticForClauseCommand {
 }
 
 #[async_trait::async_trait]
-impl Execute for ast::FunctionDefinition {
-    async fn execute(
+impl ExecuteInner for ast::FunctionDefinition {
+    async fn execute_inner(
         &self,
         shell: &mut Shell<impl extensions::ShellExtensions>,
         _params: &ExecutionParameters,
@@ -1157,7 +1430,7 @@ impl Execute for ast::FunctionDefinition {
 #[async_trait::async_trait]
 #[allow(clippy::too_many_lines)]
 impl<SE: extensions::ShellExtensions> ExecuteInPipeline<SE> for ast::SimpleCommand {
-    async fn execute_in_pipeline(
+    async fn execute_in_pipeline_inner(
         &self,
         mut context: PipelineExecutionContext<'_, SE>,
         mut params: ExecutionParameters,
@@ -1279,7 +1552,13 @@ impl<SE: extensions::ShellExtensions> ExecuteInPipeline<SE> for ast::SimpleComma
         }
 
         // If we have a command, then execute it.
-        if let Some(CommandArg::String(cmd_name)) = args.first() {
+        if let Some(signal_result) = params.consume_pending_signal(&mut context.shell).await?
+            && !signal_result.is_normal_flow()
+        {
+            return Ok(signal_result.into());
+        }
+
+        if let Some(CommandArg::String(cmd_name)) = args.first().cloned() {
             let mut stderr = params.stderr(&context.shell);
 
             let (owned_shell, parent_shell) = match context.shell {
@@ -1982,4 +2261,207 @@ fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Erro
     drop(writer);
 
     Ok(reader.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+    use std::time::Duration;
+
+    use crate::{ProcessGroupPolicy, Shell, SourceInfo};
+
+    struct BreakBuiltin;
+
+    impl crate::builtins::SimpleCommand for BreakBuiltin {
+        fn get_content(
+            _name: &str,
+            _content_type: crate::builtins::ContentType,
+            _options: &crate::builtins::ContentOptions,
+        ) -> Result<String, crate::error::Error> {
+            Ok(String::new())
+        }
+
+        fn execute<SE: crate::extensions::ShellExtensions, I: Iterator<Item = S>, S: AsRef<str>>(
+            _context: crate::commands::ExecutionContext<'_, SE>,
+            _args: I,
+        ) -> Result<crate::ExecutionResult, crate::error::Error> {
+            let mut result = crate::ExecutionResult::success();
+            result.next_control_flow = crate::ExecutionControlFlow::BreakLoop { levels: 0 };
+            Ok(result)
+        }
+    }
+
+    fn test_failure(message: impl Into<String>) -> crate::Error {
+        crate::error::ErrorKind::InternalError(message.into()).into()
+    }
+
+    fn ensure_test_condition(
+        condition: bool,
+        message: impl Into<String>,
+    ) -> Result<(), crate::Error> {
+        if condition {
+            Ok(())
+        } else {
+            Err(test_failure(message))
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_sigint_interrupts_while_loop() -> Result<(), crate::Error> {
+        let mut shell = Shell::builder().build().await?;
+        let params = shell.default_exec_params();
+        params.request_sigint();
+
+        let result = shell
+            .run_string(
+                "while ((1)); do interrupted=0; done",
+                &SourceInfo::from("test"),
+                &params,
+            )
+            .await?;
+
+        ensure_test_condition(u8::from(result.exit_code) == 130, "expected exit code 130")?;
+        ensure_test_condition(
+            matches!(
+                result.next_control_flow,
+                crate::ExecutionControlFlow::Interrupted
+            ),
+            "expected interrupted control flow",
+        )?;
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pending_sigint_interrupts_while_loop_child() -> Result<(), crate::Error> {
+        let mut shell = Shell::builder().build().await?;
+        let mut params = shell.default_exec_params();
+        params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
+        let run_params = params.clone();
+
+        let handle = tokio::spawn(async move {
+            shell
+                .run_string(
+                    "while ((1)); do sleep 10; done",
+                    &SourceInfo::from("test"),
+                    &run_params,
+                )
+                .await
+        });
+
+        let signaler = tokio::task::spawn_blocking(move || {
+            thread::sleep(Duration::from_millis(100));
+            params.request_sigint();
+        });
+        let timeout = tokio::task::spawn_blocking(|| thread::sleep(Duration::from_secs(2)));
+
+        let result = tokio::select! {
+            result = handle => result??,
+            _ = timeout => {
+                return Err(test_failure("timed out waiting for loop child cancellation"));
+            },
+        };
+        signaler.await?;
+
+        ensure_test_condition(u8::from(result.exit_code) == 130, "expected exit code 130")?;
+        ensure_test_condition(
+            matches!(
+                result.next_control_flow,
+                crate::ExecutionControlFlow::Interrupted
+            ),
+            "expected interrupted control flow",
+        )?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_sigint_runs_int_trap_in_while_loop() -> Result<(), crate::Error> {
+        let mut shell = Shell::builder()
+            .builtin(
+                "break",
+                crate::builtins::simple_builtin::<BreakBuiltin, _>(),
+            )
+            .build()
+            .await?;
+        shell.traps_mut().register_handler(
+            crate::traps::TrapSignal::try_from("INT")?,
+            "trap_seen=1; break".to_owned(),
+            SourceInfo::from("test trap"),
+        );
+        let params = shell.default_exec_params();
+        let signal_params = params.clone();
+
+        let signaler = tokio::task::spawn_blocking(move || {
+            thread::sleep(Duration::from_millis(100));
+            signal_params.request_sigint();
+        });
+        let timeout = tokio::task::spawn_blocking(|| thread::sleep(Duration::from_secs(2)));
+        let source_info = SourceInfo::from("test");
+
+        let result = tokio::select! {
+            result = shell.run_string(
+                "trap_seen=0; while ((1)); do loop_spin=1; done",
+                &source_info,
+                &params,
+            ) => result?,
+            _ = timeout => {
+                return Err(test_failure("timed out waiting for loop trap cancellation"));
+            },
+        };
+        signaler.await?;
+
+        ensure_test_condition(u8::from(result.exit_code) == 0, "expected exit code 0")?;
+        ensure_test_condition(result.is_normal_flow(), "expected normal control flow")?;
+        ensure_test_condition(
+            shell.env_str("trap_seen").as_deref() == Some("1"),
+            "expected INT trap to set trap_seen=1",
+        )?;
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pending_sigint_interrupts_and_or_list_before_rhs() -> Result<(), crate::Error> {
+        let mut shell = Shell::builder().build().await?;
+        let mut params = shell.default_exec_params();
+        params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
+        let signal_params = params.clone();
+
+        let signaler = tokio::task::spawn_blocking(move || {
+            thread::sleep(Duration::from_millis(100));
+            signal_params.request_sigint();
+        });
+        let timeout = tokio::task::spawn_blocking(|| thread::sleep(Duration::from_secs(2)));
+        let source_info = SourceInfo::from("test");
+
+        let result = tokio::select! {
+            result = shell.run_string(
+                "interrupted=0; while ((1)); do sleep 10 || interrupted=1; done",
+                &source_info,
+                &params,
+            ) => result?,
+            _ = timeout => {
+                return Err(test_failure("timed out waiting for and-or cancellation"));
+            },
+        };
+        signaler.await?;
+
+        ensure_test_condition(u8::from(result.exit_code) == 130, "expected exit code 130")?;
+        ensure_test_condition(
+            matches!(
+                result.next_control_flow,
+                crate::ExecutionControlFlow::Interrupted
+            ),
+            "expected interrupted control flow",
+        )?;
+        ensure_test_condition(
+            shell.env_str("interrupted").as_deref() == Some("0"),
+            "expected rhs assignment to be skipped",
+        )?;
+
+        Ok(())
+    }
 }

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -2291,6 +2291,8 @@ mod tests {
         }
     }
 
+    const TEST_SIGINT: i32 = 2;
+
     fn test_failure(message: impl Into<String>) -> crate::Error {
         crate::error::ErrorKind::InternalError(message.into()).into()
     }
@@ -2307,10 +2309,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_sigint_interrupts_while_loop() -> Result<(), crate::Error> {
+    async fn host_signal_interrupts_while_loop() -> Result<(), crate::Error> {
         let mut shell = Shell::builder().build().await?;
         let params = shell.default_exec_params();
-        params.request_sigint();
+        params.request_host_signal(TEST_SIGINT);
 
         let result = shell
             .run_string(
@@ -2334,7 +2336,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn pending_sigint_interrupts_while_loop_child() -> Result<(), crate::Error> {
+    async fn host_signal_interrupts_while_loop_child() -> Result<(), crate::Error> {
         let mut shell = Shell::builder().build().await?;
         let mut params = shell.default_exec_params();
         params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
@@ -2352,7 +2354,7 @@ mod tests {
 
         let signaler = tokio::task::spawn_blocking(move || {
             thread::sleep(Duration::from_millis(100));
-            params.request_sigint();
+            params.request_host_signal(TEST_SIGINT);
         });
         let timeout = tokio::task::spawn_blocking(|| thread::sleep(Duration::from_secs(2)));
 
@@ -2376,8 +2378,43 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(unix)]
     #[tokio::test]
-    async fn pending_sigint_runs_int_trap_in_while_loop() -> Result<(), crate::Error> {
+    async fn host_signal_interrupts_external_pipeline() -> Result<(), crate::Error> {
+        let mut shell = Shell::builder().build().await?;
+        let mut params = shell.default_exec_params();
+        params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
+        let signal_params = params.clone();
+
+        let signaler = tokio::task::spawn_blocking(move || {
+            thread::sleep(Duration::from_millis(100));
+            signal_params.request_host_signal(TEST_SIGINT);
+        });
+        let timeout = tokio::task::spawn_blocking(|| thread::sleep(Duration::from_secs(2)));
+        let source_info = SourceInfo::from("test");
+
+        let result = tokio::select! {
+            result = shell.run_string("sleep 10 | sleep 10", &source_info, &params) => result?,
+            _ = timeout => {
+                return Err(test_failure("timed out waiting for pipeline cancellation"));
+            },
+        };
+        signaler.await?;
+
+        ensure_test_condition(u8::from(result.exit_code) == 130, "expected exit code 130")?;
+        ensure_test_condition(
+            matches!(
+                result.next_control_flow,
+                crate::ExecutionControlFlow::Interrupted
+            ),
+            "expected interrupted control flow",
+        )?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn host_signal_runs_int_trap_in_while_loop() -> Result<(), crate::Error> {
         let mut shell = Shell::builder()
             .builtin(
                 "break",
@@ -2395,7 +2432,7 @@ mod tests {
 
         let signaler = tokio::task::spawn_blocking(move || {
             thread::sleep(Duration::from_millis(100));
-            signal_params.request_sigint();
+            signal_params.request_host_signal(TEST_SIGINT);
         });
         let timeout = tokio::task::spawn_blocking(|| thread::sleep(Duration::from_secs(2)));
         let source_info = SourceInfo::from("test");
@@ -2424,7 +2461,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn pending_sigint_interrupts_and_or_list_before_rhs() -> Result<(), crate::Error> {
+    async fn host_signal_interrupts_and_or_list_before_rhs() -> Result<(), crate::Error> {
         let mut shell = Shell::builder().build().await?;
         let mut params = shell.default_exec_params();
         params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
@@ -2432,7 +2469,7 @@ mod tests {
 
         let signaler = tokio::task::spawn_blocking(move || {
             thread::sleep(Duration::from_millis(100));
-            signal_params.request_sigint();
+            signal_params.request_host_signal(TEST_SIGINT);
         });
         let timeout = tokio::task::spawn_blocking(|| thread::sleep(Duration::from_secs(2)));
         let source_info = SourceInfo::from("test");

--- a/brush-core/src/processes.rs
+++ b/brush-core/src/processes.rs
@@ -2,7 +2,7 @@
 
 use futures::FutureExt;
 
-use crate::{error, sys};
+use crate::{ExecutionParameters, error, sys, traps};
 
 /// A waitable future that will yield the results of a child process's execution.
 pub(crate) type WaitableChildProcess = std::pin::Pin<
@@ -17,6 +17,8 @@ pub struct ChildProcess {
     pid: Option<sys::process::ProcessId>,
     /// If available, the process group ID of the child.
     pgid: Option<sys::process::ProcessId>,
+    /// Whether a host-requested signal was forwarded while waiting.
+    forwarded_signal: bool,
 }
 
 impl ChildProcess {
@@ -30,6 +32,7 @@ impl ChildProcess {
             exec_future: Box::pin(child.wait_with_output()),
             pid,
             pgid,
+            forwarded_signal: false,
         }
     }
 
@@ -43,8 +46,31 @@ impl ChildProcess {
         self.pgid
     }
 
+    /// Returns whether a host-requested signal was forwarded to this child.
+    pub const fn forwarded_signal(&self) -> bool {
+        self.forwarded_signal
+    }
+
     /// Waits for the process to exit.
     pub async fn wait(&mut self) -> Result<ProcessWaitResult, error::Error> {
+        self.wait_impl(None).await
+    }
+
+    pub(crate) async fn wait_with_params(
+        &mut self,
+        params: &ExecutionParameters,
+    ) -> Result<ProcessWaitResult, error::Error> {
+        self.wait_impl(Some(params)).await
+    }
+
+    async fn wait_impl(
+        &mut self,
+        params: Option<&ExecutionParameters>,
+    ) -> Result<ProcessWaitResult, error::Error> {
+        let mut observed_signal_generation = params
+            .map(ExecutionParameters::pending_signal_generation)
+            .unwrap_or_default();
+
         #[allow(unused_mut, reason = "only mutated on some platforms")]
         let mut sigtstp = sys::signal::tstp_signal_listener()?;
         #[allow(unused_mut, reason = "only mutated on some platforms")]
@@ -69,7 +95,40 @@ impl ChildProcess {
                     // have received it as well, and either handled it or ended up getting
                     // terminated (in which case we'll see the child exit).
                 },
+                (signal_generation, signal_number, forward_to_child) = wait_for_pending_signal(params, observed_signal_generation), if params.is_some() => {
+                    observed_signal_generation = signal_generation;
+                    if forward_to_child {
+                        self.forward_signal(signal_number);
+                    } else if let Some(params) = params {
+                        params.clear_pending_signal();
+                    }
+                },
             }
+        }
+    }
+
+    fn forward_signal(&mut self, signal_number: i32) {
+        let Ok(signal) = sys::signal::Signal::try_from(signal_number) else {
+            return;
+        };
+
+        self.forwarded_signal = true;
+        let signal = traps::TrapSignal::Signal(signal);
+        if let Some(pgid) = self.pgid {
+            if let Err(error) = sys::signal::kill_process_group(pgid, signal) {
+                tracing::debug!(
+                    pgid,
+                    %error,
+                    "failed to forward pending signal to child process group"
+                );
+            }
+            return;
+        }
+
+        if let Some(pid) = self.pid
+            && let Err(error) = sys::signal::kill_process(pid, signal)
+        {
+            tracing::debug!(pid, %error, "failed to forward pending signal to child process");
         }
     }
 
@@ -87,4 +146,17 @@ pub enum ProcessWaitResult {
     Completed(std::process::Output),
     /// The process stopped and has not yet completed.
     Stopped,
+}
+
+async fn wait_for_pending_signal(
+    params: Option<&ExecutionParameters>,
+    observed_generation: u64,
+) -> (u64, i32, bool) {
+    let Some(params) = params else {
+        futures::future::pending().await
+    };
+
+    params
+        .wait_for_pending_signal_after(observed_generation)
+        .await
 }

--- a/brush-core/src/results.rs
+++ b/brush-core/src/results.rs
@@ -3,7 +3,7 @@
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 
-use crate::{error, processes};
+use crate::{ExecutionParameters, error, processes};
 
 /// Represents the result of executing a command or similar item.
 #[derive(Default)]
@@ -49,6 +49,29 @@ impl ExecutionResult {
         Self {
             next_control_flow: ExecutionControlFlow::Normal,
             exit_code: ExecutionExitCode::GeneralError,
+        }
+    }
+
+    /// Returns a new `ExecutionResult` for an interrupted execution.
+    pub const fn interrupted() -> Self {
+        Self {
+            next_control_flow: ExecutionControlFlow::Interrupted,
+            exit_code: ExecutionExitCode::Interrupted,
+        }
+    }
+
+    /// Returns a new `ExecutionResult` for execution interrupted by a signal.
+    pub fn signaled(signal_number: i32) -> Self {
+        let exit_code = match u8::try_from(signal_number) {
+            Ok(signal_number) if (1..=127).contains(&signal_number) => {
+                ExecutionExitCode::from(128 + signal_number)
+            }
+            _ => ExecutionExitCode::Interrupted,
+        };
+
+        Self {
+            next_control_flow: ExecutionControlFlow::Interrupted,
+            exit_code,
         }
     }
 
@@ -218,6 +241,8 @@ pub enum ExecutionControlFlow {
     ReturnFromFunctionOrScript,
     /// Exit the shell.
     ExitShell,
+    /// Stop execution because a signal interrupted the shell.
+    Interrupted,
 }
 
 impl ExecutionControlFlow {
@@ -260,13 +285,42 @@ impl From<ExecutionResult> for ExecutionSpawnResult {
 impl ExecutionSpawnResult {
     /// Waits for the command to complete.
     pub async fn wait(self) -> Result<ExecutionWaitResult, error::Error> {
+        self.wait_impl(None).await
+    }
+
+    pub(crate) async fn wait_with_params(
+        self,
+        params: &ExecutionParameters,
+    ) -> Result<ExecutionWaitResult, error::Error> {
+        self.wait_impl(Some(params)).await
+    }
+
+    async fn wait_impl(
+        self,
+        params: Option<&ExecutionParameters>,
+    ) -> Result<ExecutionWaitResult, error::Error> {
         let result = match self {
             Self::StartedProcess(mut child) => {
                 // Wait for the process to exit or for a relevant signal, whichever happens
                 // first.
-                match child.wait().await? {
+                let wait_result = if let Some(params) = params {
+                    child.wait_with_params(params).await?
+                } else {
+                    child.wait().await?
+                };
+
+                let forwarded_signal = child.forwarded_signal();
+                match wait_result {
                     processes::ProcessWaitResult::Completed(output) => {
-                        ExecutionWaitResult::Completed(ExecutionResult::from(output))
+                        let result = ExecutionResult::from(output);
+                        if forwarded_signal
+                            && !matches!(result.exit_code, ExecutionExitCode::Interrupted)
+                            && let Some(params) = params
+                        {
+                            params.clear_pending_signal();
+                        }
+
+                        ExecutionWaitResult::Completed(result)
                     }
                     processes::ProcessWaitResult::Stopped => ExecutionWaitResult::Stopped(child),
                 }

--- a/brush-core/src/sys/stubs/commands.rs
+++ b/brush-core/src/sys/stubs/commands.rs
@@ -80,8 +80,12 @@ impl CommandFdInjectionExt for std::process::Command {
 pub trait CommandFgControlExt {
     /// Arranges for the command to take the foreground when it is executed.
     fn take_foreground(&mut self);
+
     /// Arranges for the command to become a session leader when it is executed.
     fn lead_session(&mut self);
+
+    /// Arranges for child job-control signals to use their default dispositions.
+    fn reset_job_control_signals(&mut self);
 }
 
 impl CommandFgControlExt for std::process::Command {
@@ -90,6 +94,10 @@ impl CommandFgControlExt for std::process::Command {
     }
 
     fn lead_session(&mut self) {
+        // NOTE: This is a no-op.
+    }
+
+    fn reset_job_control_signals(&mut self) {
         // NOTE: This is a no-op.
     }
 }

--- a/brush-core/src/sys/stubs/signal.rs
+++ b/brush-core/src/sys/stubs/signal.rs
@@ -46,6 +46,13 @@ pub fn kill_process(
     Err(error::ErrorKind::NotSupportedOnThisPlatform("killing process").into())
 }
 
+pub(crate) fn kill_process_group(
+    _pgid: sys::process::ProcessId,
+    _signal: traps::TrapSignal,
+) -> Result<(), error::Error> {
+    Err(error::ErrorKind::NotSupportedOnThisPlatform("killing process group").into())
+}
+
 pub(crate) fn lead_new_process_group() -> Result<(), error::Error> {
     Ok(())
 }
@@ -70,7 +77,8 @@ pub(crate) fn chld_signal_listener() -> Result<FakeSignal, error::Error> {
     Ok(FakeSignal::new())
 }
 
-pub(crate) async fn await_ctrl_c() -> std::io::Result<()> {
+/// Waits indefinitely for Ctrl-C on platforms without signal support.
+pub async fn await_ctrl_c() -> std::io::Result<()> {
     FakeSignal::new().recv().await;
     Ok(())
 }

--- a/brush-core/src/sys/unix/commands.rs
+++ b/brush-core/src/sys/unix/commands.rs
@@ -48,8 +48,12 @@ impl CommandFdInjectionExt for std::process::Command {
 pub trait CommandFgControlExt {
     /// Arranges for the command to take the foreground when it is executed.
     fn take_foreground(&mut self);
+
     /// Arranges for the command to become a session leader when it is executed.
     fn lead_session(&mut self);
+
+    /// Arranges for child job-control signals to use their default dispositions.
+    fn reset_job_control_signals(&mut self);
 }
 
 impl CommandFgControlExt for std::process::Command {
@@ -72,12 +76,22 @@ impl CommandFgControlExt for std::process::Command {
             self.pre_exec(pre_exec_lead_session);
         }
     }
+
+    fn reset_job_control_signals(&mut self) {
+        // SAFETY:
+        // This arranges for a provided function to run in the context of
+        // the forked process before it exec's the target command.
+        unsafe {
+            self.pre_exec(reset_job_control_signals);
+        }
+    }
 }
 
 fn pre_exec_take_foreground() -> Result<(), std::io::Error> {
     use crate::sys;
 
     sys::terminal::move_self_to_foreground()?;
+    reset_job_control_signals()?;
     Ok(())
 }
 
@@ -99,6 +113,42 @@ fn pre_exec_lead_session() -> Result<(), std::io::Error> {
     if result != 0 {
         return Err(std::io::Error::other("failed to set controlling terminal"));
     }
+
+    reset_job_control_signals()?;
+    Ok(())
+}
+
+/// Reset job control signals to `SIG_DFL` (default disposition).
+/// This undoes any `SIG_IGN` settings inherited from parent.
+fn reset_job_control_signals() -> Result<(), std::io::Error> {
+    use nix::sys::signal::{SigHandler, SigSet, SigmaskHow, Signal, signal, sigprocmask};
+
+    // These signals should have default disposition in child processes even if
+    // the parent shell ignores them. SIGPIPE is critical for pipeline handling:
+    // without it, writing to closed pipes can block indefinitely.
+    let signals = [
+        Signal::SIGINT,
+        Signal::SIGQUIT,
+        Signal::SIGTSTP,
+        Signal::SIGTTOU,
+        Signal::SIGTTIN,
+        Signal::SIGPIPE,
+    ];
+
+    for sig in signals {
+        // SAFETY:
+        // This runs in the forked child before exec. Resetting inherited signal
+        // dispositions with signal(2) is async-signal-safe.
+        unsafe {
+            signal(sig, SigHandler::SigDfl).map_err(std::io::Error::from)?;
+        }
+    }
+
+    let mut sigset = SigSet::empty();
+    for sig in signals {
+        sigset.add(sig);
+    }
+    sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&sigset), None).map_err(std::io::Error::from)?;
 
     Ok(())
 }

--- a/brush-core/src/sys/unix/signal.rs
+++ b/brush-core/src/sys/unix/signal.rs
@@ -35,6 +35,26 @@ pub fn kill_process(
     Ok(())
 }
 
+pub(crate) fn kill_process_group(
+    pgid: sys::process::ProcessId,
+    signal: traps::TrapSignal,
+) -> Result<(), error::Error> {
+    let translated_signal = match signal {
+        traps::TrapSignal::Signal(signal) => signal,
+        traps::TrapSignal::Debug
+        | traps::TrapSignal::Err
+        | traps::TrapSignal::Exit
+        | traps::TrapSignal::Return => {
+            return Err(error::ErrorKind::InvalidSignal(signal.to_string()).into());
+        }
+    };
+
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(-pgid), translated_signal)
+        .map_err(|_errno| error::ErrorKind::FailedToSendSignal)?;
+
+    Ok(())
+}
+
 pub(crate) fn lead_new_process_group() -> Result<(), error::Error> {
     nix::unistd::setpgid(nix::unistd::Pid::from_raw(0), nix::unistd::Pid::from_raw(0))?;
     Ok(())
@@ -52,7 +72,7 @@ pub(crate) fn chld_signal_listener() -> Result<tokio::signal::unix::Signal, erro
     Ok(signal)
 }
 
-pub(crate) use tokio::signal::ctrl_c as await_ctrl_c;
+pub use tokio::signal::ctrl_c as await_ctrl_c;
 
 pub(crate) fn mask_sigttou() -> Result<(), error::Error> {
     let ignore = nix::sys::signal::SigAction::new(

--- a/brush-core/src/sys/windows.rs
+++ b/brush-core/src/sys/windows.rs
@@ -11,7 +11,7 @@ pub use crate::sys::stubs::resource;
 /// Signal processing utilities
 pub mod signal {
     pub(crate) use crate::sys::stubs::signal::*;
-    pub(crate) use tokio::signal::ctrl_c as await_ctrl_c;
+    pub use tokio::signal::ctrl_c as await_ctrl_c;
 }
 
 pub use crate::sys::stubs::terminal;

--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -292,11 +292,13 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
 
         // Execute the command.
         let params = shell.default_exec_params();
+        let sigint_listener = Self::spawn_sigint_listener(&params);
         let source_info = brush_core::SourceInfo::from("main");
         let result = match shell.run_string(read_result, &source_info, &params).await {
             Ok(result) => Ok(InteractiveExecutionResult::Executed(result)),
             Err(e) => Ok(InteractiveExecutionResult::Failed(e)),
         };
+        sigint_listener.abort();
 
         // Update cumulative line counter based on actual lines in the command.
         shell.increment_interactive_line_offset(line_count);
@@ -328,6 +330,17 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
         }
 
         result
+    }
+
+    fn spawn_sigint_listener(
+        params: &brush_core::ExecutionParameters,
+    ) -> tokio::task::JoinHandle<()> {
+        let params = params.clone();
+        tokio::spawn(async move {
+            while brush_core::sys::signal::await_ctrl_c().await.is_ok() {
+                params.request_interactive_sigint();
+            }
+        })
     }
 
     async fn run_pre_prompt_actions(

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -677,7 +677,7 @@ mod tests {
     use pretty_assertions::{assert_eq, assert_matches};
 
     fn args(strs: &[&str]) -> Vec<String> {
-        strs.iter().map(|s| s.to_string()).collect()
+        strs.iter().copied().map(str::to_owned).collect()
     }
 
     #[test]

--- a/brush-shell/tests/cases/compat/builtins/trap.yaml
+++ b/brush-shell/tests/cases/compat/builtins/trap.yaml
@@ -247,7 +247,6 @@ cases:
       echo "$result"
 
   - name: "command substitution does not fire inherited signal trap"
-    known_failure: true # TODO(signals): signal handling in command substitution
     stdin: |
       trap 'echo "[int]" >&2' INT
       result=$(kill -INT $$; echo "after kill")
@@ -336,7 +335,6 @@ cases:
       wait
 
   - name: "background job does not fire inherited signal trap"
-    known_failure: true # TODO(signals): background job signal handling
     stdin: |
       trap 'echo "[int]" >&2' INT
       { kill -INT $$; echo "after kill"; } &
@@ -489,7 +487,6 @@ cases:
   # Signal trap execution verification
   #
   - name: "trap SIGUSR1"
-    known_failure: true # TODO(signals): signal handling
     stdin: |
       trap 'echo "[usr1 received]"' USR1
       trap -p USR1
@@ -497,7 +494,6 @@ cases:
       echo "after signal"
 
   - name: "trap SIGUSR2"
-    known_failure: true # TODO(signals): signal handling
     stdin: |
       trap 'echo "[usr2 received]"' SIGUSR2
       trap -p USR2
@@ -505,7 +501,6 @@ cases:
       echo "after signal"
 
   - name: "trap multiple signals with same handler"
-    known_failure: true # TODO(signals): signal handling
     stdin: |
       trap 'echo "[signal received]"' USR1 USR2
       kill -USR1 $$
@@ -513,7 +508,6 @@ cases:
       echo "done"
 
   - name: "trap handler can inspect signal"
-    known_failure: true # TODO(signals): signal handling
     stdin: |
       handler() {
         echo "handler called"
@@ -533,7 +527,6 @@ cases:
       trap -p INT
 
   - name: "trap '' ignores signal"
-    known_failure: true # TODO(signals): signal handling
     stdin: |
       trap '' INT
       trap -p INT

--- a/brush-shell/tests/interactive_tests.rs
+++ b/brush-shell/tests/interactive_tests.rs
@@ -7,6 +7,7 @@
 
 use anyhow::Context;
 use std::os::unix::process::CommandExt as _;
+use std::time::Duration;
 
 use expectrl::{
     Expect, Session,
@@ -131,6 +132,47 @@ fn login_shell_via_argv0_shows_prompt() -> anyhow::Result<()> {
     session.expect_prompt()?;
     let login_shell_output = session.exec_output("shopt -q login_shell && echo login")?;
     assert!(login_shell_output.contains("login"));
+
+    session.exit()?;
+
+    Ok(())
+}
+
+#[test]
+fn interrupt_pure_shell_loop_interactively() -> anyhow::Result<()> {
+    let mut session = start_shell_session()?;
+
+    session.expect_prompt()?;
+    session.send_line("while ((1)); do :; done")?;
+    std::thread::sleep(Duration::from_millis(300));
+    session.interrupt()?;
+    session
+        .expect_prompt()
+        .context("Prompt did not return after interrupting pure shell loop")?;
+
+    let status_output = session.exec_output("echo status=$?")?;
+    assert!(status_output.contains("status=130"));
+
+    session.exit()?;
+
+    Ok(())
+}
+
+#[test]
+fn interrupt_shell_loop_runs_int_trap_interactively() -> anyhow::Result<()> {
+    let mut session = start_shell_session()?;
+
+    session.expect_prompt()?;
+    session.send_line("trap 'echo trapped; break' INT; while ((1)); do :; done")?;
+    std::thread::sleep(Duration::from_millis(300));
+    session.interrupt()?;
+    session.expect("trapped")?;
+    session
+        .expect_prompt()
+        .context("Prompt did not return after INT trap broke shell loop")?;
+
+    let status_output = session.exec_output("echo status=$?")?;
+    assert!(status_output.contains("status=0"));
 
     session.exit()?;
 


### PR DESCRIPTION
Brush currently handles Ctrl-C differently depending on what is running. Bash sends SIGINT to the foreground process group for external commands and pipelines, and it also interrupts shell-native evaluation. If an `INT` trap is installed, Bash runs the trap and lets it decide control flow; otherwise interrupted shell-native work returns the usual SIGINT status.

This brings Brush closer to that model for both shell-native execution and foreground processes. `ExecutionParameters` can now carry a host-requested signal, and centralized execution checkpoints let loops, functions, builtins, compound commands, and traps observe cancellation without manually instrumenting every AST node. Foreground process waits can wake on the same signal state and forward the signal to the child process group, including pipelines.

The interactive shell wires Ctrl-C into the active execution parameters. In a PTY, the terminal driver already delivers SIGINT to the foreground process group, so the interactive path avoids double-forwarding and uses the cooperative signal path to make Brush's own shell code see the interrupt.

For embedders that drive a shell over an API, `ExecutionParameters::request_host_signal(signal_number)` is the hook for injecting a signal into both shell-native execution and foreground children. `ExecutionParameters::request_forced_signal(signal_number)` is available for timeout/kill-style cancellation that should bypass shell traps.
