### PR TITLE
fix(highlighting): correct crash issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "brush-core",
+ "brush-interactive",
  "brush-parser",
  "libfuzzer-sys",
  "tokio",

--- a/brush-interactive/src/highlighting.rs
+++ b/brush-interactive/src/highlighting.rs
@@ -4,8 +4,6 @@
 //! imposing any specific styling. Consumers can map the semantic categories
 //! to their own color schemes or styles.
 
-use std::str::Chars;
-
 /// Semantic category for a highlighted span.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HighlightKind {
@@ -46,30 +44,71 @@ pub enum HighlightKind {
 /// A highlighted span of text with semantic meaning.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HighlightSpan {
-    /// Start byte offset in the input string
-    pub start: usize,
-    /// End byte offset in the input string
-    pub end: usize,
-    /// Semantic category of this span
+    /// Byte range of this span within the input string.
+    pub range: std::ops::Range<usize>,
+    /// Semantic category of this span.
     pub kind: HighlightKind,
 }
 
 impl HighlightSpan {
-    /// Creates a new highlight span.
+    /// Creates a new highlight span over the given byte range.
     #[must_use]
-    pub const fn new(start: usize, end: usize, kind: HighlightKind) -> Self {
-        Self { start, end, kind }
-    }
-
-    /// Returns the text of this span from the input string.
-    #[must_use]
-    #[allow(clippy::string_slice)]
-    pub fn text<'a>(&self, input: &'a str) -> &'a str {
-        &input[self.start..self.end]
+    pub const fn new(range: std::ops::Range<usize>, kind: HighlightKind) -> Self {
+        Self { range, kind }
     }
 }
 
-/// Highlights a shell command string, returning semantic spans.
+/// The result of highlighting a line: the spans plus the line they index into.
+///
+/// Pairing the two means span text is resolved against the original input
+/// rather than a separately-supplied (and possibly mismatched) string.
+pub struct Highlighted<'a> {
+    line: &'a str,
+    spans: Vec<HighlightSpan>,
+}
+
+impl<'a> Highlighted<'a> {
+    /// The line that was highlighted.
+    #[must_use]
+    pub const fn line(&self) -> &'a str {
+        self.line
+    }
+
+    /// The spans, in order, covering the entire line.
+    #[must_use]
+    pub fn spans(&self) -> &[HighlightSpan] {
+        &self.spans
+    }
+
+    /// Returns the text of `span` within the highlighted line.
+    ///
+    /// `span` is expected to be one of [`Self::spans`]; a range that is out of
+    /// bounds or off a UTF-8 char boundary (debug-asserted) yields `""` rather
+    /// than panicking.
+    #[must_use]
+    pub fn text(&self, span: &HighlightSpan) -> &'a str {
+        debug_assert!(
+            self.line.is_char_boundary(span.range.start),
+            "highlight span start {} is not a UTF-8 char boundary in {:?}",
+            span.range.start,
+            self.line,
+        );
+        debug_assert!(
+            self.line.is_char_boundary(span.range.end),
+            "highlight span end {} is not a UTF-8 char boundary in {:?}",
+            span.range.end,
+            self.line,
+        );
+        self.line.get(span.range.clone()).unwrap_or("")
+    }
+
+    /// Iterates `(kind, text)` for each span, with text borrowed from the line.
+    pub fn iter(&self) -> impl Iterator<Item = (HighlightKind, &'a str)> + '_ {
+        self.spans.iter().map(|span| (span.kind, self.text(span)))
+    }
+}
+
+/// Highlights a shell command string.
 ///
 /// # Arguments
 /// * `shell` - Reference to the shell for context (aliases, functions, builtins, etc.)
