### PR TITLE
fix(vars): populate BASH_ARGV/BASH_ARGC without extdebug

### DIFF
--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -666,47 +666,74 @@ fn get_bash_source_value(shell: &dyn ShellState) -> variables::ShellValue {
     }
 }
 
+/// Returns the positional arguments that the given call-stack frame contributes
+/// to `BASH_ARGC`/`BASH_ARGV`, or `None` if the frame contributes nothing.
+///
+/// Even without extended debugging mode, bash tracks script-level frames (the
+/// top-level invocation plus `source`/`.` calls); only *function* frames are
+/// gated behind extended debugging mode. A sourced script invoked without
+/// explicit positional arguments contributes its own name (the path passed to
+/// `.`/`source`) as a single argument, matching bash.
+fn frame_bash_args(
+    frame: &crate::callstack::Frame,
+    extdebug: bool,
+) -> Option<std::borrow::Cow<'_, [String]>> {
+    use std::borrow::Cow;
+    match &frame.frame_type {
+        crate::callstack::FrameType::Script(call) => {
+            if matches!(call.call_type, crate::callstack::ScriptCallType::Source)
+                && frame.args.is_empty()
+            {
+                Some(Cow::Owned(vec![call.name().into_owned()]))
+            } else {
+                Some(Cow::Borrowed(frame.args.as_slice()))
+            }
+        }
+        crate::callstack::FrameType::CommandString
+        | crate::callstack::FrameType::InteractiveSession => {
+            Some(Cow::Borrowed(frame.args.as_slice()))
+        }
+        crate::callstack::FrameType::Function(..) => {
+            extdebug.then_some(Cow::Borrowed(frame.args.as_slice()))
+        }
+        crate::callstack::FrameType::TrapHandler(_) | crate::callstack::FrameType::Eval => None,
+    }
+}
+
+/// Returns `true` if `BASH_ARGC`/`BASH_ARGV` should report an empty stack.
+///
+/// Without extended debugging mode, bash leaves these arrays empty whenever a
+/// function is active on the call stack.
+fn bash_args_suppressed(shell: &dyn ShellState) -> bool {
+    !shell.options().enable_debugger && shell.call_stack().in_function()
+}
+
 fn get_bash_argc_value(shell: &dyn ShellState) -> variables::ShellValue {
-    if !shell.options().enable_debugger {
+    if bash_args_suppressed(shell) {
         return ShellValue::indexed_array_from_strs(&[]);
     }
 
-    let stack = shell.call_stack();
-    stack
+    let extdebug = shell.options().enable_debugger;
+    shell
+        .call_stack()
         .iter()
-        .filter_map(|frame| match &frame.frame_type {
-            crate::callstack::FrameType::Function(..)
-            | crate::callstack::FrameType::Script(..)
-            | crate::callstack::FrameType::CommandString
-            | crate::callstack::FrameType::InteractiveSession => Some(frame.args.len().to_string()),
-            crate::callstack::FrameType::TrapHandler(_) | crate::callstack::FrameType::Eval => None,
-        })
+        .filter_map(|frame| frame_bash_args(frame, extdebug).map(|args| args.len().to_string()))
         .collect::<Vec<_>>()
         .into()
 }
 
 fn get_bash_argv_value(shell: &dyn ShellState) -> variables::ShellValue {
-    if !shell.options().enable_debugger {
+    if bash_args_suppressed(shell) {
         return ShellValue::indexed_array_from_strs(&[]);
     }
 
-    let stack = shell.call_stack();
+    let extdebug = shell.options().enable_debugger;
     let mut argv = Vec::new();
 
-    for frame in stack.iter() {
-        let include = match &frame.frame_type {
-            crate::callstack::FrameType::Function(..)
-            | crate::callstack::FrameType::Script(..)
-            | crate::callstack::FrameType::CommandString
-            | crate::callstack::FrameType::InteractiveSession => true,
-            crate::callstack::FrameType::TrapHandler(_) | crate::callstack::FrameType::Eval => {
-                false
-            }
-        };
-
-        if include {
+    for frame in shell.call_stack().iter() {
+        if let Some(args) = frame_bash_args(frame, extdebug) {
             // Push args in reverse order per frame (last arg at lowest index = top of stack)
-            for arg in frame.args.iter().rev() {
+            for arg in args.iter().rev() {
                 argv.push(arg.clone());
             }
         }

--- a/brush-shell/tests/cases/compat/well_known_vars.yaml
+++ b/brush-shell/tests/cases/compat/well_known_vars.yaml
@@ -113,6 +113,45 @@ cases:
 
       echo "Input exit"; declare -p FUNCNAME
 
+  # Regression test for https://github.com/reubeno/brush/issues/1212: BASH_ARGV
+  # and BASH_ARGC are populated for script-level frames (the top-level invocation
+  # plus sourced scripts) even without extended debugging mode. A sourced script
+  # invoked with no positional arguments contributes its own name.
+  - name: "BASH_ARGV/BASH_ARGC - sourced script without arguments"
+    test_files:
+      - path: "argv.sh"
+        contents: |
+          declare -p BASH_ARGV BASH_ARGC
+    stdin: |
+      . ./argv.sh
+
+  - name: "BASH_ARGV/BASH_ARGC - nested sourced scripts without arguments"
+    test_files:
+      - path: "outer.sh"
+        contents: |
+          . ./inner.sh
+      - path: "inner.sh"
+        contents: |
+          declare -p BASH_ARGV BASH_ARGC
+    stdin: |
+      . ./outer.sh
+
+  - name: "BASH_ARGV/BASH_ARGC - empty inside function without extdebug"
+    stdin: |
+      myfunc() {
+        declare -p BASH_ARGV BASH_ARGC
+      }
+      myfunc a b c
+
+  - name: "BASH_ARGV/BASH_ARGC - sourced script without arguments with extdebug"
+    test_files:
+      - path: "argv.sh"
+        contents: |
+          declare -p BASH_ARGV BASH_ARGC
+    stdin: |
+      shopt -s extdebug
+      . ./argv.sh
+
   - name: "BASH_SUBSHELL"
     stdin: |
       echo "Initial BASH_SUBSHELL: $BASH_SUBSHELL"


### PR DESCRIPTION
Bash tracks script-level frames (the top-level invocation plus source/. calls) in BASH_ARGV/BASH_ARGC even without extended debugging mode; only function frames are gated behind extdebug. A sourced script invoked with no positional args contributes its own name. brush previously left these arrays empty unless extdebug was on.

Fixes #1212