### PR TITLE
Use `IntoIterator` over `Vec`

### DIFF
--- a/brush-builtins/src/trap.rs
+++ b/brush-builtins/src/trap.rs
@@ -95,11 +95,13 @@ impl TrapCommand {
         context.shell.traps_mut().remove_handlers(signal);
     }
 
-    fn register_handler(
+    fn register_handler<I>(
         context: &mut brush_core::ExecutionContext<'_, impl brush_core::ShellExtensions>,
-        signals: Vec<TrapSignal>,
+        signals: I,
         handler: &str,
-    ) {
+    ) where
+        I: IntoIterator<Item = TrapSignal>,
+    {
         // Our new source context is relative to the current position.
         // TODO(source-info): Provide the location of the specific token that makes up
         // `self.args[0]`.

--- a/brush-coreutils-builtins/src/lib.rs
+++ b/brush-coreutils-builtins/src/lib.rs
@@ -92,7 +92,10 @@ macro_rules! register {
     ($map:expr, $feature:literal, $name:literal, $util_crate:ident) => {
         #[cfg(feature = $feature)]
         {
-            fn adapter(args: Vec<OsString>) -> i32 {
+            fn adapter<I>(args: I) -> i32
+            where
+                I: IntoIterator<Item = OsString>,
+            {
                 $crate::prepare_uutil_runtime(stringify!($util_crate));
                 let code = $util_crate::uumain(args.into_iter());
                 $crate::finalize_uutil_runtime();


### PR DESCRIPTION
Both of these places only use `into_iter` by itself, not `Vec::into_iter`. It probably will result in basically the same machine code, but this way is technically better.