### PR TITLE
fix(input): accumulate multi-line input when stdin isn't a terminal

### DIFF
--- a/brush-interactive/src/basic/input_backend.rs
+++ b/brush-interactive/src/basic/input_backend.rs
@@ -49,11 +49,7 @@ impl BasicInputBackend {
                 ReadResult::Input(s) => {
                     result.push_str(s.as_str());
 
-                    let shell = tokio::task::block_in_place(|| {
-                        tokio::runtime::Handle::current().block_on(shell_ref.lock())
-                    });
-
-                    if Self::is_valid_input(&shell, result.as_str()) {
+                    if !crate::completeness::needs_more_input(shell_ref, result.as_str()) {
                         break;
                     }
 
@@ -79,21 +75,6 @@ impl BasicInputBackend {
     #[expect(clippy::unused_self)]
     fn should_display_prompt(&self) -> bool {
         std::io::stdin().is_terminal()
-    }
-
-    fn is_valid_input(shell: &Shell<impl brush_core::ShellExtensions>, input: &str) -> bool {
-        match shell.parse_string(input) {
-            // Incomplete tokenizing (unclosed quotes, etc.) - need more input
-            Err(brush_parser::ParseError::Tokenizing { inner, position: _ })
-                if inner.is_incomplete() =>
-            {
-                false
-            }
-            // Parse error at end of input - could be incomplete
-            Err(brush_parser::ParseError::ParsingAtEndOfInput) => false,
-            // Parse error at a specific position OR successful parse - complete
-            _ => true,
-        }
     }
 
     fn generate_completions(

--- a/brush-interactive/src/completeness.rs
+++ b/brush-interactive/src/completeness.rs
@@ -1,0 +1,159 @@
+//! Deciding whether accumulated input forms a complete shell program.
+//!
+//! Input backends read a line at a time and need to know when they have enough to hand
+//! over for execution.
+
+use brush_core::Shell;
+
+/// Returns whether the given accumulated input is an incomplete shell program, i.e.
+/// whether more input must be read before it can be executed.
+///
+/// Acquires the shell lock without blocking. Input is read between commands, with no
+/// other task holding the lock, so acquisition is expected to succeed; blocking instead
+/// isn't an option because backends also run on single-threaded runtimes.
+///
+/// # Arguments
+///
+/// * `shell_ref` - The shell whose parsing options should be used.
+/// * `input` - The input accumulated so far.
+#[allow(dead_code)]
+pub(crate) fn needs_more_input(
+    shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
+    input: &str,
+) -> bool {
+    let Ok(shell) = shell_ref.try_lock() else {
+        tracing::warn!("shell was unexpectedly busy; treating input as complete");
+        return false;
+    };
+
+    needs_more_input_locked(&shell, input)
+}
+
+/// Returns whether more input is needed, given an already-acquired shell.
+#[allow(dead_code)]
+fn needs_more_input_locked(shell: &Shell<impl brush_core::ShellExtensions>, input: &str) -> bool {
+    match shell.parse_string(input) {
+        // Mid-token: unclosed quotes, unterminated here documents, and the like.
+        Err(brush_parser::ParseError::Tokenizing { inner, position: _ })
+            if inner.is_incomplete() =>
+        {
+            true
+        }
+        // Ran out of tokens partway through a construct; more input may complete it.
+        Err(brush_parser::ParseError::ParsingAtEndOfInput) => true,
+        // A bad token at a specific position stays bad no matter what follows it.
+        Err(_) => false,
+        // Parsed cleanly. One catch: a trailing backslash-newline is a line
+        // continuation, which the tokenizer drops silently at end of input. Ask again
+        // with the newline removed; the tokenizer reports an unterminated escape only
+        // if that backslash was really escaping something.
+        Ok(_) => ends_with_line_continuation(shell, input),
+    }
+}
+
+/// Returns whether the given input ends with a backslash-newline acting as a line
+/// continuation.
+fn ends_with_line_continuation(
+    shell: &Shell<impl brush_core::ShellExtensions>,
+    input: &str,
+) -> bool {
+    let Some(truncated) = input.strip_suffix('\n') else {
+        return false;
+    };
+
+    // Keeps the extra parse off the common path.
+    if !truncated.ends_with('\\') {
+        return false;
+    }
+
+    matches!(
+        shell.parse_string(truncated),
+        Err(brush_parser::ParseError::Tokenizing {
+            inner: brush_parser::TokenizerError::UnterminatedEscapeSequence,
+            position: _,
+        })
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_shell() -> Shell<brush_core::extensions::DefaultShellExtensions> {
+        brush_core::Shell::builder().build().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn treats_trailing_line_continuation_as_incomplete() {
+        let shell = test_shell().await;
+
+        assert!(needs_more_input_locked(&shell, "echo a\\\n"));
+        assert!(needs_more_input_locked(&shell, "printf '%s' \\\n"));
+        assert!(needs_more_input_locked(&shell, "echo \"quoted\" \\\n"));
+        // A backslash at the very end, with no newline yet.
+        assert!(needs_more_input_locked(&shell, "echo a\\"));
+    }
+
+    #[tokio::test]
+    async fn treats_complete_programs_as_complete() {
+        let shell = test_shell().await;
+
+        assert!(!needs_more_input_locked(&shell, "echo a\n"));
+        assert!(!needs_more_input_locked(&shell, ""));
+        // An escaped backslash is a literal backslash, not an escape of the newline.
+        assert!(!needs_more_input_locked(&shell, "echo a\\\\\n"));
+        // A continuation that isn't at the end has already been joined.
+        assert!(!needs_more_input_locked(&shell, "echo a\\\nb\n"));
+        // A backslash followed by a space escapes the space, not the newline.
+        assert!(!needs_more_input_locked(&shell, "echo a\\ \n"));
+        assert!(!needs_more_input_locked(&shell, "echo a\\\t\n"));
+    }
+
+    #[tokio::test]
+    async fn ignores_backslashes_that_do_not_escape() {
+        let shell = test_shell().await;
+
+        // Backslashes are literal inside single quotes...
+        assert!(!needs_more_input_locked(&shell, "echo 'a\\'\n"));
+        // ...and inside comments, which end at the newline regardless.
+        assert!(!needs_more_input_locked(&shell, "echo hi # trailing\\\n"));
+        assert!(!needs_more_input_locked(&shell, "# whole-line comment\\\n"));
+    }
+
+    #[tokio::test]
+    async fn honors_quoting_context() {
+        let shell = test_shell().await;
+
+        // A `#` inside quotes doesn't start a comment, so these really are continuations.
+        assert!(needs_more_input_locked(
+            &shell,
+            "echo \"# not a comment\" \\\n"
+        ));
+        assert!(needs_more_input_locked(
+            &shell,
+            "echo '# not a comment' \\\n"
+        ));
+        // A `#` mid-word doesn't start a comment either.
+        assert!(needs_more_input_locked(&shell, "echo a#b \\\n"));
+    }
+
+    #[tokio::test]
+    async fn treats_bad_syntax_as_complete_even_with_a_trailing_continuation() {
+        let shell = test_shell().await;
+
+        // More input can't repair a bad token, so don't sit waiting for it.
+        assert!(!needs_more_input_locked(&shell, "echo ;;\n"));
+        assert!(!needs_more_input_locked(&shell, "echo ;; \\\n"));
+    }
+
+    #[tokio::test]
+    async fn treats_unfinished_constructs_as_incomplete() {
+        let shell = test_shell().await;
+
+        assert!(needs_more_input_locked(&shell, "if true\n"));
+        assert!(needs_more_input_locked(&shell, "f() {\n"));
+        assert!(needs_more_input_locked(&shell, "cat <<EOF\n"));
+        assert!(needs_more_input_locked(&shell, "echo 'unterminated\n"));
+        assert!(needs_more_input_locked(&shell, "true &&\n"));
+    }
+}

--- a/brush-interactive/src/lib.rs
+++ b/brush-interactive/src/lib.rs
@@ -15,6 +15,7 @@ pub use options::UIOptions;
 mod refs;
 pub use refs::ShellRef;
 
+mod completeness;
 mod term_detection;
 mod term_integration;
 mod trace_categories;

--- a/brush-interactive/src/minimal/input_backend.rs
+++ b/brush-interactive/src/minimal/input_backend.rs
@@ -1,4 +1,4 @@
-use std::io::{IsTerminal, Write};
+use std::io::{BufRead, IsTerminal, Write};
 
 use crate::{
     InputBackend, ShellError,
@@ -12,17 +12,59 @@ pub struct MinimalInputBackend;
 impl InputBackend for MinimalInputBackend {
     fn read_line(
         &mut self,
-        _shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
+        shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
         prompt: InteractivePrompt,
     ) -> Result<ReadResult, ShellError> {
-        self.display_prompt(&prompt)?;
+        let stdin = std::io::stdin();
+        let prompt = stdin.is_terminal().then_some(&prompt);
 
-        let result = match Self::read_input_line()? {
-            ReadResult::Input(s) => s,
-            ReadResult::BoundCommand(s) => s,
-            ReadResult::Eof => return Ok(ReadResult::Eof),
-            ReadResult::Interrupted => return Ok(ReadResult::Interrupted),
-        };
+        Self::read_program_from(shell_ref, prompt, &mut stdin.lock(), &mut std::io::stderr())
+    }
+}
+
+impl MinimalInputBackend {
+    /// Reads lines from the given reader until they form a complete shell program.
+    /// Compound commands, here documents, and backslash continuations all span lines,
+    /// so a single line is often not a program on its own.
+    ///
+    /// # Arguments
+    ///
+    /// * `shell_ref` - The shell whose parsing options decide when input is complete.
+    /// * `prompt` - The prompt to display, or `None` to display nothing.
+    /// * `reader` - The source to read lines from.
+    /// * `writer` - Where prompts are written.
+    fn read_program_from<R: BufRead, W: Write>(
+        shell_ref: &crate::ShellRef<impl brush_core::ShellExtensions>,
+        prompt: Option<&InteractivePrompt>,
+        reader: &mut R,
+        writer: &mut W,
+    ) -> Result<ReadResult, ShellError> {
+        let mut result = String::new();
+
+        loop {
+            if let Some(prompt) = prompt {
+                let to_display = if result.is_empty() {
+                    &prompt.prompt
+                } else {
+                    &prompt.continuation_prompt
+                };
+
+                write!(writer, "{to_display}")?;
+                writer.flush()?;
+            }
+
+            // Nothing more is coming; run what we have and let the parser complain if
+            // it's still incomplete.
+            let Some(line) = Self::read_input_line(reader)? else {
+                break;
+            };
+
+            result.push_str(line.as_str());
+
+            if !crate::completeness::needs_more_input(shell_ref, result.as_str()) {
+                break;
+            }
+        }
 
         if result.is_empty() {
             Ok(ReadResult::Eof)
@@ -30,33 +72,119 @@ impl InputBackend for MinimalInputBackend {
             Ok(ReadResult::Input(result))
         }
     }
-}
 
-impl MinimalInputBackend {
-    #[expect(clippy::unused_self)]
-    fn should_display_prompt(&self) -> bool {
-        std::io::stdin().is_terminal()
-    }
-
-    fn display_prompt(&self, prompt: &InteractivePrompt) -> Result<(), ShellError> {
-        if self.should_display_prompt() {
-            eprint!("{}", prompt.prompt);
-            std::io::stderr().flush()?;
-        }
-
-        Ok(())
-    }
-
-    fn read_input_line() -> Result<ReadResult, ShellError> {
+    /// Reads a single line, returning `None` at end of input.
+    fn read_input_line<R: BufRead>(reader: &mut R) -> Result<Option<String>, ShellError> {
         let mut input = String::new();
-        let bytes_read = std::io::stdin()
+        let bytes_read = reader
             .read_line(&mut input)
             .map_err(ShellError::InputError)?;
 
-        if bytes_read == 0 {
-            Ok(ReadResult::Eof)
-        } else {
-            Ok(ReadResult::Input(input))
+        Ok((bytes_read > 0).then_some(input))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{io::Cursor, sync::Arc};
+
+    async fn test_shell_ref() -> crate::ShellRef {
+        Arc::new(tokio::sync::Mutex::new(
+            brush_core::Shell::builder().build().await.unwrap(),
+        ))
+    }
+
+    fn test_prompt() -> InteractivePrompt {
+        InteractivePrompt {
+            prompt: String::from("$ "),
+            alt_side_prompt: String::new(),
+            continuation_prompt: String::from("> "),
         }
+    }
+
+    /// Reads one program from `input`, returning what the backend accumulated.
+    async fn read_program(input: &str) -> ReadResult {
+        let shell_ref = test_shell_ref().await;
+        let mut reader = Cursor::new(input.as_bytes());
+
+        MinimalInputBackend::read_program_from(&shell_ref, None, &mut reader, &mut Vec::new())
+            .unwrap()
+    }
+
+    async fn assert_reads(input: &str, expected: &str) {
+        let actual = match read_program(input).await {
+            ReadResult::Input(s) => format!("Input({s:?})"),
+            ReadResult::BoundCommand(s) => format!("BoundCommand({s:?})"),
+            ReadResult::Eof => String::from("Eof"),
+            ReadResult::Interrupted => String::from("Interrupted"),
+        };
+
+        assert_eq!(
+            actual,
+            format!("Input({expected:?})"),
+            "for input {input:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stops_at_a_complete_program() {
+        assert_reads("echo one\necho two\n", "echo one\n").await;
+    }
+
+    #[tokio::test]
+    async fn accumulates_until_complete() {
+        assert_reads("true &&\necho yes\n", "true &&\necho yes\n").await;
+        assert_reads(
+            "if true\nthen\necho yes\nfi\necho after\n",
+            "if true\nthen\necho yes\nfi\n",
+        )
+        .await;
+        assert_reads("cat <<EOF\nbody\nEOF\n", "cat <<EOF\nbody\nEOF\n").await;
+        assert_reads("echo a\\\nb\n", "echo a\\\nb\n").await;
+    }
+
+    #[tokio::test]
+    async fn returns_incomplete_input_at_end_of_input() {
+        // Truncated mid-construct: hand it over anyway so the parser reports the error.
+        assert_reads("if true\nthen\n", "if true\nthen\n").await;
+    }
+
+    #[tokio::test]
+    async fn reports_end_of_input_when_there_is_nothing_to_read() {
+        assert!(matches!(read_program("").await, ReadResult::Eof));
+    }
+
+    #[tokio::test]
+    async fn displays_a_continuation_prompt_for_each_extra_line() {
+        let shell_ref = test_shell_ref().await;
+        let prompt = test_prompt();
+        let mut prompts = Vec::new();
+
+        MinimalInputBackend::read_program_from(
+            &shell_ref,
+            Some(&prompt),
+            &mut Cursor::new(b"if true\nthen\necho hi\nfi\n".as_slice()),
+            &mut prompts,
+        )
+        .unwrap();
+
+        assert_eq!(String::from_utf8(prompts).unwrap(), "$ > > > ");
+    }
+
+    #[tokio::test]
+    async fn displays_no_prompts_without_one_to_display() {
+        let shell_ref = test_shell_ref().await;
+        let mut prompts = Vec::new();
+
+        MinimalInputBackend::read_program_from(
+            &shell_ref,
+            None,
+            &mut Cursor::new(b"if true\nthen\necho hi\nfi\n".as_slice()),
+            &mut prompts,
+        )
+        .unwrap();
+
+        assert!(prompts.is_empty());
     }
 }

--- a/brush-interactive/src/reedline/validator.rs
+++ b/brush-interactive/src/reedline/validator.rs
@@ -6,20 +6,10 @@ pub(crate) struct ReedlineValidator<SE: brush_core::ShellExtensions> {
 
 impl<SE: brush_core::ShellExtensions> reedline::Validator for ReedlineValidator<SE> {
     fn validate(&self, line: &str) -> reedline::ValidationResult {
-        let shell = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.shell.lock())
-        });
-
-        match shell.parse_string(line.to_owned()) {
-            Err(brush_parser::ParseError::Tokenizing { inner, position: _ })
-                if inner.is_incomplete() =>
-            {
-                reedline::ValidationResult::Incomplete
-            }
-            Err(brush_parser::ParseError::ParsingAtEndOfInput) => {
-                reedline::ValidationResult::Incomplete
-            }
-            _ => reedline::ValidationResult::Complete,
+        if crate::completeness::needs_more_input(&self.shell, line) {
+            reedline::ValidationResult::Incomplete
+        } else {
+            reedline::ValidationResult::Complete
         }
     }
 }

--- a/brush-shell/tests/cases/compat/piped_script.yaml
+++ b/brush-shell/tests/cases/compat/piped_script.yaml
@@ -1,0 +1,208 @@
+name: "Scripts piped in on stdin (a la 'curl | sh')"
+cases:
+  # Cases carrying `removed_default_args` drop `--input-backend=basic` so brush
+  # picks the backend it uses for real when stdin isn't a terminal. Otherwise
+  # that path goes untested.
+
+  - name: "Multi-line if/then/fi"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      if true
+      then
+        echo yes
+      fi
+
+  - name: "Multi-line function definition"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      greet() {
+        echo "hello, $1"
+      }
+
+      greet world
+
+  - name: "Here document"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      cat <<EOF
+      first
+      second
+      EOF
+      echo after
+
+  - name: "Pipeline continued after trailing pipe"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      echo hi |
+        tr a-z A-Z
+
+  - name: "And-and continuation"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      true &&
+        echo yes
+
+  - name: "For loop with do/done on separate lines"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      for i in 1 2 3
+      do
+        echo "item $i"
+      done
+
+  - name: "While loop"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      i=0
+      while [ $i -lt 3 ]
+      do
+        echo "i=$i"
+        i=$((i + 1))
+      done
+
+  - name: "Case statement"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      x=beta
+      case $x in
+        alpha)
+          echo one
+          ;;
+        beta)
+          echo two
+          ;;
+        *)
+          echo other
+          ;;
+      esac
+
+  - name: "Multi-line subshell and command substitution"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      (
+        echo in-subshell
+      )
+      v=$(
+        echo from-cmd-subst
+      )
+      echo "$v"
+
+  - name: "Realistic installer-shaped script"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      set -e
+
+      INSTALL_DIR="./installed"
+
+      log() {
+        echo "[install] $1"
+      }
+
+      detect_platform() {
+        case "$(uname -s)" in
+          Linux*)
+            echo linux
+            ;;
+          Darwin*)
+            echo darwin
+            ;;
+          *)
+            echo unknown
+            ;;
+        esac
+      }
+
+      main() {
+        platform="$(detect_platform)"
+        if [ -z "$platform" ]; then
+          log "could not detect platform"
+          exit 1
+        fi
+
+        mkdir -p "$INSTALL_DIR" &&
+          log "created dir"
+
+        cat >"$INSTALL_DIR/config" <<EOF
+      platform=detected
+      dir=$INSTALL_DIR
+      EOF
+
+        while read -r line; do
+          log "config: $line"
+        done <"$INSTALL_DIR/config"
+
+        log "done"
+      }
+
+      main
+
+  # A stream cut off partway through a construct: everything ahead of the cut
+  # should still run, then the shell should fail. Only the error text differs.
+  - name: "Stream truncated mid-construct"
+    removed_default_args: ["--input-backend=basic"]
+    ignore_stderr: true
+    stdin: |
+      echo start
+      greet() {
+        echo hello
+      }
+      greet
+      if true
+      then
+        echo mid
+
+  # A bad token can't be repaired by anything that follows it, so the shell must
+  # report it rather than accumulate more input -- even when the offending line
+  # ends in a continuation. Only the error text differs from bash.
+  - name: "Syntax error mid-stream"
+    removed_default_args: ["--input-backend=basic"]
+    ignore_stderr: true
+    stdin: |
+      echo before
+      ;;
+      echo after
+
+  - name: "Syntax error mid-stream on a line ending in a continuation"
+    removed_default_args: ["--input-backend=basic"]
+    ignore_stderr: true
+    stdin: |
+      echo before
+      echo ;; \
+      echo after
+
+  # Backslash-newline continuation, which the tokenizer consumes silently at end
+  # of input. Not backend-specific, so the first pair covers both backends.
+
+  - name: "Backslash line continuation (minimal backend)"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      echo a\
+      b
+
+  - name: "Backslash line continuation (basic backend)"
+    stdin: |
+      echo a\
+      b
+
+  - name: "Backslash continuation splitting arguments"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      printf '%s-%s-%s\n' \
+        one \
+        two \
+        three
+
+  # A backslash before a space escapes the space, not the newline, so the first
+  # line is a complete command and must run before the second line fails to
+  # parse. Only the error text differs from bash.
+  - name: "Backslash before trailing whitespace is not a continuation"
+    removed_default_args: ["--input-backend=basic"]
+    ignore_stderr: true
+    stdin: "echo a\\ \n;;\n"
+
+  - name: "Backslash continuation after a comment line"
+    removed_default_args: ["--input-backend=basic"]
+    stdin: |
+      # a comment ending in a backslash\
+      echo a\
+      b


### PR DESCRIPTION
The minimal backend, used for piped/redirected stdin, read one line per command, so every multi-line construct in a piped script failed to parse. Share one completeness check across all three backends, and treat input ending in a backslash-newline continuation as incomplete.

Also guard against a `removed_default_args` entry silently ceasing to match, which would quietly run a case against the wrong configuration.

Based on the approach and testing in #944.
