### PR TITLE
fix(help): return non-zero exit status when no help topics match

### DIFF
--- a/brush-builtins/src/help.rs
+++ b/brush-builtins/src/help.rs
@@ -31,13 +31,23 @@ impl builtins::Command for HelpCommand {
     ) -> Result<brush_core::ExecutionResult, Self::Error> {
         if self.topic_patterns.is_empty() {
             Self::display_general_help(&context)?;
-        } else {
-            for topic_pattern in &self.topic_patterns {
-                self.display_help_for_topic_pattern(&context, topic_pattern)?;
+            return Ok(ExecutionResult::success());
+        }
+
+        // Match bash: succeed if at least one requested topic pattern matched
+        // something; return a non-zero exit code only when none of them matched.
+        let mut any_matched = false;
+        for topic_pattern in &self.topic_patterns {
+            if self.display_help_for_topic_pattern(&context, topic_pattern)? {
+                any_matched = true;
             }
         }
 
-        Ok(ExecutionResult::success())
+        if any_matched {
+            Ok(ExecutionResult::success())
+        } else {
+            Ok(ExecutionResult::general_error())
+        }
     }
 }
 
@@ -73,16 +83,18 @@ impl HelpCommand {
         Ok(())
     }
 
+    /// Displays help for the builtins matching `topic_pattern`, returning whether
+    /// at least one topic matched.
     fn display_help_for_topic_pattern(
         &self,
         context: &brush_core::ExecutionContext<'_, impl brush_core::ShellExtensions>,
         topic_pattern: &str,
-    ) -> Result<(), brush_core::Error> {
+    ) -> Result<bool, brush_core::Error> {
         let pattern = brush_core::patterns::Pattern::from(topic_pattern)
             .set_extended_globbing(context.shell.options().extended_globbing)
             .set_case_insensitive(context.shell.options().case_insensitive_pathname_expansion);
 
-        let mut found_count = 0;
+        let mut matched = false;
         for (builtin_name, builtin_registration) in get_builtins_sorted_by_name(context) {
             if pattern.exactly_matches(builtin_name.as_str())? {
                 self.display_help_for_builtin(
@@ -90,15 +102,15 @@ impl HelpCommand {
                     builtin_name.as_str(),
                     builtin_registration,
                 )?;
-                found_count += 1;
+                matched = true;
             }
         }
 
-        if found_count == 0 {
+        if !matched {
             writeln!(context.stderr(), "No help topics match '{topic_pattern}'")?;
         }
 
-        Ok(())
+        Ok(matched)
     }
 
     fn display_help_for_builtin<SE: brush_core::ShellExtensions>(

--- a/brush-shell/tests/cases/compat/builtins/help.yaml
+++ b/brush-shell/tests/cases/compat/builtins/help.yaml
@@ -11,3 +11,15 @@ cases:
     ignore_stderr: true
     stdin: |
       help echo
+
+  - name: "Help for unknown topic returns non-zero"
+    ignore_stdout: true
+    ignore_stderr: true
+    stdin: |
+      help this-is-not-a-real-builtin
+
+  - name: "Help for known and unknown topics returns zero"
+    ignore_stdout: true
+    ignore_stderr: true
+    stdin: |
+      help echo this-is-not-a-real-builtin


### PR DESCRIPTION
## Problem

`help nonexistent` prints "No help topics match ..." but exits 0, whereas bash exits 1 when none of the requested topics match. (#1236)

## Root cause

`HelpCommand::execute` always returned `ExecutionResult::success()`, and `display_help_for_topic_pattern` didn't report whether it matched anything.

## Fix

`display_help_for_topic_pattern` now returns whether at least one topic matched, and `execute` returns `general_error()` (exit 1) only when none of the requested patterns matched — mirroring bash, which succeeds as long as at least one requested topic matches:

| stdin | bash 5.2.21 | brush before | brush after |
| --- | --- | --- | --- |
| `help cd` | 0 | 0 | 0 |
| `help nonexistent` | 1 | 0 | 1 |
| `help cd nonexistent` | 0 | 0 | 0 |
| `help nope1 nope2` | 1 | 0 | 1 |
| `help` (no args) | 0 | 0 | 0 |

The stderr message is unchanged; only the exit status is affected.

## Tests

Added two oracle cases to `builtins/help.yaml`: one for an unknown topic (expects exit 1) and one for a known+unknown mix (expects exit 0).

## Verification

`cargo build`, `cargo fmt --all -- --check`, and `cargo clippy --all-targets -- -D warnings` are clean. Also ran `brush -c 'help ...'` directly for each row above and confirmed the exit statuses match bash 5.2.21.

Closes #1236

---

*Assisted-by: Claude (Anthropic) — disclosed here and in the commit trailer per the project's AI policy. I've reviewed and understand the change and vouch for it.*
