### PR TITLE
fix(expansion): honor IFS when joining fields in more scalar contexts

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -101,13 +101,6 @@ impl Default for Expansion {
     }
 }
 
-impl From<Expansion> for String {
-    fn from(value: Expansion) -> Self {
-        // TODO(IFS): Use IFS instead for separator?
-        value.fields.into_iter().map(Self::from).join(" ")
-    }
-}
-
 impl From<String> for Expansion {
     fn from(value: String) -> Self {
         Self {
@@ -593,21 +586,26 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
     /// Apply tilde-expansion, parameter expansion, command substitution, and arithmetic expansion.
     pub async fn basic_expand_to_str(&mut self, word: &str) -> Result<String, error::Error> {
         let expansion = self.basic_expand(word).await?;
-        // Join the expanded fields for scalar (non-split) contexts following
-        // bash rules: `$*`/`${a[*]}` (concatenate=true) join with the first
-        // character of IFS, while `$@`/`${a[@]}` join with a space. A single
-        // field (the common case) is unaffected. Without this, e.g.
-        // `x=${arr[*]}` under `IFS=:` would yield `a b c` instead of `a:b:c`.
+        Ok(self.fields_to_string(expansion))
+    }
+
+    /// Join an [`Expansion`]'s fields into a single string for scalar
+    /// (non-field-splitting) contexts, following bash rules: `$*`/`${a[*]}`
+    /// (`concatenate=true`) join with the first character of IFS, while
+    /// `$@`/`${a[@]}` join with a space. A single field (the common case) is
+    /// unaffected. Without this, e.g. `x=${arr[*]}` under `IFS=:` would yield
+    /// `a b c` instead of bash's `a:b:c`.
+    fn fields_to_string(&self, expansion: Expansion) -> String {
         let joiner = if expansion.concatenate {
             self.shell.get_ifs_first_char()
         } else {
             ' '
         };
-        Ok(expansion
+        expansion
             .fields
             .into_iter()
             .map(String::from)
-            .join(joiner.to_string().as_str()))
+            .join(joiner.to_string().as_str())
     }
 
     async fn basic_expand_opt_pattern(
@@ -1200,8 +1198,8 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                         ParameterState::DefinedEmptyString,
                     ) => Ok(expanded_parameter),
                     _ => {
-                        let expanded_default_value =
-                            String::from(self.expand_parameter_word(default_value).await?);
+                        let expanded_default = self.expand_parameter_word(default_value).await?;
+                        let expanded_default_value = self.fields_to_string(expanded_default);
                         self.assign_to_parameter(&parameter, expanded_default_value.clone())
                             .await?;
                         Ok(Expansion::from(expanded_default_value))
@@ -1687,7 +1685,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
             Ok(self.try_resolve_parameter_to_variable_without_indirect(parameter))
         } else {
             let expansion = self.expand_parameter(parameter, false).await?;
-            let parameter_str: String = expansion.into();
+            let parameter_str: String = self.fields_to_string(expansion);
             let inner_parameter =
                 brush_parser::word::parse_parameter(parameter_str.as_str(), &self.parser_options)?;
             Ok(self.try_resolve_parameter_to_variable_without_indirect(&inner_parameter))
@@ -1762,7 +1760,7 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         if !indirect {
             Ok(expansion)
         } else {
-            let parameter_str: String = expansion.into();
+            let parameter_str: String = self.fields_to_string(expansion);
             let inner_parameter =
                 brush_parser::word::parse_parameter(parameter_str.as_str(), &self.parser_options)?;
 

--- a/brush-shell/tests/cases/compat/ifs.yaml
+++ b/brush-shell/tests/cases/compat/ifs.yaml
@@ -439,3 +439,40 @@ cases:
       IFS=:
       x=$*
       echo "[$x]"
+
+  - name: "Assign-default array star join honors IFS"
+    # `:` + a multi-field `:=` argument triggers a pre-existing, unrelated
+    # brush quirk ("command not found: <first field>" on stderr); the stdout
+    # is what verifies the IFS join.
+    ignore_stderr: true
+    stdin: |
+      arr=(a b c)
+      IFS=:
+      unset x
+      : ${x:=${arr[*]}}
+      echo "[$x]"
+
+  - name: "Assign-default array at join uses space"
+    ignore_stderr: true
+    stdin: |
+      arr=(a b c)
+      IFS=:
+      unset y
+      : ${y:=${arr[@]}}
+      echo "[$y]"
+
+  - name: "Use-default array star join honors IFS"
+    stdin: |
+      arr=(a b c)
+      IFS=:
+      unset z
+      echo "[${z:-${arr[*]}}]"
+
+  - name: "Assign-default positional star join honors IFS"
+    ignore_stderr: true
+    stdin: |
+      set -- a b c
+      IFS=:
+      unset p
+      : ${p:=$*}
+      echo "[$p]"


### PR DESCRIPTION
Follow-up to #1197, which fixed the IFS join only in `basic_expand_to_str`.

## Problem

The original fix (#1197) covered only its own call site. The underlying path — `impl From<Expansion> for String`, which joined fields with a hardcoded space and carried a `// TODO(IFS)` note — was still used in three other scalar contexts:

- **`${param:=word}`** (AssignDefaultValues): the default word was joined with a space, so `x=${arr[*]}` was already fixed but `unset x; : ${x:=${arr[*]}}` set `x` to `a b c` instead of bash's `a:b:c`.
- **`${!param}`** (indirect expansion, two sites): the outer expansion was joined with a space to re-parse as a name.

```text
$ arr=(a b c); IFS=:; unset x; : ${x:=${arr[*]}}; echo "[$x]"
bash:  [a:b:c]
brush: [a b c]   # before this PR
```

## Fix

- Extracted the IFS-aware join into a `fields_to_string` helper (`concatenate` ⇒ first IFS char, else space), reusing the logic #1197 added inline.
- Used it in `basic_expand_to_str` and all three remaining sites.
- Removed the now-unused `From<Expansion> for String` impl so the buggy path can't be reintroduced.

`${param:-word}` and `${param:+word}` were already correct — they propagate the `Expansion` with its `concatenate` flag up to the top-level join.

## Verification

New cases in `brush-shell/tests/cases/compat/ifs.yaml`, verified against the bash oracle:

```text
$ cargo test --test brush-compat-tests -- 'IFS' 'join'
56 succeeded, 0 failed, 11 known to fail
```

`x=${arr[*]}`, `: ${x:=${arr[*]}}`, `: ${x:=$*}`, and `${z:-${arr[*]}}` now all honor IFS under `IFS=:`.

## Note

The three `:`-based cases use `ignore_stderr` because of a **pre-existing, unrelated** brush quirk: `:` + a multi-field `:=` argument emits a spurious `command not found: <first field>` on stderr. stdout is correct, and it reproduces on `main` independent of this change — worth a separate look.
