### PR TITLE
fix(expansion): slice sparse indexed arrays by subscript

### DIFF
--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1361,24 +1361,53 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                     );
                 }
 
+                // For an indexed array sliced via [@]/[*], bash interprets the offset as a
+                // subscript value rather than a position in the (possibly sparse) list of
+                // present elements. Capture the sorted subscripts so we can translate the
+                // offset below; positional parameters, scalars, and associative arrays keep
+                // their positional behavior.
+                let array_subscripts: Option<Vec<u64>> = if indirect {
+                    None
+                } else if let brush_parser::word::Parameter::NamedWithAllIndices { name, .. } =
+                    &parameter
+                {
+                    match self.shell.env().get(name) {
+                        Some((_, var)) => match var.value() {
+                            ShellValue::IndexedArray(array) => {
+                                Some(array.keys().copied().collect())
+                            }
+                            _ => None,
+                        },
+                        None => None,
+                    }
+                } else {
+                    None
+                };
+
                 #[expect(clippy::cast_possible_wrap)]
                 let expanded_parameter_len = expanded_parameter.polymorphic_len() as i64;
-                let mut expanded_offset = offset.eval(self.shell, self.params, false).await?;
+                let raw_offset = offset.eval(self.shell, self.params, false).await?;
 
-                // We handle negative indexes as offsets from the end of the element, with -1
-                // referencing the last element.
-                if expanded_offset < 0 {
-                    expanded_offset += expanded_parameter_len;
+                let expanded_offset = if let Some(subscripts) = &array_subscripts {
+                    // Translate the subscript-space offset into a dense position.
+                    array_offset_to_position(subscripts, raw_offset, expanded_parameter_len)
+                } else {
+                    // We handle negative indexes as offsets from the end of the element, with
+                    // -1 referencing the last element.
+                    let mut position = raw_offset;
+                    if position < 0 {
+                        position += expanded_parameter_len;
 
-                    // If the offset is still negative, then we need to yield an empty slice.
-                    // We force the offset to the end of the array.
-                    if expanded_offset < 0 {
-                        expanded_offset = expanded_parameter_len;
+                        // If the offset is still negative, then we need to yield an empty
+                        // slice. We force the offset to the end of the array.
+                        if position < 0 {
+                            position = expanded_parameter_len;
+                        }
                     }
-                }
 
-                // Make sure the offset is within the bounds of the item.
-                let expanded_offset = min(expanded_offset, expanded_parameter_len);
+                    // Make sure the offset is within the bounds of the item.
+                    min(position, expanded_parameter_len)
+                };
 
                 let end_offset = if let Some(length) = length {
                     let mut expanded_length = length.eval(self.shell, self.params, false).await?;
@@ -2055,6 +2084,36 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
             }
         }
     }
+}
+
+/// Translates a substring-expansion offset into a dense position within an
+/// indexed array's element list.
+///
+/// For indexed arrays, bash treats the offset of `${array[@]:offset:length}` as a
+/// subscript value rather than a position in the (possibly sparse) list of present
+/// elements. This maps that subscript-space offset onto the dense position of the
+/// first element whose subscript is at least `offset`. `subscripts` must be sorted
+/// in ascending order. A negative offset counts back from one past the largest
+/// subscript (matching bash); if it still falls before the start of the array,
+/// `empty_position` is returned so the resulting slice is empty.
+fn array_offset_to_position(subscripts: &[u64], offset: i64, empty_position: i64) -> i64 {
+    let effective_offset = if offset < 0 {
+        #[expect(clippy::cast_possible_wrap)]
+        let one_past_last = subscripts.last().map_or(0, |last| *last as i64 + 1);
+        offset + one_past_last
+    } else {
+        offset
+    };
+
+    if effective_offset < 0 {
+        return empty_position;
+    }
+
+    #[expect(clippy::cast_sign_loss)]
+    let threshold = effective_offset as u64;
+    let position = subscripts.partition_point(|&subscript| subscript < threshold);
+
+    i64::try_from(position).unwrap_or(empty_position)
 }
 
 fn coalesce_expansions(expansions: Vec<Expansion>) -> Expansion {

--- a/brush-shell/tests/cases/compat/word_expansion/params.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/params.yaml
@@ -611,6 +611,19 @@ cases:
       declare -a result2=("${myarray[@]:3}")
       declare -p result2
 
+  - name: "Substring operator on sparse indexed array"
+    stdin: |
+      sparse=([1]=one [5]=five [9]=nine)
+      echo "\${sparse[@]:1}:   ${sparse[@]:1}"
+      echo "\${sparse[@]:2}:   ${sparse[@]:2}"
+      echo "\${sparse[@]:6}:   ${sparse[@]:6}"
+      echo "\${sparse[@]:1:1}: ${sparse[@]:1:1}"
+      echo "\${sparse[@]:1:2}: ${sparse[@]:1:2}"
+      echo "\${sparse[@]:5:0}: ${sparse[@]:5:0}"
+      echo "\${sparse[@]: -1}:  ${sparse[@]: -1}"
+      echo "\${sparse[@]: -5}:  ${sparse[@]: -5}"
+      echo "\${sparse[@]: -11}: ${sparse[@]: -11}"
+
   - name: "Substring with length (with nested expressions)"
     stdin: |
       var="Hello, world!"


### PR DESCRIPTION
Substring expansion of an indexed array via `[@]`/`[*]` treated the offset as a position in the dense list of present elements. Bash interprets the offset as a subscript value: it selects elements whose subscript is at least the offset, and the length still counts elements positionally from there.

For the sparse array in #1219:

```bash
a=([1]=1 [5]=5 [9]=9)
echo "${a[*]:1}"   # brush: (empty)   bash: 1 5 9
echo "${a[*]:2}"   # brush: (empty)   bash: 5 9
echo "${a[*]:6}"   # brush: (empty)   bash: 9
echo "${a[*]:1:2}" # brush: (empty)   bash: 1 5
echo "${a[*]: -1}" # brush: (empty)   bash: 9
```

Element `1` sat at dense position 0, so a position-based offset of 1 skipped past it.

The fix translates the subscript-space offset onto a dense position before slicing. A non-negative offset maps to the first element whose subscript is at least the offset; a negative offset counts back from one past the largest subscript (matching bash). Scalars, positional parameters, and associative arrays keep their existing positional behavior, so contiguous arrays (`a=(x y z); ${a[*]:1}` -> `y z`) are unchanged.

Added a compat test (`Substring operator on sparse indexed array`) covering positive, negative, and length-bounded offsets against the bash oracle.

Fixes #1219.