### PR TITLE
fix(expansion): join $*/${a[*]} via IFS first char in scalar contexts

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -592,7 +592,22 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
 
     /// Apply tilde-expansion, parameter expansion, command substitution, and arithmetic expansion.
     pub async fn basic_expand_to_str(&mut self, word: &str) -> Result<String, error::Error> {
-        Ok(String::from(self.basic_expand(word).await?))
+        let expansion = self.basic_expand(word).await?;
+        // Join the expanded fields for scalar (non-split) contexts following
+        // bash rules: `$*`/`${a[*]}` (concatenate=true) join with the first
+        // character of IFS, while `$@`/`${a[@]}` join with a space. A single
+        // field (the common case) is unaffected. Without this, e.g.
+        // `x=${arr[*]}` under `IFS=:` would yield `a b c` instead of `a:b:c`.
+        let joiner = if expansion.concatenate {
+            self.shell.get_ifs_first_char()
+        } else {
+            ' '
+        };
+        Ok(expansion
+            .fields
+            .into_iter()
+            .map(String::from)
+            .join(joiner.to_string().as_str()))
     }
 
     async fn basic_expand_opt_pattern(

--- a/brush-shell/tests/cases/compat/ifs.yaml
+++ b/brush-shell/tests/cases/compat/ifs.yaml
@@ -403,3 +403,39 @@ cases:
       for arg in "$@"; do
         echo "[$arg]"
       done
+
+  - name: "Array star join in scalar assignment honors IFS"
+    stdin: |
+      arr=(a b c)
+      IFS=:
+      x=${arr[*]}
+      echo "[$x]"
+
+  - name: "Array at join in scalar assignment uses space"
+    stdin: |
+      arr=(a b c)
+      IFS=:
+      y=${arr[@]}
+      echo "[$y]"
+
+  - name: "Export assignment from array star honors IFS"
+    stdin: |
+      np=(/first/bin /usr/lib/llvm/21/bin /usr/bin)
+      IFS=:
+      export TESTPATH=${np[*]}
+      echo "[$TESTPATH]"
+
+  - name: "Split on IFS then rejoin via star"
+    stdin: |
+      p="x:y:z"
+      IFS=:
+      s=( ${p} )
+      out=${s[*]}
+      echo "[$out]"
+
+  - name: "Positional star join in scalar assignment honors IFS"
+    stdin: |
+      set -- a b c
+      IFS=:
+      x=$*
+      echo "[$x]"


### PR DESCRIPTION
## Summary

In scalar (non-field-splitting) contexts such as an assignment RHS, `basic_expand_to_str` converted the expanded fields to a string with a hardcoded space join (the `From<Expansion> for String` impl), ignoring both the expansion's `concatenate` flag and `IFS`.

So `x=${arr[*]}` (or `x=$*`) under `IFS=:` produced `a b c` instead of bash's `a:b:c`.

```sh
arr=(a b c)
IFS=:
x=${arr[*]}
echo "[$x]"   # bash: [a:b:c]   brush (before): [a b c]
```

This also breaks the common split-then-rejoin idiom (e.g. Gentoo's `llvm-utils` eclass), where `local IFS=:; sp=( ${PATH} ); export PATH=${sp[*]}` mangled every `:` separator into a space.

## Fix

Join the expanded fields following bash rules:
- `$*` / `${a[*]}` (`concatenate=true`) join with the **first character of IFS**
- `$@` / `${a[@]}` join with a **space**

A single field — the common scalar case — is unaffected.

## Tests

Verified against the bash oracle with new cases in `compat/ifs.yaml` (array/positional `[*]` and `[@]` joins in scalar assignment, the export-assignment PATH idiom, and split-then-rejoin). Full compat suite: 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)