### PR TITLE
fix(cd): remove unsupported `no-clearly-defined` option from about.toml

### DIFF
--- a/brush-shell/about.toml
+++ b/brush-shell/about.toml
@@ -1,6 +1,5 @@
 ignore-build-dependencies = true
 ignore-dev-dependencies = true
-no-clearly-defined = true
 
 accepted = [
     "MIT",


### PR DESCRIPTION
## Problem

The CD workflow fails at the "Generate license notices" step:

```
Run cargo about generate -o ../THIRD_PARTY_LICENSES.html about.hbs
error: expected a table, found boolean
  ┌─ /Users/runner/work/brush/brush/brush-shell/about.toml:3:22
  │
3 │ no-clearly-defined = true
  │                      ^^^^
```

CD installs `cargo-about` fresh (`cargo install cargo-about --locked --features cli`), so it picks up the latest version, whose config schema no longer accepts the `no-clearly-defined` option as a boolean.

## Fix

Remove the `no-clearly-defined = true` line from `brush-shell/about.toml`. The option is no longer part of the `cargo-about` config schema; the license-notice generation works without it.

## Verification

This is a one-line config deletion. The CD run on this branch will confirm the "Generate license notices" step passes.
