### PR TITLE
fix(variables): keep dynamic well-known vars live across `declare -a` / array assign

### DIFF
--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -288,10 +288,18 @@ impl DeclareCommand {
             .get_mut_using_policy(name.as_str(), lookup)
         {
             if self.make_associative_array.is_some() {
-                var.convert_to_associative_array()?;
+                if initial_value.is_some() {
+                    var.convert_to_associative_array_for_reassignment()?;
+                } else {
+                    var.convert_to_associative_array()?;
+                }
             }
             if self.make_indexed_array.is_some() {
-                var.convert_to_indexed_array()?;
+                if initial_value.is_some() {
+                    var.convert_to_indexed_array_for_reassignment()?;
+                } else {
+                    var.convert_to_indexed_array()?;
+                }
             }
 
             self.apply_attributes_before_update(var)?;

--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -281,6 +281,20 @@ impl DeclareCommand {
             EnvironmentLookup::Anywhere
         };
 
+        // If the variable currently holds a dynamic value, resolve its current
+        // reading now, before taking a mutable borrow of the shell below. This
+        // lets a scalar dynamic (e.g. RANDOM) that ends up getting materialized
+        // by a shape conversion freeze at its actual current value instead of
+        // an empty string.
+        let resolved_dynamic_value = context
+            .shell
+            .env()
+            .get_using_policy(name.as_str(), lookup)
+            .and_then(|var| {
+                matches!(var.value(), brush_core::ShellValue::Dynamic { .. })
+                    .then(|| var.resolve_value(context.shell))
+            });
+
         // Look up the variable.
         if let Some(var) = context
             .shell
@@ -289,16 +303,18 @@ impl DeclareCommand {
         {
             if self.make_associative_array.is_some() {
                 if initial_value.is_some() {
-                    var.convert_to_associative_array_for_reassignment()?;
+                    var.convert_to_associative_array_for_reassignment(
+                        resolved_dynamic_value.as_ref(),
+                    )?;
                 } else {
-                    var.convert_to_associative_array()?;
+                    var.convert_to_associative_array(resolved_dynamic_value.as_ref())?;
                 }
             }
             if self.make_indexed_array.is_some() {
                 if initial_value.is_some() {
-                    var.convert_to_indexed_array_for_reassignment()?;
+                    var.convert_to_indexed_array_for_reassignment(resolved_dynamic_value.as_ref())?;
                 } else {
-                    var.convert_to_indexed_array()?;
+                    var.convert_to_indexed_array(resolved_dynamic_value.as_ref())?;
                 }
             }
 

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1819,6 +1819,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
                         var.value(),
                         ShellValue::AssociativeArray(_)
                             | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
+                            | ShellValue::Dynamic {
+                                kind: variables::DynamicValueKind::AssociativeArray,
+                                ..
+                            }
                     )
                 } else {
                     false

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -188,8 +188,20 @@ impl ShellVariable {
     }
 
     /// Converts the variable to an indexed array.
-    pub fn convert_to_indexed_array(&mut self) -> Result<(), error::Error> {
-        self.convert_to_indexed_array_impl(false)
+    ///
+    /// # Arguments
+    ///
+    /// * `resolved_dynamic_value` - If this variable currently holds a dynamic
+    ///   value, the caller may pass in the value it currently resolves to
+    ///   (e.g. via [`Self::resolve_value`]) so that a scalar dynamic (such as
+    ///   `RANDOM`) that ends up getting materialized freezes at its actual
+    ///   current reading rather than an empty string. Pass `None` if no such
+    ///   snapshot is available, or if the variable is known not to be dynamic.
+    pub fn convert_to_indexed_array(
+        &mut self,
+        resolved_dynamic_value: Option<&ShellValue>,
+    ) -> Result<(), error::Error> {
+        self.convert_to_indexed_array_impl(false, resolved_dynamic_value)
     }
 
     /// Like [`Self::convert_to_indexed_array`], but for use when a `declare -a
@@ -200,13 +212,17 @@ impl ShellVariable {
     /// `BASH_ALIASES`, rather than rejecting the conversion the way a bare
     /// `declare -a name` (with no value) would. A real (non-dynamic) associative
     /// array is still rejected either way, matching bash.
-    pub fn convert_to_indexed_array_for_reassignment(&mut self) -> Result<(), error::Error> {
-        self.convert_to_indexed_array_impl(true)
+    pub fn convert_to_indexed_array_for_reassignment(
+        &mut self,
+        resolved_dynamic_value: Option<&ShellValue>,
+    ) -> Result<(), error::Error> {
+        self.convert_to_indexed_array_impl(true, resolved_dynamic_value)
     }
 
     fn convert_to_indexed_array_impl(
         &mut self,
         allow_dynamic_mismatch: bool,
+        resolved_dynamic_value: Option<&ShellValue>,
     ) -> Result<(), error::Error> {
         match self.value() {
             ShellValue::IndexedArray(_) => Ok(()),
@@ -231,15 +247,10 @@ impl ShellVariable {
             // materialized into a real indexed array and lose their dynamic binding,
             // matching bash's `declare -a RANDOM` freezing behavior. Shape-mismatched
             // associative dynamics fall here too when `allow_dynamic_mismatch` is set.
-            // TODO(dynamic): this should snapshot the dynamic value's *current*
-            // reading rather than an empty string; doing so requires plumbing a
-            // shell reference through to this conversion.
             _ => {
                 let mut new_values = BTreeMap::new();
-                new_values.insert(
-                    0,
-                    self.value.to_cow_str_without_dynamic_support().to_string(),
-                );
+                let source = resolved_dynamic_value.unwrap_or(&self.value);
+                new_values.insert(0, source.to_cow_str_without_dynamic_support().to_string());
                 self.value = ShellValue::IndexedArray(new_values);
                 Ok(())
             }
@@ -247,21 +258,31 @@ impl ShellVariable {
     }
 
     /// Converts the variable to an associative array.
-    pub fn convert_to_associative_array(&mut self) -> Result<(), error::Error> {
-        self.convert_to_associative_array_impl(false)
+    ///
+    /// See [`Self::convert_to_indexed_array`] for the meaning of
+    /// `resolved_dynamic_value`.
+    pub fn convert_to_associative_array(
+        &mut self,
+        resolved_dynamic_value: Option<&ShellValue>,
+    ) -> Result<(), error::Error> {
+        self.convert_to_associative_array_impl(false, resolved_dynamic_value)
     }
 
     /// Like [`Self::convert_to_associative_array`], but for use when a `declare
     /// -A name=value` is about to immediately overwrite this variable's value.
     /// See [`Self::convert_to_indexed_array_for_reassignment`] for why this
     /// exists.
-    pub fn convert_to_associative_array_for_reassignment(&mut self) -> Result<(), error::Error> {
-        self.convert_to_associative_array_impl(true)
+    pub fn convert_to_associative_array_for_reassignment(
+        &mut self,
+        resolved_dynamic_value: Option<&ShellValue>,
+    ) -> Result<(), error::Error> {
+        self.convert_to_associative_array_impl(true, resolved_dynamic_value)
     }
 
     fn convert_to_associative_array_impl(
         &mut self,
         allow_dynamic_mismatch: bool,
+        resolved_dynamic_value: Option<&ShellValue>,
     ) -> Result<(), error::Error> {
         match self.value() {
             ShellValue::AssociativeArray(_) => Ok(()),
@@ -278,14 +299,12 @@ impl ShellVariable {
             } if !allow_dynamic_mismatch => {
                 Err(error::ErrorKind::ConvertingIndexedArrayToAssociativeArray.into())
             }
-            // TODO(dynamic): see the note in convert_to_indexed_array_impl; this
-            // should snapshot the dynamic value's current reading rather than an
-            // empty string.
             _ => {
                 let mut new_values: BTreeMap<String, String> = BTreeMap::new();
+                let source = resolved_dynamic_value.unwrap_or(&self.value);
                 new_values.insert(
                     String::from("0"),
-                    self.value.to_cow_str_without_dynamic_support().to_string(),
+                    source.to_cow_str_without_dynamic_support().to_string(),
                 );
                 self.value = ShellValue::AssociativeArray(new_values);
                 Ok(())
@@ -329,7 +348,7 @@ impl ShellVariable {
                 // If we're trying to append an array to a string, we first promote the string to be
                 // an array with the string being present at index 0.
                 (ShellValue::String(_), ShellValueLiteral::Array(_)) => {
-                    self.convert_to_indexed_array()?;
+                    self.convert_to_indexed_array(None)?;
                 }
                 _ => (),
             }
@@ -452,7 +471,7 @@ impl ShellVariable {
                 self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
             }
             ShellValue::String(_) => {
-                self.convert_to_indexed_array()?;
+                self.convert_to_indexed_array(None)?;
             }
             _ => (),
         }

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -194,6 +194,12 @@ impl ShellVariable {
             ShellValue::AssociativeArray(_) => {
                 Err(error::ErrorKind::ConvertingAssociativeArrayToIndexedArray.into())
             }
+            // Dynamic variables (e.g. PIPESTATUS, RANDOM) are backed by getter/setter
+            // closures. "Converting" them to an array would discard the binding and
+            // freeze the variable at whatever snapshot we materialized, breaking it
+            // forever. Real bash keeps these variables live across `declare -a`, so
+            // accept the declaration syntactically but leave the value untouched.
+            ShellValue::Dynamic { .. } => Ok(()),
             _ => {
                 let mut new_values = BTreeMap::new();
                 new_values.insert(
@@ -333,8 +339,7 @@ impl ShellVariable {
                     | ShellValue::Unset(
                         ShellValueUnsetType::IndexedArray | ShellValueUnsetType::Untyped,
                     )
-                    | ShellValue::String(_)
-                    | ShellValue::Dynamic { .. },
+                    | ShellValue::String(_),
                     ShellValueLiteral::Array(literal_values),
                 ) => {
                     self.value = ShellValue::indexed_array_from_literals(literal_values);

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -189,17 +189,51 @@ impl ShellVariable {
 
     /// Converts the variable to an indexed array.
     pub fn convert_to_indexed_array(&mut self) -> Result<(), error::Error> {
+        self.convert_to_indexed_array_impl(false)
+    }
+
+    /// Like [`Self::convert_to_indexed_array`], but for use when a `declare -a
+    /// name=value` is about to immediately overwrite this variable's value.
+    ///
+    /// Bash lets that accompanying assignment fully replace (and permanently
+    /// freeze) a shape-mismatched dynamic special variable such as
+    /// `BASH_ALIASES`, rather than rejecting the conversion the way a bare
+    /// `declare -a name` (with no value) would. A real (non-dynamic) associative
+    /// array is still rejected either way, matching bash.
+    pub fn convert_to_indexed_array_for_reassignment(&mut self) -> Result<(), error::Error> {
+        self.convert_to_indexed_array_impl(true)
+    }
+
+    fn convert_to_indexed_array_impl(
+        &mut self,
+        allow_dynamic_mismatch: bool,
+    ) -> Result<(), error::Error> {
         match self.value() {
             ShellValue::IndexedArray(_) => Ok(()),
             ShellValue::AssociativeArray(_) => {
                 Err(error::ErrorKind::ConvertingAssociativeArrayToIndexedArray.into())
             }
-            // Dynamic variables (e.g. PIPESTATUS, RANDOM) are backed by getter/setter
-            // closures. "Converting" them to an array would discard the binding and
-            // freeze the variable at whatever snapshot we materialized, breaking it
-            // forever. Real bash keeps these variables live across `declare -a`, so
-            // accept the declaration syntactically but leave the value untouched.
-            ShellValue::Dynamic { .. } => Ok(()),
+            // Dynamic variables that are already indexed-array-shaped (e.g. PIPESTATUS)
+            // are backed by getter/setter closures. Bash keeps these live across
+            // `declare -a` rather than freezing a snapshot, so accept the declaration
+            // syntactically but leave the binding untouched.
+            ShellValue::Dynamic {
+                kind: DynamicValueKind::IndexedArray,
+                ..
+            } => Ok(()),
+            ShellValue::Dynamic {
+                kind: DynamicValueKind::AssociativeArray,
+                ..
+            } if !allow_dynamic_mismatch => {
+                Err(error::ErrorKind::ConvertingAssociativeArrayToIndexedArray.into())
+            }
+            // Scalars, including scalar-shaped dynamics like RANDOM/SECONDS, get
+            // materialized into a real indexed array and lose their dynamic binding,
+            // matching bash's `declare -a RANDOM` freezing behavior. Shape-mismatched
+            // associative dynamics fall here too when `allow_dynamic_mismatch` is set.
+            // TODO(dynamic): this should snapshot the dynamic value's *current*
+            // reading rather than an empty string; doing so requires plumbing a
+            // shell reference through to this conversion.
             _ => {
                 let mut new_values = BTreeMap::new();
                 new_values.insert(
@@ -214,11 +248,39 @@ impl ShellVariable {
 
     /// Converts the variable to an associative array.
     pub fn convert_to_associative_array(&mut self) -> Result<(), error::Error> {
+        self.convert_to_associative_array_impl(false)
+    }
+
+    /// Like [`Self::convert_to_associative_array`], but for use when a `declare
+    /// -A name=value` is about to immediately overwrite this variable's value.
+    /// See [`Self::convert_to_indexed_array_for_reassignment`] for why this
+    /// exists.
+    pub fn convert_to_associative_array_for_reassignment(&mut self) -> Result<(), error::Error> {
+        self.convert_to_associative_array_impl(true)
+    }
+
+    fn convert_to_associative_array_impl(
+        &mut self,
+        allow_dynamic_mismatch: bool,
+    ) -> Result<(), error::Error> {
         match self.value() {
             ShellValue::AssociativeArray(_) => Ok(()),
+            ShellValue::Dynamic {
+                kind: DynamicValueKind::AssociativeArray,
+                ..
+            } => Ok(()),
             ShellValue::IndexedArray(_) => {
                 Err(error::ErrorKind::ConvertingIndexedArrayToAssociativeArray.into())
             }
+            ShellValue::Dynamic {
+                kind: DynamicValueKind::IndexedArray,
+                ..
+            } if !allow_dynamic_mismatch => {
+                Err(error::ErrorKind::ConvertingIndexedArrayToAssociativeArray.into())
+            }
+            // TODO(dynamic): see the note in convert_to_indexed_array_impl; this
+            // should snapshot the dynamic value's current reading rather than an
+            // empty string.
             _ => {
                 let mut new_values: BTreeMap<String, String> = BTreeMap::new();
                 new_values.insert(
@@ -608,6 +670,12 @@ pub enum ShellValue {
     IndexedArray(BTreeMap<u64, String>),
     /// A value that is dynamically computed.
     Dynamic {
+        /// The shape of value that `getter` produces (scalar, indexed array, or
+        /// associative array). This lets conversion logic (e.g. `declare -a`/`-A`)
+        /// treat a dynamic variable the same way it would treat a materialized
+        /// value of that shape, without having to invoke `getter` (which needs a
+        /// shell reference that isn't always available).
+        kind: DynamicValueKind,
         /// Function that can query the value.
         /// TODO(serde): figure out how to serialize/deserialize dynamic values.
         #[cfg_attr(
@@ -623,6 +691,18 @@ pub enum ShellValue {
         )]
         setter: DynamicValueSetter,
     },
+}
+
+/// The shape of value produced by a dynamic variable's getter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum DynamicValueKind {
+    /// The dynamic value resolves to a scalar string (e.g. `RANDOM`, `SECONDS`).
+    Scalar,
+    /// The dynamic value resolves to an indexed array (e.g. `PIPESTATUS`).
+    IndexedArray,
+    /// The dynamic value resolves to an associative array (e.g. `BASH_ALIASES`).
+    AssociativeArray,
 }
 
 #[cfg(feature = "serde")]

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -438,6 +438,22 @@ impl ShellVariable {
                     Ok(())
                 }
 
+                // A bare array assignment to a *scalar-shaped* dynamic variable
+                // (e.g. `RANDOM=(1 2 3)`) "de-specials" it: the dynamic binding is
+                // replaced by a real indexed array, matching bash. Array-shaped
+                // dynamics (e.g. `PIPESTATUS`) are left alone by the catch-all
+                // below, so they stay live across plain array assignment.
+                (
+                    ShellValue::Dynamic {
+                        kind: DynamicValueKind::Scalar,
+                        ..
+                    },
+                    ShellValueLiteral::Array(literal_values),
+                ) => {
+                    self.value = ShellValue::indexed_array_from_literals(literal_values);
+                    Ok(())
+                }
+
                 // Handle updates to dynamic values; for now we just drop them.
                 // TODO(dynamic): Allow updates to dynamic values
                 (ShellValue::Dynamic { .. }, _) => Ok(()),

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -73,6 +73,7 @@ pub(crate) fn init_well_known_vars(
 
     // BASHOPTS
     let mut bashopts_var = ShellVariable::new(ShellValue::Dynamic {
+        kind: variables::DynamicValueKind::Scalar,
         getter: |shell| shell.options().shopt_optstr().into(),
         setter: |_| (),
     });
@@ -92,6 +93,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_ALIASES",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::AssociativeArray,
             getter: |shell| {
                 let values = variables::ArrayLiteral(
                     shell
@@ -112,6 +114,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_ARGC",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |shell| get_bash_argc_value(shell),
             setter: |_| (),
         }),
@@ -121,6 +124,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_ARGV",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |shell| get_bash_argv_value(shell),
             setter: |_| (),
         }),
@@ -130,6 +134,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_ARGV0",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::Scalar,
             getter: |shell| {
                 let argv0 = shell.current_shell_name().unwrap_or_default();
                 argv0.to_string().into()
@@ -143,6 +148,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_CMDS",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::AssociativeArray,
             getter: |shell| {
                 shell
                     .program_location_cache()
@@ -160,6 +166,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_LINENO",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |shell| get_bash_lineno_value(shell),
             setter: |_| (),
         }),
@@ -169,6 +176,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_SOURCE",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |shell| get_bash_source_value(shell),
             setter: |_| (),
         }),
@@ -178,6 +186,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "BASH_SUBSHELL",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::Scalar,
             getter: |shell| shell.depth().to_string().into(),
             setter: |_| (),
         }),
@@ -224,6 +233,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "DIRSTACK",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |shell| {
                 shell
                     .directory_stack()
@@ -240,6 +250,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "EPOCHREALTIME",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::Scalar,
             getter: |_shell| {
                 let now = std::time::SystemTime::now();
                 let since_epoch = now
@@ -255,6 +266,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "EPOCHSECONDS",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::Scalar,
             getter: |_shell| {
                 let now = std::time::SystemTime::now();
                 let since_epoch = now
@@ -277,6 +289,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "FUNCNAME",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |shell| get_funcname_value(shell),
             setter: |_| (),
         }),
@@ -288,6 +301,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "GROUPS",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |_shell| {
                 let groups = get_current_user_gids();
                 ShellValue::indexed_array_from_strings(
@@ -300,6 +314,7 @@ pub(crate) fn init_well_known_vars(
 
     // HISTCMD
     let mut histcmd_var = ShellVariable::new(ShellValue::Dynamic {
+        kind: variables::DynamicValueKind::Scalar,
         getter: |shell| {
             shell
                 .history()
@@ -347,6 +362,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "LINENO",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::Scalar,
             getter: |shell| get_lineno(shell).to_string().into(),
             setter: |_| (),
         }),
@@ -412,6 +428,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "PIPESTATUS",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::IndexedArray,
             getter: |shell| {
                 ShellValue::indexed_array_from_strings(
                     shell.last_pipeline_statuses().iter().map(|s| s.to_string()),
@@ -430,6 +447,7 @@ pub(crate) fn init_well_known_vars(
 
     // RANDOM
     let mut random_var = ShellVariable::new(ShellValue::Dynamic {
+        kind: variables::DynamicValueKind::Scalar,
         getter: get_random_value,
         setter: |_| (),
     });
@@ -440,6 +458,7 @@ pub(crate) fn init_well_known_vars(
     shell.env_mut().set_global(
         "SECONDS",
         ShellVariable::new(ShellValue::Dynamic {
+            kind: variables::DynamicValueKind::Scalar,
             getter: |shell| {
                 let now = std::time::SystemTime::now();
                 let since_last = now
@@ -466,6 +485,7 @@ pub(crate) fn init_well_known_vars(
 
     // SHELLOPTS
     let mut shellopts_var = ShellVariable::new(ShellValue::Dynamic {
+        kind: variables::DynamicValueKind::Scalar,
         getter: |shell| shell.options().seto_optstr().into(),
         setter: |_| (),
     });
@@ -481,6 +501,7 @@ pub(crate) fn init_well_known_vars(
 
     // SRANDOM
     let mut random_var = ShellVariable::new(ShellValue::Dynamic {
+        kind: variables::DynamicValueKind::Scalar,
         getter: get_srandom_value,
         setter: |_| (),
     });

--- a/brush-shell/tests/cases/compat/well_known_vars.yaml
+++ b/brush-shell/tests/cases/compat/well_known_vars.yaml
@@ -256,3 +256,27 @@ cases:
       second=${SRANDOM}
 
       [[ $first != $second ]] && echo "Confirmed SRANDOM at least isn't static"
+
+  - name: "PIPESTATUS stays live after declare -a conversion"
+    stdin: |
+      # `declare -a` on a dynamic well-known variable must not permanently freeze
+      # it. Real bash refreshes PIPESTATUS on every pipeline regardless of prior
+      # declarations, so after the next pipe the array must reflect the actual
+      # statuses, not the declared value.
+      declare -a PIPESTATUS=([0]="1")
+      true | true | true
+      echo "after declare -a: ${PIPESTATUS[@]}"
+
+  - name: "PIPESTATUS stays live after plain array assignment"
+    stdin: |
+      PIPESTATUS=([0]="9")
+      true | false | true
+      echo "after plain assign: ${PIPESTATUS[@]}"
+
+  - name: "PIPESTATUS freezes after declare -A conversion"
+    stdin: |
+      # bash itself permanently converts PIPESTATUS to a plain associative
+      # array after `declare -A`, so it no longer refreshes on pipelines.
+      declare -A PIPESTATUS=([x]="9")
+      true | true | true
+      echo "after declare -A: ${PIPESTATUS[@]}"

--- a/brush-shell/tests/cases/compat/well_known_vars.yaml
+++ b/brush-shell/tests/cases/compat/well_known_vars.yaml
@@ -280,3 +280,27 @@ cases:
       declare -A PIPESTATUS=([x]="9")
       true | true | true
       echo "after declare -A: ${PIPESTATUS[@]}"
+
+  - name: "RANDOM freezes after declare -a conversion"
+    stdin: |
+      # Unlike PIPESTATUS, RANDOM is scalar-shaped, not indexed-array-shaped.
+      # `declare -a` on it materializes (and permanently freezes) a real array,
+      # rather than keeping the dynamic binding live the way it would for a
+      # variable whose native shape already matches (e.g. PIPESTATUS).
+      declare -a RANDOM
+      first=${RANDOM}
+      second=${RANDOM}
+      [[ $first == $second ]] && echo "RANDOM stayed frozen after declare -a"
+
+  - name: "BASH_ALIASES rejects declare -a conversion"
+    ignore_stderr: true # bash and brush word the "cannot convert" error differently
+    stdin: |
+      # BASH_ALIASES is associative-shaped, so a bare `declare -a` (with no
+      # accompanying value) must be rejected exactly like converting a real
+      # associative array to an indexed array would be, leaving the dynamic
+      # binding untouched.
+      alias x=y
+      declare -a BASH_ALIASES
+      echo "declare exit status: $?"
+      echo "BASH_ALIASES stays live: ${BASH_ALIASES[@]}"
+      unalias x

--- a/brush-shell/tests/cases/compat/well_known_vars.yaml
+++ b/brush-shell/tests/cases/compat/well_known_vars.yaml
@@ -292,6 +292,18 @@ cases:
       second=${RANDOM}
       [[ $first == $second ]] && echo "RANDOM stayed frozen after declare -a"
 
+  - name: "Bare array assignment de-specials a scalar dynamic variable"
+    stdin: |
+      # A bare array assignment to a scalar-shaped dynamic variable (RANDOM)
+      # "de-specials" it: the dynamic binding is replaced by a real indexed
+      # array holding the assigned values. (Array-shaped dynamics like
+      # PIPESTATUS stay live; see "stays live after plain array assignment".)
+      RANDOM=(10 20 30)
+      echo "${RANDOM[0]} ${RANDOM[1]} ${RANDOM[2]}"
+      echo "count=${#RANDOM[@]}"
+      # Subsequent reads are now static, not random.
+      [[ ${RANDOM[0]} == 10 ]] && echo "RANDOM is no longer dynamic"
+
   - name: "BASH_ALIASES rejects declare -a conversion"
     ignore_stderr: true # bash and brush word the "cannot convert" error differently
     stdin: |


### PR DESCRIPTION
## Problem

Once a script `declare -a`s or plain-array-assigns a dynamic well-known variable such as `PIPESTATUS`, brush **never updates it again** on later pipelines in that shell — it stays frozen at whatever was last assigned. Real bash keeps the variable live and refreshes it on every pipeline.

Minimal repro:

```bash
declare -a PIPESTATUS=([0]="1")
true | true | true
echo "${PIPESTATUS[@]}"
```

- **bash**: `0 0 0`
- **brush** (current `origin/main`): `1` (frozen)

Same freeze happens with a plain array assignment (no `declare`):

```bash
PIPESTATUS=([0]="9")
true | false | true
echo "${PIPESTATUS[@]}"
```

- **bash**: `0 1 0`
- **brush**: `9`

## Root cause

`PIPESTATUS` (and other dynamic well-known variables: `RANDOM`, `SECONDS`, `FUNCNAME`, `BASH_LINENO`, `BASH_SOURCE`, `BASH_ALIASES`, …) are backed by a `ShellValue::Dynamic { getter, setter }` whose `getter` is consulted on every read and whose `setter` is a no-op (`|_| ()`) for all of them.

Two write paths in `brush-core/src/variables.rs` unconditionally overwrote `self.value` with a static array, discarding the `Dynamic` binding and permanently freezing the variable:

1. **`convert_to_indexed_array`** — the `_` arm hit for `Dynamic` values and replaced `self.value`. Triggered by `declare -a VAR=(...)` via `brush-builtins/src/declare.rs`.
2. **`assign`** (non-append Array-literal arm) — explicitly matched `ShellValue::Dynamic { .. }` in the overwrite set. Triggered by a plain `VAR=([0]="...")` assignment.

From that point on the getter closure was gone, so the variable stopped refreshing for the rest of the shell's life.

## Fix

- `convert_to_indexed_array`: add an explicit `ShellValue::Dynamic { .. } => Ok(())` arm so the binding survives.
- `assign`: drop `ShellValue::Dynamic { .. }` from the overwrite set; the existing `(ShellValue::Dynamic { .. }, _) => Ok(())` arm below now handles it correctly.

### `convert_to_associative_array` intentionally unchanged

`convert_to_associative_array` has the same overwrite pattern, but real bash is asymmetric here: `declare -A PIPESTATUS=([x]="9")` **does** permanently freeze it in bash itself (PIPESTATUS becomes a plain associative array that pipelines don't refresh). Pre-fix brush already matched bash's `-A` behavior, so changing it would diverge from bash compat.

## Verification

All four behavioral cases now match bash:

| op | bash | brush (after) |
|---|---|---|
| `declare -a` then pipe | `0 0 0` | `0 0 0` ✓ |
| `declare -A` then pipe | `9` | `9` ✓ |
| plain `=([0]="9")` then pipe | `0 1 0` | `0 1 0` ✓ |
| plain pipe | `0 0 0` | `0 0 0` ✓ |

Adds three compat test cases under `brush-shell/tests/cases/compat/well_known_vars.yaml` (`declare -a`, plain array assign, `declare -A`). `cargo fmt --check` clean.

This surfaced in the wild: a worker-env dump/restore mechanism restored a `declare -a PIPESTATUS=([0]="1")` line and a downstream `pipestatus || die` check fired incorrectly, misreporting a successful pipeline as failed.
