### PR TITLE
chore: upgrade fancy-regex for improvements (+test deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "expectrl"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e0706d01b4f43adaf7e0fb460e07477c36b74ae60fdeb1d045001bd77b4bd1"
+checksum = "9e0df3044b2257277f573d1e40912ebd4d5891f7588640e3125cbbbb24ff7be3"
 dependencies = [
  "conpty",
  "nix 0.26.4",
@@ -1589,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/brush-builtins/Cargo.toml
+++ b/brush-builtins/Cargo.toml
@@ -133,7 +133,7 @@ brush-parser = { version = "^0.4.0", path = "../brush-parser" }
 cfg-if = "1.0.4"
 chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive", "wrap_help"] }
-fancy-regex = "0.18.0"
+fancy-regex = "0.19.0"
 itertools = "0.14.0"
 strum = "0.28.0"
 thiserror = "2.0.18"

--- a/brush-core/Cargo.toml
+++ b/brush-core/Cargo.toml
@@ -31,7 +31,7 @@ cfg-if = "1.0.4"
 chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive", "wrap_help"] }
 color-print = "0.3.7"
-fancy-regex = "0.18.0"
+fancy-regex = "0.19.0"
 futures = "0.3.32"
 inherent = "1.0.13"
 itertools = "0.14.0"

--- a/brush-core/src/expansion.rs
+++ b/brush-core/src/expansion.rs
@@ -1974,9 +1974,10 @@ impl<'a, SE: extensions::ShellExtensions> WordExpander<'a, SE> {
         if let Some(pattern) = pattern {
             if !pattern.is_empty() {
                 let regex = pattern.to_regex(false, false)?;
-                let result = regex.replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_>| {
-                    transform(&caps[0])
-                });
+                let result = regex
+                    .replace_all(s.as_ref(), |caps: &fancy_regex::Captures<'_, str>| {
+                        transform(&caps[0])
+                    });
                 Ok(result.into_owned())
             } else {
                 Ok(transform(s))

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -147,4 +147,4 @@ nix = { version = "0.31.2" }
 # expectrl's pty support (via ptyprocess) is limited to these platforms;
 # the interactive tests that rely on it are gated accordingly.
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd"))'.dev-dependencies]
-expectrl = "0.8.0"
+expectrl = "0.9.0"

--- a/brush-test-harness/Cargo.toml
+++ b/brush-test-harness/Cargo.toml
@@ -54,4 +54,4 @@ cfg_aliases = "0.2.1"
 # pty-based tests are reported as unsupported elsewhere. Keep this list in sync
 # with the `pty` cfg in build.rs (which gates the code using this dependency).
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd"))'.dependencies]
-expectrl = "0.8.0"
+expectrl = "0.9.0"


### PR DESCRIPTION
The test-only dependencies were simple to upgrade; upgrading fancy-regex will allow us to benefit from improvements in that crate, but require some minor changes to compenstate for some API changes.