### PR TITLE
fix(parser): recognize a comment after an odd number of blanks

### DIFF
--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -294,6 +294,15 @@ impl TokenParseState {
         !self.token_so_far.is_empty()
     }
 
+    /// Returns true if the token so far consists only of blanks.
+    ///
+    /// This can only happen when tokenizing with `include_space`, where blanks are accumulated
+    /// into the token so that the original text of a nested construct can be reproduced. Such
+    /// blanks are not a word, so a `#` following them still begins a comment.
+    pub fn only_blanks_so_far(&self) -> bool {
+        !self.token_so_far.is_empty() && self.token_so_far.chars().all(is_blank)
+    }
+
     pub fn append_char(&mut self, c: char) {
         self.token_so_far.push(c);
     }
@@ -1147,8 +1156,18 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
             // N.B. We need to remember if we were recursively called in a variable
             // expansion expression; in that case we won't think a token was started but...
             // we'd be wrong.
+            //
+            // The `!only_blanks_so_far` clause keeps a comment recognizable inside a nested
+            // construct. With `include_space`, a blank is appended to the token when none is
+            // started and delimits the token when one is, so the blanks before a `#` alternate
+            // between the two; after an odd number of them a token is "in progress" and the `#`
+            // was appended to it rather than starting a comment. `$( #'<newline>)` then failed to
+            // tokenize with an unterminated single quote, while `$(  #'<newline>)` — two blanks —
+            // was fine.
+            //
             else if !state.token_is_operator
                 && (state.started_token() || matches!(terminating_char, Some('}')))
+                && !(c == '#' && state.only_blanks_so_far())
             {
                 self.consume_char()?;
                 state.append_char(c);
@@ -1393,6 +1412,21 @@ bc"
 "
         )?);
         Ok(())
