### PR TITLE
fix(kill): support numeric signal in -sigspec syntax

### DIFF
--- a/brush-builtins/src/kill.rs
+++ b/brush-builtins/src/kill.rs
@@ -71,18 +71,19 @@ impl builtins::Command for KillCommand {
         // Look through the remaining args for a pid/job spec or a -sigspec style option.
         let mut pid_or_job_spec = None;
         for arg in &self.args {
-            // See if this is -sigspec syntax.
             if let Some(possible_sigspec) = arg.strip_prefix("-") {
-                // See if this is -sigspec syntax.
-                if let Ok(parsed_trap_signal) = TrapSignal::try_from(possible_sigspec) {
+                // See if this is -sigspec syntax. The sigspec may be a signal name
+                // (e.g., -TERM) or a signal number (e.g., -9).
+                if let Ok(parsed_trap_signal) = possible_sigspec.parse::<TrapSignal>() {
                     trap_signal = parsed_trap_signal;
                 } else {
                     writeln!(
                         context.stderr(),
-                        "{}: invalid signal name",
-                        context.command_name
+                        "{}: {}: invalid signal specification",
+                        context.command_name,
+                        possible_sigspec
                     )?;
-                    return Ok(ExecutionExitCode::InvalidUsage.into());
+                    return Ok(ExecutionResult::general_error());
                 }
             } else if pid_or_job_spec.is_none() {
                 pid_or_job_spec = Some(arg);

--- a/brush-shell/tests/cases/compat/builtins/kill.yaml
+++ b/brush-shell/tests/cases/compat/builtins/kill.yaml
@@ -25,3 +25,17 @@ cases:
   - name: "kill -sigspec"
     stdin: |
       kill -USR1 $$
+
+  - name: "kill -sigspec (numeric)"
+    stdin: |
+      kill -9 $$
+
+  - name: "kill -sigspec (numeric, full name resolution)"
+    stdin: |
+      kill -l $(kill -l KILL)
+
+  - name: "kill -sigspec (numeric, invalid)"
+    ignore_stderr: true
+    stdin: |
+      kill -9999 $$
+      echo "exit code: $?"


### PR DESCRIPTION
Resolves #1206.

## Problem

`kill -9 <pid>` (a numeric signal in `-sigspec` form) failed with `kill: invalid signal name` and did not send any signal. The `-sigspec` handler parsed the spec with `TrapSignal::try_from(&str)`, which only understands signal *names* (`TERM`, `SIGKILL`), so numeric specs fell through to the error path.

## Fix

- Parse the sigspec via `TrapSignal`'s `FromStr` impl, which handles both numeric (`-9`) and named (`-TERM`) signals.
- Match bash's error wording (`kill: 9999: invalid signal specification`) and its exit code (`1`) for invalid specs.

## Validation

Added YAML compat test cases (validated against the bash oracle):
- `kill -9 $$` — numeric sigspec (the issue repro)
- `kill -l $(kill -l KILL)` — numeric round-trip resolution
- `kill -9999 $$` — invalid numeric sigspec error path

All kill compat tests pass; also verified manually that `kill -9 <pid>` now returns `0` and actually terminates the target process.