### PR TITLE
fix(reedline): use theme-adaptive input styles

### DIFF
--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -73,6 +73,16 @@ pub(crate) struct ReedlineHighlighter<SE: brush_core::ShellExtensions> {
     pub shell: refs::ShellRef<SE>,
 }
 
+pub(crate) struct PlainTextHighlighter;
+
+impl reedline::Highlighter for PlainTextHighlighter {
+    fn highlight(&self, line: &str, _cursor: usize) -> reedline::StyledText {
+        let mut styled = reedline::StyledText::new();
+        styled.push((Style::new(), line.to_owned()));
+        styled
+    }
+}
+
 impl<SE: brush_core::ShellExtensions> reedline::Highlighter for ReedlineHighlighter<SE> {
     #[expect(clippy::significant_drop_tightening)]
     fn highlight(&self, line: &str, cursor: usize) -> reedline::StyledText {
@@ -110,5 +120,21 @@ fn kind_to_style(kind: highlighting::HighlightKind) -> Style {
         highlighting::HighlightKind::ExternalCommand => styles::external_command(),
         highlighting::HighlightKind::NotFoundCommand => styles::not_found_command(),
         highlighting::HighlightKind::UnknownCommand => styles::unknown_command(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reedline::Highlighter;
+
+    #[test]
+    fn plain_text_highlighter_uses_terminal_default_colors() {
+        let styled = PlainTextHighlighter.highlight("echo hello", 0);
+
+        assert_eq!(styled.buffer.len(), 1);
+        assert_eq!(styled.buffer[0].0.foreground, None);
+        assert_eq!(styled.buffer[0].0.background, None);
+        assert_eq!(styled.buffer[0].1, "echo hello");
     }
 }

--- a/brush-interactive/src/reedline/input_backend.rs
+++ b/brush-interactive/src/reedline/input_backend.rs
@@ -1,4 +1,4 @@
-use nu_ansi_term::Color;
+use nu_ansi_term::Style;
 use reedline::MenuBuilder;
 
 use super::{completer, edit_mode, highlighter, history, validator};
@@ -11,6 +11,26 @@ pub struct ReedlineInputBackend {
 }
 
 const COMPLETION_MENU_NAME: &str = "completion_menu";
+
+fn completion_menu_text_style() -> Style {
+    Style::new()
+}
+
+fn completion_menu_selected_text_style() -> Style {
+    Style::new().bold().reverse()
+}
+
+fn completion_menu_match_text_style() -> Style {
+    Style::new().underline()
+}
+
+fn completion_menu_selected_match_text_style() -> Style {
+    completion_menu_selected_text_style().underline()
+}
+
+fn history_hint_style() -> Style {
+    Style::new().italic().dimmed()
+}
 
 impl ReedlineInputBackend {
     /// Returns a new interactive shell instance, created with the provided options.
@@ -38,7 +58,7 @@ impl ReedlineInputBackend {
         let validator = validator::ReedlineValidator {
             shell: shell_ref.clone(),
         };
-        let highlighter = highlighter::ReedlineHighlighter {
+        let syntax_highlighter = highlighter::ReedlineHighlighter {
             shell: shell_ref.clone(),
         };
         let history = history::ReedlineHistory {
@@ -57,14 +77,16 @@ impl ReedlineInputBackend {
                 .with_name(COMPLETION_MENU_NAME)
                 .with_marker("")
                 .with_columns(10)
-                .with_selected_text_style(Color::Blue.bold().reverse())
-                .with_selected_match_text_style(Color::Blue.bold().reverse()),
+                .with_text_style(completion_menu_text_style())
+                .with_match_text_style(completion_menu_match_text_style())
+                .with_selected_text_style(completion_menu_selected_text_style())
+                .with_selected_match_text_style(completion_menu_selected_match_text_style()),
         );
 
         // Set up default history-based hinter.
         let mut hinter = reedline::DefaultHinter::default();
         if !options.disable_color {
-            hinter = hinter.with_style(nu_ansi_term::Style::new().italic().fg(Color::DarkGray));
+            hinter = hinter.with_style(history_hint_style());
         }
 
         // Instantiate reedline with some defaults and hand it ownership of
@@ -80,9 +102,15 @@ impl ReedlineInputBackend {
             .with_edit_mode(Box::new(mutable_edit_mode))
             .with_history(Box::new(history));
 
-        // If requested, apply some additional niceties.
-        if !options.disable_highlighting && !options.disable_color {
-            reedline = reedline.with_highlighter(Box::new(highlighter));
+        // Override Reedline's default example highlighter, which hard-codes white as the
+        // neutral input color. When syntax highlighting is disabled we still install a plain
+        // highlighter so typed text follows the terminal's default foreground color.
+        if !options.disable_color {
+            reedline = if options.disable_highlighting {
+                reedline.with_highlighter(Box::new(highlighter::PlainTextHighlighter))
+            } else {
+                reedline.with_highlighter(Box::new(syntax_highlighter))
+            };
         }
 
         let mut shell = tokio::task::block_in_place(|| {
@@ -224,4 +252,45 @@ fn compose_key_bindings(completion_menu_name: &str) -> reedline::Keybindings {
     );
 
     key_bindings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_hint_style_is_theme_adaptive() {
+        let style = history_hint_style();
+
+        assert_eq!(style.foreground, None);
+        assert_eq!(style.background, None);
+        assert!(style.is_italic);
+        assert!(style.is_dimmed);
+    }
+
+    #[test]
+    fn completion_menu_styles_are_theme_adaptive() {
+        let text_style = completion_menu_text_style();
+        let match_style = completion_menu_match_text_style();
+        let selected_text_style = completion_menu_selected_text_style();
+        let selected_match_text_style = completion_menu_selected_match_text_style();
+
+        assert_eq!(text_style.foreground, None);
+        assert_eq!(text_style.background, None);
+
+        assert_eq!(match_style.foreground, None);
+        assert_eq!(match_style.background, None);
+        assert!(match_style.is_underline);
+
+        assert_eq!(selected_text_style.foreground, None);
+        assert_eq!(selected_text_style.background, None);
+        assert!(selected_text_style.is_bold);
+        assert!(selected_text_style.is_reverse);
+
+        assert_eq!(selected_match_text_style.foreground, None);
+        assert_eq!(selected_match_text_style.background, None);
+        assert!(selected_match_text_style.is_bold);
+        assert!(selected_match_text_style.is_reverse);
+        assert!(selected_match_text_style.is_underline);
+    }
 }


### PR DESCRIPTION
Summary:

Keep Reedline input, completion menus, and history hints aligned with the terminal theme instead of forcing hard-coded colors. Reedline's default example highlighter painted unhighlighted input white, and our menu and hint styles also pinned specific colors, which made the interactive UI look wrong when syntax highlighting was disabled.

Install a plain-text highlighter whenever colors are enabled but syntax highlighting is not, and switch neutral menu and hint styles to attribute-only formatting. Add tests that assert these styles leave the terminal's foreground and background colors untouched.

Test Plan:

1. Run 'cargo fmt --check'.
2. Run 'cargo test --package brush-interactive'.
3. Run 'cargo test --package brush-interactive --features reedline'.

I have also been using this for a bit. Here are the screenshots.

Before

<img width="387" height="35" alt="Screenshot 2026-06-12 at 18 46 16" src="https://github.com/user-attachments/assets/789db6c6-e7ce-40e0-9fd5-105dd4422283" />

<img width="387" height="35" alt="Screenshot 2026-06-12 at 18 46 39" src="https://github.com/user-attachments/assets/4f9842d6-1f87-47c6-b04c-5f30338e0ebb" />

After

<img width="379" height="35" alt="Screenshot 2026-06-12 at 18 43 07" src="https://github.com/user-attachments/assets/7643cc6b-d57b-4c58-a45a-da084d1accc1" />

<img width="379" height="35" alt="Screenshot 2026-06-12 at 18 42 35" src="https://github.com/user-attachments/assets/faf37410-44e9-427a-a897-7f9de333b169" />