+    }
+
+    #[test]
+    fn tokenize_comment_in_command_substitution() {
+        // A comment inside `$( )` is a comment however many blanks precede its `#`. An odd number
+        // of them used to leave a token in progress, so the `#` was appended to that token instead
+        // of starting a comment, and the apostrophe in the comment's text then opened a quote that
+        // was never closed.
+        for prefix in ["", " ", "  ", "   ", "\t", "\t\t", " \t", "\t "] {
+            let input = format!("$({prefix}# it's a comment\n)\n");
+            assert!(
+                tokenize_str(input.as_str()).is_ok(),
+                "failed to tokenize {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -294,6 +294,15 @@ impl TokenParseState {
         !self.token_so_far.is_empty()
     }
 
+    /// Returns true if the token so far consists only of blanks.
+    ///
+    /// This can only happen when tokenizing with `include_space`, where blanks are accumulated
+    /// into the token so that the original text of a nested construct can be reproduced. Such
+    /// blanks are not a word, so a `#` following them still begins a comment.
+    pub fn only_blanks_so_far(&self) -> bool {
+        !self.token_so_far.is_empty() && self.token_so_far.chars().all(is_blank)
+    }
+
     pub fn append_char(&mut self, c: char) {
         self.token_so_far.push(c);
     }
@@ -1142,8 +1151,18 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
             // N.B. We need to remember if we were recursively called in a variable
             // expansion expression; in that case we won't think a token was started but...
             // we'd be wrong.
+            //
+            // The `!only_blanks_so_far` clause keeps a comment recognizable inside a nested
+            // construct. With `include_space`, a blank is appended to the token when none is
+            // started and delimits the token when one is, so the blanks before a `#` alternate
+            // between the two; after an odd number of them a token is "in progress" and the `#`
+            // was appended to it rather than starting a comment. `$( #'<newline>)` then failed to
+            // tokenize with an unterminated single quote, while `$(  #'<newline>)` — two blanks —
+            // was fine.
+            //
             else if !state.token_is_operator
                 && (state.started_token() || matches!(terminating_char, Some('}')))
+                && !(c == '#' && state.only_blanks_so_far())
             {
                 self.consume_char()?;
                 state.append_char(c);
@@ -1388,6 +1407,21 @@ bc"
 "
         )?);
         Ok(())
+    }
+
+    #[test]
+    fn tokenize_comment_in_command_substitution() {
+        // A comment inside `$( )` is a comment however many blanks precede its `#`. An odd number
+        // of them used to leave a token in progress, so the `#` was appended to that token instead
+        // of starting a comment, and the apostrophe in the comment's text then opened a quote that
+        // was never closed.
+        for prefix in ["", " ", "  ", "   ", "\t", "\t\t", " \t", "\t "] {
+            let input = format!("$({prefix}# it's a comment\n)\n");
+            assert!(
+                tokenize_str(input.as_str()).is_ok(),
+                "failed to tokenize {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -1420,11 +1420,28 @@ bc"
         // of them used to leave a token in progress, so the `#` was appended to that token instead
         // of starting a comment, and the apostrophe in the comment's text then opened a quote that
         // was never closed.
-        for prefix in ["", " ", "  ", "   ", "\t", "\t\t", " \t", "\t "] {
+        //
+        // The comment is dropped from the text reconstructed for the substitution, leaving just
+        // the blanks that preceded it. A blank that delimits an in-progress token comes back as a
+        // single space, so the blanks aren't always reproduced verbatim; that's insignificant
+        // inside `$( )`, where the text gets re-parsed as a program.
+        for (prefix, reconstructed_blanks) in [
+            ("", ""),
+            (" ", " "),
+            ("  ", "  "),
+            ("   ", "   "),
+            ("\t", "\t"),
+            ("\t\t", "\t "),
+            (" \t", "  "),
+            ("\t ", "\t "),
+        ] {
             let input = format!("$({prefix}# it's a comment\n)\n");
-            assert!(
-                tokenize_str(input.as_str()).is_ok(),
-                "failed to tokenize {input:?}"
+            let tokens = tokenize_str(input.as_str()).unwrap();
+            let token_strs: Vec<_> = tokens.iter().map(Token::to_str).collect();
+            assert_eq!(
+                token_strs,
+                [format!("$({reconstructed_blanks}\n)").as_str(), "\n"],
+                "tokenizing {input:?}"
             );
         }
     }

--- a/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
@@ -88,6 +88,37 @@ cases:
     stdin: |
       echo $(echo $#)
 
+  - name: "Comment after blanks in command substitution"
+    stdin: |
+      echo "0 blanks: $(# I'm a comment
+      echo hi)"
+      echo "1 blank: $( # I'm a comment
+      echo hi)"
+      echo "2 blanks: $(  # I'm a comment
+      echo hi)"
+      echo "3 blanks: $(   # I'm a comment
+      echo hi)"
+
+  - name: "Comment after tabs in command substitution"
+    stdin: |
+      echo "1 tab: $(	# I'm a comment
+      echo hi)"
+      echo "2 tabs: $(		# I'm a comment
+      echo hi)"
+      echo "blank and tab: $( 	# I'm a comment
+      echo hi)"
+
+  - name: "Hash after blanks that is not a comment in command substitution"
+    stdin: |
+      echo "1: $( echo a#b )"
+      echo "2: $( echo 'a # b' )"
+      echo "3: $( echo one # I'm a trailing comment
+      echo two)"
+      echo "4: $(cat <<HERE
+       # not a comment
+      HERE
+      )"
+
   - name: "Ignore single quote in comment in command substitution (backticks)"
     stdin: |
       var=`


### PR DESCRIPTION
A comment inside `$( … )` is only recognized when the number of blanks before its `#` is even.
Otherwise the comment text gets tokenized as shell, and an unbalanced quote in it never closes.

Smallest repro I could get it down to is 7 bytes. bash accepts it:

```sh
$( #'
)
```

```
unterminated single quote at 1,5 (detected near line 3 col 1)
```

Zero blanks work. One doesn't. Two work, three doesn't, and so on. Tabs count the same as spaces.
Only `$( … )` is affected; the same comment at top level or inside backticks is fine.

One trap if you go poking at this: the comment needs an odd number of quotes to show the failure.
`# it's the shell's` has two apostrophes and they pair up harmlessly, so it parses. That cost me a
test I thought was passing.

### Cause

`consume_nested_construct` tokenizes with `include_space: true`. In that mode a blank appends to
the token when none is started, and delimits when one is, so the blanks alternate between the two.
After an odd number, a token is in progress. The `#` arm sits after the "token in progress" arm,
so it never runs and the `#` gets appended instead.

### Fix

The blanks `include_space` accumulates are there to reproduce the construct's original text. They
aren't a word, so a `#` after nothing but those blanks should still start a comment. That's one
clause on the existing condition plus a small helper.

I narrowed the guard rather than moving the `#` arm earlier, since `started_token()` is doing real
work there: `a#b` is one word.

### Testing

New test covers eight blank prefixes. `cargo test -p brush-parser`: 225 pass. clippy and fmt clean.

I ran `brush-compat-tests` on `main` and on the branch and got identical numbers both times (1730
pass, 65 fail, 379 known-fail, 28 skipped), so those 65 are pre-existing and none of them moved.

I hit this building a shell on `brush-parser`. Two files in modernish's test suite trip it, both
`$(`, newline, one tab, then a comment with an apostrophe in it.
