### PR TITLE
fix(status): don't let PS4 expansion clobber assignment exit status

### DIFF
--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -90,7 +90,9 @@ pub struct Shell<SE: extensions::ShellExtensions = extensions::DefaultShellExten
     /// The status of the last completed command.
     last_exit_status: u8,
 
-    /// Tracks changes to `last_exit_status`.
+    /// Tracks changes to `last_exit_status`. Assignment-only commands observe it
+    /// to tell whether an expansion set a status (see `interp.rs`), so code that
+    /// rolls back `$?` must roll this back too.
     last_exit_status_change_count: usize,
 
     /// The status of each of the commands in the last pipeline.
@@ -511,7 +513,8 @@ impl<SE: extensions::ShellExtensions> ShellState for Shell<SE> {
         self.last_exit_status
     }
 
-    /// Updates the last exit status.
+    /// Updates the last exit status. To *restore* a saved status, restore
+    /// `last_exit_status_change_count` as well.
     pub fn set_last_exit_status(&mut self, status: u8) {
         self.last_exit_status = status;
         self.last_exit_status_change_count += 1;

--- a/brush-core/src/shell/prompts.rs
+++ b/brush-core/src/shell/prompts.rs
@@ -51,8 +51,10 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
             return Ok(String::new());
         }
 
-        // Save (and later restore) the last exit status.
+        // Save (and later restore) the last exit status, change count included, so
+        // that expanding here is invisible to `$?`.
         let prev_last_result = self.last_exit_status();
+        let prev_last_result_change_count = self.last_exit_status_change_count;
         let prev_last_pipeline_statuses = self.last_pipeline_statuses.clone();
 
         // Expand it.
@@ -62,6 +64,7 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
         // Restore the last exit status.
         self.last_pipeline_statuses = prev_last_pipeline_statuses;
         self.set_last_exit_status(prev_last_result);
+        self.last_exit_status_change_count = prev_last_result_change_count;
 
         // Strip out special characters that readline would typically drop:
         // \001 and \002 (start and end of non-printing sequences).

--- a/brush-shell/tests/cases/compat/options/set-e.yaml
+++ b/brush-shell/tests/cases/compat/options/set-e.yaml
@@ -1299,6 +1299,22 @@ cases:
       x=$unset
       echo "after"
 
+  - name: "with -x and if/else ending in assignment"
+    stdin: |
+      set -ex
+      if false; then
+        E=then
+      else
+        E=else
+      fi
+      echo "after ${E}"
+
+  - name: "with -x and assignment after exempted failing command"
+    stdin: |
+      set -ex
+      false || E=value
+      echo "after ${E}"
+
   - name: "syntax error"
     ignore_stderr: true
     stdin: |

--- a/brush-shell/tests/cases/compat/status.yaml
+++ b/brush-shell/tests/cases/compat/status.yaml
@@ -51,6 +51,44 @@ cases:
 
       echo "Status after assignment: $assign_status"
 
+  - name: "Status from assignment with xtrace"
+    stdin: |
+      set -x
+      false
+      scalar=value
+      echo "Status after scalar assignment: $?"
+
+      false
+      arr=(1 2)
+      echo "Status after array assignment: $?"
+
+      false
+      appended+=more
+      echo "Status after appending assignment: $?"
+
+      false
+      first=1 second=2
+      echo "Status after multiple assignments: $?"
+
+      false
+      expanded=${undefined:-fallback}
+      echo "Status after expanded assignment: $?"
+
+  - name: "Status from assignment with command substitution and xtrace"
+    stdin: |
+      set -x
+      f() {
+        echo "out$1"
+        return $1
+      }
+
+      captured=$(f 42)
+      echo "Status after substitution assignment: $?"
+
+      true
+      captured=$(f 42)
+      echo "Status after substitution assignment: $?"
+
   - name: "Status within assignments"
     stdin: |
       f() {


### PR DESCRIPTION
Assignment-only commands set `$?` to 0 unless an expansion within them set a status. `expand_prompt_var` saves and restores `$?` around the expansion, but not the mechanism used to track expansion.

This fix restores the change count alongside the status so prompt expansion is fully transparent to `$?`.

Fixes #1245