@@ -77,16 +116,19 @@ impl HighlightSpan {
 /// * `cursor` - Current cursor position (byte offset)
 ///
 /// # Returns
-/// A vector of highlighted spans covering the entire input string.
+/// The highlighted line: spans covering the entire input, paired with the input.
 #[must_use]
-pub fn highlight_command(
+pub fn highlight_command<'a>(
     shell: &brush_core::Shell<impl brush_core::ShellExtensions>,
-    line: &str,
+    line: &'a str,
     cursor: usize,
-) -> Vec<HighlightSpan> {
+) -> Highlighted<'a> {
     let mut highlighter = Highlighter::new(shell, line, cursor);
     highlighter.highlight_program(line, 0);
-    highlighter.spans
+    Highlighted {
+        line,
+        spans: highlighter.spans,
+    }
 }
 
 enum CommandType {
@@ -101,21 +143,22 @@ enum CommandType {
 
 struct Highlighter<'a, SE: brush_core::ShellExtensions> {
     shell: &'a brush_core::Shell<SE>,
+    /// The topmost input line; span offsets stored in `spans` index into this string.
+    input_line: &'a str,
     cursor: usize,
     spans: Vec<HighlightSpan>,
-    remaining_chars: Chars<'a>,
-    current_char_index: usize,
+    current_byte_index: usize,
     next_missing_kind: Option<HighlightKind>,
 }
 
 impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
-    fn new(shell: &'a brush_core::Shell<SE>, input_line: &'a str, cursor: usize) -> Self {
+    const fn new(shell: &'a brush_core::Shell<SE>, input_line: &'a str, cursor: usize) -> Self {
         Self {
             shell,
+            input_line,
             cursor,
             spans: Vec::new(),
-            remaining_chars: input_line.chars(),
-            current_char_index: 0,
+            current_byte_index: 0,
             next_missing_kind: None,
         }
     }
@@ -126,22 +169,48 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
             &(self.shell.parser_options().tokenizer_options()),
         ) {
             let mut saw_command_token = false;
+
+            // Tokenizer offsets are *character* indices into `line`; slicing needs bytes.
+            // `char_indices()` gives the byte offset of each char, plus a sentinel for the
+            // end, so a lookup is O(1) and the whole line costs one pass (not O(n²)).
+            let char_byte_offsets: Vec<usize> = line
+                .char_indices()
+                .map(|(byte_idx, _)| byte_idx)
+                .chain(std::iter::once(line.len()))
+                .collect();
+            let byte_offset = |char_offset: usize| {
+                char_byte_offsets
+                    .get(char_offset)
+                    .copied()
+                    .unwrap_or(line.len())
+            };
+
             for token in tokens {
                 match token {
                     brush_parser::Token::Operator(_op, token_location) => {
-                        self.append_span(
-                            HighlightKind::Operator,
-                            global_offset + token_location.start.index,
-                            global_offset + token_location.end.index,
-                        );
+                        let start = global_offset + byte_offset(token_location.start.index);
+                        let end = global_offset + byte_offset(token_location.end.index);
+                        self.append_span(HighlightKind::Operator, start..end);
                     }
                     brush_parser::Token::Word(w, token_location) => {
+                        let start_byte = byte_offset(token_location.start.index);
+                        let end_byte = byte_offset(token_location.end.index);
+
+                        // Parse the raw slice from `line`, not `w.as_str()`: the tokenizer may
+                        // drop chars from `w` (e.g. `\<newline>` continuations), so offsets into
+                        // `w` no longer map onto `line`; offsets into the raw slice do.
+                        let raw_word_text = line.get(start_byte..end_byte).unwrap_or("");
                         if let Ok(word_pieces) =
-                            brush_parser::word::parse(w.as_str(), &self.shell.parser_options())
+                            brush_parser::word::parse(raw_word_text, &self.shell.parser_options())
                         {
+                            let token_range =
+                                (global_offset + start_byte)..(global_offset + end_byte);
+
+                            // Classify against the tokenized form `w` (the logical word) so
+                            // command lookups ignore mid-word line continuations.
                             let default_text_kind = self.get_kind_for_word(
                                 w.as_str(),
-                                &token_location,
+                                &token_range,
                                 &mut saw_command_token,
                             );
 
@@ -149,7 +218,7 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
                                 self.highlight_word_piece(
                                     word_piece,
                                     default_text_kind,
-                                    global_offset + token_location.start.index,
+                                    token_range.start,
                                 );
                             }
                         }
@@ -161,8 +230,7 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
         } else {
             self.append_span(
                 HighlightKind::Default,
-                global_offset,
-                global_offset + line.len(),
+                global_offset..global_offset + line.len(),
             );
         }
     }
@@ -173,17 +241,15 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
         default_text_kind: HighlightKind,
         global_offset: usize,
     ) {
-        self.skip_ahead(global_offset + word_piece.start_index);
+        let piece =
+            (global_offset + word_piece.start_index)..(global_offset + word_piece.end_index);
+        self.skip_ahead(piece.start);
 
         match word_piece.piece {
             brush_parser::word::WordPiece::SingleQuotedText(_)
             | brush_parser::word::WordPiece::AnsiCQuotedText(_)
             | brush_parser::word::WordPiece::EscapeSequence(_) => {
-                self.append_span(
-                    HighlightKind::Quoted,
-                    global_offset + word_piece.start_index,
-                    global_offset + word_piece.end_index,
-                );
+                self.append_span(HighlightKind::Quoted, piece.clone());
             }
             brush_parser::word::WordPiece::DoubleQuotedSequence(subpieces)
             | brush_parser::word::WordPiece::GettextDoubleQuotedSequence(subpieces) => {
@@ -195,84 +261,70 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
             }
             brush_parser::word::WordPiece::ParameterExpansion(_)
             | brush_parser::word::WordPiece::TildeExpansion(_) => {
-                self.append_span(
-                    HighlightKind::Parameter,
-                    global_offset + word_piece.start_index,
-                    global_offset + word_piece.end_index,
-                );
+                self.append_span(HighlightKind::Parameter, piece.clone());
             }
             brush_parser::word::WordPiece::BackquotedCommandSubstitution(command) => {
                 self.set_next_missing_kind(HighlightKind::CommandSubstitution);
                 self.highlight_program(
                     command.as_str(),
-                    global_offset + word_piece.start_index + 1, /* account for opening backtick */
+                    piece.start + 1, /* opening backtick */
                 );
                 self.set_next_missing_kind(HighlightKind::CommandSubstitution);
             }
             brush_parser::word::WordPiece::CommandSubstitution(command) => {
                 self.set_next_missing_kind(HighlightKind::CommandSubstitution);
-                self.highlight_program(
-                    command.as_str(),
-                    global_offset + word_piece.start_index + 2, /* account for opening $( */
-                );
+                self.highlight_program(command.as_str(), piece.start + 2 /* opening $( */);
                 self.set_next_missing_kind(HighlightKind::CommandSubstitution);
             }
             brush_parser::word::WordPiece::ArithmeticExpression(_) => {
                 // TODO(highlighting): Consider individually highlighting pieces of the expression
                 // itself.
-                self.append_span(
-                    HighlightKind::Arithmetic,
-                    global_offset + word_piece.start_index,
-                    global_offset + word_piece.end_index,
-                );
+                self.append_span(HighlightKind::Arithmetic, piece.clone());
             }
             brush_parser::word::WordPiece::Text(_text) => {
-                self.append_span(
-                    default_text_kind,
-                    global_offset + word_piece.start_index,
-                    global_offset + word_piece.end_index,
-                );
+                self.append_span(default_text_kind, piece.clone());
             }
         }
 
-        self.skip_ahead(global_offset + word_piece.end_index);
+        self.skip_ahead(piece.end);
     }
 
-    fn append_span(&mut self, kind: HighlightKind, start: usize, end: usize) {
+    fn append_span(&mut self, kind: HighlightKind, range: std::ops::Range<usize>) {
+        debug_assert!(
+            self.input_line.is_char_boundary(range.start),
+            "span start {} is not a UTF-8 char boundary in {:?}",
+            range.start,
+            self.input_line,
+        );
+        debug_assert!(
+            self.input_line.is_char_boundary(range.end),
+            "span end {} is not a UTF-8 char boundary in {:?}",
+            range.end,
+            self.input_line,
+        );
+
         // See if we need to cover a gap between this substring and the one that preceded it.
-        if start > self.current_char_index {
+        if range.start > self.current_byte_index {
             let missing_kind = self.next_missing_kind.unwrap_or(HighlightKind::Comment);
-            let gap_len = start - self.current_char_index;
-
-            // Skip characters in the gap
-            for _ in 0..gap_len {
-                self.remaining_chars.next();
-            }
-
             self.spans.push(HighlightSpan::new(
-                self.current_char_index,
-                start,
+                self.current_byte_index..range.start,
                 missing_kind,
             ));
-            self.current_char_index = start;
+            self.current_byte_index = range.start;
         }
 
-        if end > start {
-            // Skip characters in this span
-            for _ in 0..(end - start) {
-                self.remaining_chars.next();
-            }
-
-            self.spans.push(HighlightSpan::new(start, end, kind));
+        let end = range.end;
+        if !range.is_empty() {
+            self.spans.push(HighlightSpan::new(range, kind));
         }
 
-        self.current_char_index = end;
+        self.current_byte_index = end;
     }
 
     fn skip_ahead(&mut self, dest: usize) {
         // Append a no-op span to make sure we cover any trailing gaps in the input line not
         // otherwise styled.
-        self.append_span(HighlightKind::Default, dest, dest);
+        self.append_span(HighlightKind::Default, dest..dest);
     }
 
     const fn set_next_missing_kind(&mut self, kind: HighlightKind) {
@@ -282,7 +334,7 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
     fn get_kind_for_word(
         &self,
         w: &str,
-        token_location: &brush_parser::SourceSpan,
+        token_range: &std::ops::Range<usize>,
         saw_command_token: &mut bool,
     ) -> HighlightKind {
         if !*saw_command_token {
@@ -290,7 +342,7 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
                 HighlightKind::Assignment
             } else {
                 *saw_command_token = true;
-                match self.classify_possible_command(w, token_location) {
+                match self.classify_possible_command(w, token_range) {
                     CommandType::Function => HighlightKind::Function,
                     CommandType::Keyword => HighlightKind::Keyword,
                     CommandType::Builtin => HighlightKind::Builtin,
@@ -314,7 +366,7 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
     fn classify_possible_command(
         &self,
         name: &str,
-        token_location: &brush_parser::SourceSpan,
+        token_range: &std::ops::Range<usize>,
     ) -> CommandType {
         if self.shell.is_keyword(name) {
             return CommandType::Keyword;
@@ -326,9 +378,9 @@ impl<'a, SE: brush_core::ShellExtensions> Highlighter<'a, SE> {
             return CommandType::Builtin;
         }
 
-        // Short-circuit if the cursor is still in this token.
-        if (self.cursor >= token_location.start.index) && (self.cursor <= token_location.end.index)
-        {
+        // Short-circuit if the cursor is still in this token (inclusive of its end, so a
+        // command still being typed isn't prematurely flagged as not-found).
+        if self.cursor >= token_range.start && self.cursor <= token_range.end {
             return CommandType::Unknown;
         }
 
@@ -359,17 +411,20 @@ mod tests {
         let shell = brush_core::Shell::builder().build().await.unwrap();
         let line = "somecommand hello";
         // Use cursor position at the end so we get final highlighting
-        let spans = highlight_command(&shell, line, line.len());
+        let highlighted = highlight_command(&shell, line, line.len());
 
         // Should have at least 2 spans
-        assert!(!spans.is_empty());
+        assert!(!highlighted.spans().is_empty());
 
         // Verify highlighting produces spans that cover the input
-        let total_covered: usize = spans.iter().map(|s| s.end - s.start).sum();
+        let total_covered: usize = highlighted.spans().iter().map(|s| s.range.len()).sum();
         assert_eq!(total_covered, line.len(), "Spans should cover entire input");
 
         // The command should be classified as something (NotFound, External, etc.)
-        let cmd_span = spans.iter().find(|s| s.text(line) == "somecommand");
+        let cmd_span = highlighted
+            .spans()
+            .iter()
+            .find(|s| highlighted.text(s) == "somecommand");
         assert!(cmd_span.is_some(), "Should have a span for the command");
     }
 
@@ -377,39 +432,166 @@ mod tests {
     async fn test_highlight_quoted_string() {
         let shell = brush_core::Shell::builder().build().await.unwrap();
         let line = r#"echo "hello world""#;
-        let spans = highlight_command(&shell, line, 0);
+        let highlighted = highlight_command(&shell, line, 0);
 
         // Should have spans for: echo, space, "hello world"
-        assert!(!spans.is_empty());
+        assert!(!highlighted.spans().is_empty());
 
         // Check that quoted parts are marked as Quoted
-        assert!(spans.iter().any(|s| s.kind == HighlightKind::Quoted));
+        assert!(
+            highlighted
+                .spans()
+                .iter()
+                .any(|s| s.kind == HighlightKind::Quoted)
+        );
     }
 
     #[tokio::test]
     async fn test_highlight_parameter_expansion() {
         let shell = brush_core::Shell::builder().build().await.unwrap();
         let line = "echo $HOME";
-        let spans = highlight_command(&shell, line, 0);
+        let highlighted = highlight_command(&shell, line, 0);
 
         // Should have spans including a parameter expansion
-        assert!(spans.iter().any(|s| s.kind == HighlightKind::Parameter));
+        assert!(
+            highlighted
+                .spans()
+                .iter()
+                .any(|s| s.kind == HighlightKind::Parameter)
+        );
     }
 
     #[tokio::test]
     async fn test_highlight_covers_entire_input() {
         let shell = brush_core::Shell::builder().build().await.unwrap();
         let line = "echo hello world";
-        let spans = highlight_command(&shell, line, 0);
+        let highlighted = highlight_command(&shell, line, 0);
 
         // Verify that spans cover the entire input (no gaps)
         let mut covered = vec![false; line.len()];
-        for span in &spans {
-            for item in covered.iter_mut().take(span.end).skip(span.start) {
+        for span in highlighted.spans() {
+            for item in covered
+                .iter_mut()
+                .take(span.range.end)
+                .skip(span.range.start)
+            {
                 *item = true;
             }
         }
 
         assert!(covered.iter().all(|&c| c), "Not all characters are covered");
+    }
+
+    /// Asserts the invariants every highlighter output must satisfy (mirrors
+    /// `fuzz/fuzz_targets/fuzz_highlight.rs`).
+    fn assert_spans_are_valid(highlighted: &Highlighted<'_>) {
+        let line = highlighted.line();
+
+        // 1. Each span is in-range and lands on UTF-8 char boundaries.
+        for span in highlighted.spans() {
+            assert!(
+                span.range.start <= span.range.end,
+                "span has start > end: {span:?} (line={line:?})",
+            );
+            assert!(
+                span.range.end <= line.len(),
+                "span end exceeds line length: {span:?} (line.len()={})",
+                line.len(),
+            );
+            assert!(
+                line.is_char_boundary(span.range.start),
+                "span start not on char boundary: {span:?} (line={line:?}, bytes={:?})",
+                line.as_bytes(),
+            );
+            assert!(
+                line.is_char_boundary(span.range.end),
+                "span end not on char boundary: {span:?} (line={line:?}, bytes={:?})",
+                line.as_bytes(),
+            );
+        }
+
+        // 2. Spans are ordered and contiguous, covering the entire input.
+        let mut next_expected_start = 0usize;
+        for span in highlighted.spans() {
+            assert_eq!(
+                span.range.start, next_expected_start,
+                "spans are not contiguous: {span:?} (expected start={next_expected_start}, line={line:?})",
+            );
+            next_expected_start = span.range.end;
+        }
+        assert_eq!(
+            next_expected_start,
+            line.len(),
+            "spans do not cover entire input (covered {next_expected_start} of {}, line={line:?})",
+            line.len(),
+        );
+
+        // 3. Resolving each span's text must not panic.
+        for (_, _) in highlighted.iter() {}
+    }
+
+    #[tokio::test]
+    async fn test_highlight_multibyte_chars_in_word_does_not_panic() {
+        // Regression: a multibyte word followed by another token used to panic from
+        // mixing char indices (tokenizer) with byte indices (word parser).
+        let shell = brush_core::Shell::builder().build().await.unwrap();
+        let line = ": 爸爸 /";
+        let highlighted = highlight_command(&shell, line, line.len());
+
+        assert_spans_are_valid(&highlighted);
+    }
+
+    #[tokio::test]
+    async fn test_highlight_multibyte_chars_partial_input_does_not_panic() {
+        // Simulate intermediate keystrokes while a user is typing the line.
+        let shell = brush_core::Shell::builder().build().await.unwrap();
+        let full = ": 爸爸 /";
+        // Every char-boundary prefix must highlight without panicking.
+        for (boundary, _) in full
+            .char_indices()
+            .chain(std::iter::once((full.len(), ' ')))
+        {
+            // `boundary` is sourced from char_indices(), so slicing is on a char boundary.
+            #[allow(clippy::string_slice)]
+            let line = &full[..boundary];
+            let highlighted = highlight_command(&shell, line, line.len());
+            assert_spans_are_valid(&highlighted);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_highlight_multibyte_in_various_positions() {
+        let shell = brush_core::Shell::builder().build().await.unwrap();
+        let cases = [
+            "爸",
+            "爸 x",
+            "x 爸",
+            "echo 爸爸",
+            "爸爸=value",
+            "\"爸爸\" /",
+            "$爸",
+            "$(爸爸) /",
+            "`爸爸` /",
+            "# 爸爸 comment",
+        ];
+        for line in cases {
+            let highlighted = highlight_command(&shell, line, line.len());
+            assert_spans_are_valid(&highlighted);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_highlight_issue_1128_multibyte_then_paren() {
+        // Regression for #1128: a 2-byte char immediately followed by `(` panicked
+        // because the operator's char index was sliced as a byte offset, landing
+        // mid-character. Exercise the reported chars, including the keystroke-by-
+        // keystroke sequence (the char alone, then the char + `(`).
+        let shell = brush_core::Shell::builder().build().await.unwrap();
+        for prefix in ["£", "€", "é", "½", "§", "²", "ï", "¤", "…"] {
+            for line in [prefix.to_string(), format!("{prefix}(")] {
+                let highlighted = highlight_command(&shell, &line, line.len());
+                assert_spans_are_valid(&highlighted);
+            }
+        }
     }
 }

--- a/brush-interactive/src/reedline/highlighter.rs
+++ b/brush-interactive/src/reedline/highlighter.rs
@@ -90,12 +90,11 @@ impl<SE: brush_core::ShellExtensions> reedline::Highlighter for ReedlineHighligh
             tokio::runtime::Handle::current().block_on(self.shell.lock())
         });
 
-        let spans = highlighting::highlight_command(shell.as_ref(), line, cursor);
+        let highlighted = highlighting::highlight_command(shell.as_ref(), line, cursor);
 
         let mut styled = reedline::StyledText::new();
-        for span in spans {
-            let style = kind_to_style(span.kind);
-            styled.push((style, span.text(line).to_owned()));
+        for (kind, text) in highlighted.iter() {
+            styled.push((kind_to_style(kind), text.to_owned()));
         }
 
         styled

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,6 +31,10 @@ path = "../brush-core"
 path = "../brush-parser"
 features = ["arbitrary"]
 
+[dependencies.brush-interactive]
+path = "../brush-interactive"
+features = ["highlighting"]
+
 [[bin]]
 name = "fuzz_parse"
 path = "fuzz_targets/fuzz_parse.rs"
@@ -41,6 +45,13 @@ bench = false
 [[bin]]
 name = "fuzz_arithmetic"
 path = "fuzz_targets/fuzz_arithmetic.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_highlight"
+path = "fuzz_targets/fuzz_highlight.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/fuzz_highlight.rs
+++ b/fuzz/fuzz_targets/fuzz_highlight.rs
@@ -1,0 +1,92 @@
+#![no_main]
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use libfuzzer_sys::fuzz_target;
+use std::sync::LazyLock;
+
+use brush_interactive::highlighting::{Highlighted, highlight_command};
+
+static TOKIO_RT: LazyLock<tokio::runtime::Runtime> =
+    LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
+
+static SHELL_TEMPLATE: LazyLock<brush_core::Shell> = LazyLock::new(|| {
+    TOKIO_RT
+        .block_on(
+            brush_core::Shell::builder()
+                .profile(brush_core::ProfileLoadBehavior::Skip)
+                .rc(brush_core::RcLoadBehavior::Skip)
+                .build(),
+        )
+        .unwrap()
+});
+
+/// Clamps `raw` into `[0, line.len()]` and down to a UTF-8 char boundary.
+const fn snap_cursor(line: &str, raw: u32) -> usize {
+    let upper = line.len();
+    if upper == 0 {
+        return 0;
+    }
+    let mut pos = (raw as usize) % (upper + 1);
+    while pos > 0 && !line.is_char_boundary(pos) {
+        pos -= 1;
+    }
+    pos
+}
+
+fn assert_invariants(highlighted: &Highlighted<'_>) {
+    let line = highlighted.line();
+
+    // 1. Every span lands on UTF-8 char boundaries and the range is valid.
+    for span in highlighted.spans() {
+        assert!(
+            span.range.start <= span.range.end,
+            "span has start > end: {span:?} (line={line:?})",
+        );
+        assert!(
+            span.range.end <= line.len(),
+            "span end exceeds line length: {span:?} (line.len()={}, line={line:?})",
+            line.len(),
+        );
+        assert!(
+            line.is_char_boundary(span.range.start),
+            "span start not on char boundary: {span:?} (line={line:?})",
+        );
+        assert!(
+            line.is_char_boundary(span.range.end),
+            "span end not on char boundary: {span:?} (line={line:?})",
+        );
+    }
+
+    // 2. Spans are ordered and contiguous, covering the entire input.
+    let mut next_expected_start = 0usize;
+    for span in highlighted.spans() {
+        assert_eq!(
+            span.range.start, next_expected_start,
+            "spans are not contiguous: gap or overlap before {span:?} \
+             (expected start={next_expected_start}, line={line:?})",
+        );
+        next_expected_start = span.range.end;
+    }
+    assert_eq!(
+        next_expected_start,
+        line.len(),
+        "spans do not cover entire input (covered {next_expected_start} of {}, line={line:?})",
+        line.len(),
+    );
+
+    // 3. Resolving the text of each span must not panic.
+    for (_, _) in highlighted.iter() {}
+}
+
+// `raw_cursor` is clamped into the line and snapped to a char boundary below.
+fuzz_target!(|input: (String, u32)| {
+    let (line, raw_cursor) = input;
+    let cursor = snap_cursor(&line, raw_cursor);
+
+    let shell = SHELL_TEMPLATE.clone();
+    let highlighted = highlight_command(&shell, &line, cursor);
+
+    assert_invariants(&highlighted);
+});


### PR DESCRIPTION
Corrects syntax highlighting code to interpret token locations as character indices and not byte offsets. Addresses code quality feedback via API improvements, use of proper ranges, etc.

Resolves #1163, #1128