### PR TITLE
fix: wrong end token for if_clause

### DIFF
--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -366,7 +366,7 @@ peg::parser! {
         rule if_clause() -> ast::IfClauseCommand =
             s:specific_word("if") condition:compound_list() specific_word("then") then:compound_list() elses:else_part()? e:specific_word("fi") {
                 let start = s.location();
-                let end = s.location();
+                let end = e.location();
                 let loc = SourceSpan::within(start, end);
 
                 ast::IfClauseCommand {


### PR DESCRIPTION
I noticed there was a typo in the source location for `fi`.