### PR TITLE
refactor: extract array-kind predicates on ShellValue

### DIFF
--- a/brush-builtins/src/mapfile.rs
+++ b/brush-builtins/src/mapfile.rs
@@ -67,13 +67,7 @@ impl builtins::Command for MapFileCommand {
         }
 
         if let Some((_, var)) = context.shell.env().get(&self.array_var_name) {
-            if matches!(
-                var.value(),
-                variables::ShellValue::AssociativeArray(_)
-                    | variables::ShellValue::Unset(
-                        variables::ShellValueUnsetType::AssociativeArray
-                    )
-            ) {
+            if var.value().is_associative_array() {
                 writeln!(
                     context.stderr(),
                     "{}: {}: not an indexed array",

--- a/brush-builtins/src/unimp.rs
+++ b/brush-builtins/src/unimp.rs
@@ -7,9 +7,6 @@ use clap::Parser;
 pub(crate) struct UnimplementedCommand {
     #[clap(allow_hyphen_values = true)]
     args: Vec<String>,
-
-    #[clap(skip)]
-    declarations: Vec<brush_core::CommandArg>,
 }
 
 impl builtins::Command for UnimplementedCommand {
@@ -25,11 +22,5 @@ impl builtins::Command for UnimplementedCommand {
             self.args.join(" ")
         );
         Ok(ExecutionExitCode::Unimplemented.into())
-    }
-}
-
-impl builtins::DeclarationCommand for UnimplementedCommand {
-    fn set_declarations(&mut self, declarations: Vec<brush_core::CommandArg>) {
-        self.declarations = declarations;
     }
 }

--- a/brush-builtins/src/unset.rs
+++ b/brush-builtins/src/unset.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use clap::Parser;
 
-use brush_core::{ExecutionResult, Shell, ShellValue, builtins, variables::ShellValueUnsetType};
+use brush_core::{ExecutionResult, Shell, builtins};
 
 /// Unset a variable.
 #[derive(Parser)]
@@ -99,15 +99,10 @@ fn unset_array_index(
     index: &str,
 ) -> Result<bool, brush_core::Error> {
     // First check to see if it's an associative array.
-    let is_assoc_array = if let Some((_, var)) = shell.env().get(name) {
-        matches!(
-            var.value(),
-            ShellValue::AssociativeArray(_)
-                | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
-        )
-    } else {
-        false
-    };
+    let is_assoc_array = shell
+        .env()
+        .get(name)
+        .is_some_and(|(_, var)| var.value().is_associative_array());
 
     // Compute which index we should actually use. For indexed arrays, we need to evaluate
     // the index string as an arithmetic expression first.

--- a/brush-core/src/variables.rs
+++ b/brush-core/src/variables.rs
@@ -535,17 +535,10 @@ impl ShellVariable {
 
         let mut result = String::new();
 
-        if matches!(
-            value,
-            ShellValue::IndexedArray(_) | ShellValue::Unset(ShellValueUnsetType::IndexedArray)
-        ) {
+        if value.is_indexed_array() {
             result.push('a');
         }
-        if matches!(
-            value,
-            ShellValue::AssociativeArray(_)
-                | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
-        ) {
+        if value.is_associative_array() {
             result.push('A');
         }
         if matches!(
@@ -719,16 +712,26 @@ pub enum FormatStyle {
 }
 
 impl ShellValue {
-    /// Returns whether or not the value is an array.
-    pub const fn is_array(&self) -> bool {
+    /// Returns whether or not the value is an indexed array, including a declared but unset one.
+    pub const fn is_indexed_array(&self) -> bool {
         matches!(
             self,
-            Self::IndexedArray(_)
-                | Self::AssociativeArray(_)
-                | Self::Unset(
-                    ShellValueUnsetType::IndexedArray | ShellValueUnsetType::AssociativeArray
-                )
+            Self::IndexedArray(_) | Self::Unset(ShellValueUnsetType::IndexedArray)
         )
+    }
+
+    /// Returns whether or not the value is an associative array, including a declared but unset
+    /// one.
+    pub const fn is_associative_array(&self) -> bool {
+        matches!(
+            self,
+            Self::AssociativeArray(_) | Self::Unset(ShellValueUnsetType::AssociativeArray)
+        )
+    }
+
+    /// Returns whether or not the value is an array.
+    pub const fn is_array(&self) -> bool {
+        self.is_indexed_array() || self.is_associative_array()
     }
 
     /// Returns whether or not the value is set.


### PR DESCRIPTION
Add is_indexed_array() and is_associative_array() const helpers on ShellValue, replacing repeated inline matches! patterns across the codebase. Also remove the unused DeclarationCommand impl from UnimplementedCommand.

No behavioral change.