### PR TITLE
fix(arrays): evaluate subscript on non-assoc array assignment

### DIFF
--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -1545,16 +1545,20 @@ async fn apply_assignment(
 
     // See if we need to eval an array index.
     if let Some(idx) = &array_index {
-        let will_be_indexed_array = if let Some((_, existing_value)) =
-            shell.env().get(variable_name)
-        {
-            matches!(
-                existing_value.value(),
-                ShellValue::IndexedArray(_) | ShellValue::Unset(ShellValueUnsetType::IndexedArray)
-            )
-        } else {
-            true
-        };
+        // An array subscript is arithmetically evaluated unless the target is an
+        // associative array (in which case the subscript is used as a literal key).
+        // A scalar or unset/untyped variable becomes an indexed array, so its
+        // subscript still needs to be evaluated.
+        let will_be_indexed_array =
+            if let Some((_, existing_value)) = shell.env().get(variable_name) {
+                !matches!(
+                    existing_value.value(),
+                    ShellValue::AssociativeArray(_)
+                        | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
+                )
+            } else {
+                true
+            };
 
         if will_be_indexed_array {
             array_index = Some(

--- a/brush-shell/tests/cases/compat/arrays.yaml
+++ b/brush-shell/tests/cases/compat/arrays.yaml
@@ -105,6 +105,36 @@ cases:
       y[x[1]]=11
       declare -p y
 
+  - name: "Arithmetic index assignment on declared-but-unset variable"
+    stdin: |
+      declare a
+      i=1
+      a[i]=help
+      declare -p a
+
+  - name: "Arithmetic index assignment on local declared-but-unset variable"
+    stdin: |
+      f() {
+        local a
+        i=1
+        a[i]=help
+        declare -p a
+      }
+      f
+
+  - name: "Arithmetic index assignment on scalar variable"
+    stdin: |
+      a=foo
+      i=1
+      a[i]=help
+      declare -p a
+
+  - name: "Arithmetic index assignment on undeclared variable"
+    stdin: |
+      i=1
+      a[i]=help
+      declare -p a
+
   - name: "Replacing array with string"
     stdin: |
       var=(a b c)


### PR DESCRIPTION
## Problem
`local a; i=1; a[i]=help` assigned to index `0` instead of arithmetically evaluating the subscript `i` to `1`.

## Root cause
In `apply_assignment` (`brush-core/src/interp.rs`), the decision of whether to arithmetically evaluate an array subscript used an allowlist that only matched `IndexedArray` / `Unset(IndexedArray)`. A variable declared but not yet typed as an array (`local a` / `declare a` → `Unset(Untyped)`) or a plain scalar (`String`) fell through, so the subscript was treated as a literal key (resolving to `0` for an indexed array).

In bash, a subscript is arithmetically evaluated unless the variable is an associative array.

## Fix
Inverted the check to a denylist: evaluate the subscript unless the target is an associative array (`AssociativeArray` / `Unset(AssociativeArray)`). This correctly handles untyped/unset, scalar, and indexed-array targets.

## Tests
Added 4 YAML compat cases (`declare a`, `local a`, scalar→array, undeclared). Before the fix 3 of 4 failed; after, all pass. Full compat suite: 0 failures, no regressions.

Closes #1175