### PR TITLE
fix(read): skip terminal settings for non-terminal input

### DIFF
--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -566,6 +566,17 @@ impl ReadCommand {
         &self,
         file: &brush_core::openfiles::OpenFile,
     ) -> Result<Option<brush_core::terminal::AutoModeGuard>, brush_core::Error> {
+        // Terminal settings only make sense for terminal input. `AutoModeGuard::new`
+        // keys off the process's standard handles, which may be a console even when
+        // the read input is a pipe/file/redirect (e.g. an agent shell hosted in a
+        // terminal): in that case `apply_settings` would hit `SetConsoleMode` on the
+        // non-console input and fail with ERROR_INVALID_PARAMETER (os error 87),
+        // failing the read entirely. Skip terminal setup for non-terminal input,
+        // matching bash's termios behavior.
+        if !file.is_terminal() {
+            return Ok(None);
+        }
+
         let mode = brush_core::terminal::AutoModeGuard::new(file.to_owned()).ok();
         if let Some(mode) = &mode {
             let config = brush_core::terminal::Settings::builder()
@@ -690,6 +701,48 @@ mod tests {
     use itertools::assert_equal;
 
     use super::*;
+
+    // ==================== setup_terminal_settings tests ====================
+
+    /// Terminal setup must be skipped entirely for non-terminal input (pipes,
+    /// files, redirects). `AutoModeGuard::new` keys off the process's standard
+    /// handles, which may be a console even when the read input is not — running
+    /// `apply_settings` on such input fails with ERROR_INVALID_PARAMETER (os
+    /// error 87) on Windows and fails the whole read.
+    #[test]
+    fn test_setup_terminal_settings_skips_pipe_input() {
+        let (reader, _writer) = std::io::pipe().expect("pipe creation must succeed");
+        let file = brush_core::openfiles::OpenFile::from(reader);
+
+        let command = ReadCommand::try_parse_from(["read"]).expect("parse must succeed");
+        let result = command.setup_terminal_settings(&file);
+
+        assert!(result.is_ok(), "non-terminal input must not error");
+        assert!(
+            result.unwrap().is_none(),
+            "non-terminal input must not install a mode guard"
+        );
+    }
+
+    #[test]
+    fn test_setup_terminal_settings_skips_file_input() {
+        let mut tmp = std::env::temp_dir();
+        tmp.push(format!("read-setup-{}.txt", std::process::id()));
+        std::fs::write(&tmp, "x").expect("write fixture must succeed");
+        let file = brush_core::openfiles::OpenFile::from(
+            std::fs::File::open(&tmp).expect("open fixture must succeed"),
+        );
+        let _ = std::fs::remove_file(&tmp);
+
+        let command = ReadCommand::try_parse_from(["read"]).expect("parse must succeed");
+        let result = command.setup_terminal_settings(&file);
+
+        assert!(result.is_ok(), "file input must not error");
+        assert!(
+            result.unwrap().is_none(),
+            "file input must not install a mode guard"
+        );
+    }
 
     // ==================== split_line_by_ifs tests ====================
 


### PR DESCRIPTION
## Problem

On Windows, `read` fails with `os error 87` (ERROR_INVALID_PARAMETER) whenever the input is a pipe, file, or redirect AND the host process's standard handles are a console. This is the common case for an agent shell hosted in a terminal (e.g. a coding agent running `printf 'x\n' | while read -r line; ...`), where the shell runs in-process in the TUI host.

## Root cause

`setup_terminal_settings` always calls `AutoModeGuard::new(file)` and applies settings. `AutoModeGuard::new`'s `from_term` keys off the process's standard handles (`GetStdHandle`) rather than the `file` argument — so in a terminal-hosted process it succeeds even when the read input is a pipe/file/redirect. `apply_settings` then calls `SetConsoleMode` on the non-console input, which fails with ERROR_INVALID_PARAMETER, and the `?` propagates the failure, failing the whole read.

Subprocesses never hit this because their stdin is a pipe, so `AutoModeGuard::new` fails and the `.ok()` degrades to no-op.

## Fix

Skip terminal-mode setup entirely for non-terminal input (`if !file.is_terminal() { return Ok(None); }`), matching bash's termios behavior (bash only applies terminal settings to terminal input).

## Tests

Two contract tests: pipe input and file input both return `Ok(None)` (no mode guard installed, no error).

Verified on Windows: after this change `printf 'ok\n' | while IFS= read -r x; do echo "$x"; done` works in the terminal-hosted agent shell.