### PR TITLE
refactor: add standalone assignment parsing functions

### DIFF
--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -1401,6 +1401,17 @@ pub enum AssignmentName {
     ArrayElementName(String, String),
 }
 
+impl AssignmentName {
+    /// Returns the base name of the assignment, without any array indexing
+    /// if present.
+    pub fn base_name(&self) -> &str {
+        match self {
+            Self::VariableName(name) => name,
+            Self::ArrayElementName(name, _index) => name,
+        }
+    }
+}
+
 impl Display for AssignmentName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/brush-parser/src/parser/mod.rs
+++ b/brush-parser/src/parser/mod.rs
@@ -235,6 +235,24 @@ pub fn parse_tokens(
     parse_result_to_error(parse_result, tokens)
 }
 
+/// Tokenizes and parses text as a compound assignment value, returning its element words. Returns
+/// `None` if the text is not a well-formed compound value.
+///
+/// # Arguments
+///
+/// * `input` - The text to parse.
+/// * `options` - The options to use when parsing.
+pub(crate) fn parse_compound_assignment_value(
+    input: &str,
+    options: &ParserOptions,
+) -> Option<Vec<String>> {
+    let mut parser = Parser::new(input.as_bytes(), options);
+    let tokens = parser.tokenize().ok()?;
+    let tokens = Tokens { tokens: &tokens };
+    let elements = peg::token_parser::compound_assignment_value(&tokens, options).ok()?;
+    Some(elements.into_iter().cloned().collect())
+}
+
 fn parse_result_to_error<R>(
     parse_result: Result<R, ::peg::error::ParseError<usize>>,
     tokens: &[Token],

--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -661,7 +661,7 @@ peg::parser! {
 
         pub(crate) rule assignment_word() -> (ast::Assignment, ast::Word) =
             non_posix_extensions_enabled() [Token::Word(w, l)] specific_operator("(") elements:array_elements() end:specific_operator(")") {?
-                let mut parsed = word::parse_array_assignment(w.as_str(), elements.as_slice())?;
+                let mut parsed = word::parse_array_assignment(w.as_str(), elements.as_slice(), parser_options)?;
 
                 let mut all_as_word = w.to_owned();
                 all_as_word.push('(');
@@ -678,9 +678,17 @@ peg::parser! {
                 Ok((parsed, ast::Word::with_location(&all_as_word, &loc)))
             } /
             [Token::Word(w, l)] {?
-                let mut parsed = word::parse_assignment_word(w.as_str()).map_err(|_| "not assignment word")?;
+                let mut parsed = word::parse_scalar_assignment(w.as_str(), parser_options).map_err(|_| "not assignment word")?;
                 parsed.loc = l.clone();
                 Ok((parsed, ast::Word::with_location(w, l)))
+            }
+
+        // A standalone compound assignment value, i.e. the `(...)` half of an array assignment.
+        // Used to reinterpret text that only became recognizable as a compound value after
+        // expansion.
+        pub(crate) rule compound_assignment_value() -> Vec<&'input String> =
+            non_posix_extensions_enabled() specific_operator("(") elements:array_elements() specific_operator(")") {
+                elements
             }
 
         rule array_elements() -> Vec<&'input String> =

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -592,41 +592,89 @@ pub fn parse_brace_expansions(
         .map_err(|err| error::WordParseError::BraceExpansion(word.to_owned(), err.into()))
 }
 
-pub(crate) fn parse_assignment_word(
+/// Parses a scalar assignment from a given word.
+///
+/// A parenthesized value is treated as scalar text; see
+/// [`parse_compound_assignment_value`] for reinterpreting such a value as a compound one.
+///
+/// # Arguments
+///
+/// * `word` - The word to parse.
+/// * `options` - The parser options to use.
+pub fn parse_scalar_assignment(
     word: &str,
-) -> Result<ast::Assignment, peg::error::ParseError<peg::str::LineCol>> {
-    expansion_parser::name_equals_scalar_value(word, &ParserOptions::default())
+    options: &ParserOptions,
+) -> Result<ast::Assignment, error::WordParseError> {
+    expansion_parser::name_equals_scalar_value(word, options)
+        .map_err(|err| error::WordParseError::Word(word.to_owned(), err.into()))
 }
 
+/// Parses text as a compound assignment value, returning its optionally-keyed element words.
+/// Returns `None` if the text is not a well-formed compound value.
+///
+/// This exists so that text which only becomes recognizable as a compound value *after* expansion
+/// can be reinterpreted without reconstructing and re-parsing a whole assignment word.
+///
+/// # Arguments
+///
+/// * `value` - The candidate compound value text, including its enclosing parentheses.
+/// * `options` - The parser options to use.
+#[must_use]
+pub fn parse_compound_assignment_value(
+    value: &str,
+    options: &ParserOptions,
+) -> Option<Vec<(Option<ast::Word>, ast::Word)>> {
+    let elements = crate::parser::parse_compound_assignment_value(value, options)?;
+    parse_array_elements(elements.iter(), options).ok()
+}
+
+/// Parses an array assignment from a given word and its array elements.
+///
+/// # Arguments
+///
+/// * `word` - The assignment name and equals sign to parse.
+/// * `elements` - The array element words to parse.
+/// * `options` - The parser options to use.
 pub(crate) fn parse_array_assignment(
     word: &str,
     elements: &[&String],
+    options: &ParserOptions,
 ) -> Result<ast::Assignment, &'static str> {
-    let (assignment_name, append) = expansion_parser::name_equals(word, &ParserOptions::default())
-        .map_err(|_| "not array assignment word")?;
-
-    let elements = elements
-        .iter()
-        .map(|element| expansion_parser::literal_array_element(element, &ParserOptions::default()))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|_| "invalid array element in literal")?;
-
-    let elements_as_words = elements
-        .into_iter()
-        .map(|(key, value)| {
-            (
-                key.map(|k| ast::Word::new(k.as_str())),
-                ast::Word::new(value.as_str()),
-            )
-        })
-        .collect();
+    let (assignment_name, append) =
+        expansion_parser::name_equals(word, options).map_err(|_| "not array assignment word")?;
 
     Ok(ast::Assignment {
         name: assignment_name,
-        value: ast::AssignmentValue::Array(elements_as_words),
+        value: ast::AssignmentValue::Array(parse_array_elements(
+            elements.iter().copied(),
+            options,
+        )?),
         append,
         loc: SourceSpan::default(),
     })
+}
+
+/// Parses literal array element text into optionally-keyed element words.
+///
+/// # Arguments
+///
+/// * `elements` - The array element texts to parse.
+/// * `options` - The parser options to use.
+fn parse_array_elements<'a>(
+    elements: impl IntoIterator<Item = &'a String>,
+    options: &ParserOptions,
+) -> Result<Vec<(Option<ast::Word>, ast::Word)>, &'static str> {
+    elements
+        .into_iter()
+        .map(|element| {
+            let (key, value) = expansion_parser::literal_array_element(element, options)
+                .map_err(|_| "invalid array element in literal")?;
+            Ok((
+                key.map(|key| ast::Word::new(key.as_str())),
+                ast::Word::new(value.as_str()),
+            ))
+        })
+        .collect()
 }
 
 peg::parser! {
@@ -1377,12 +1425,39 @@ mod tests {
     }
 
     #[test]
-    fn parse_assignment_word() -> Result<()> {
-        super::parse_assignment_word("x=3")?;
-        super::parse_assignment_word("x=")?;
-        super::parse_assignment_word("x[3]=a")?;
-        super::parse_assignment_word("x[${y[3]}]=a")?;
-        super::parse_assignment_word("x[y[3]]=a")?;
+    fn test_scalar_assignment_parsing() -> Result<()> {
+        let options = ParserOptions::default();
+
+        super::parse_scalar_assignment("x=3", &options)?;
+        super::parse_scalar_assignment("x=", &options)?;
+        super::parse_scalar_assignment("x[3]=a", &options)?;
+        super::parse_scalar_assignment("x[${y[3]}]=a", &options)?;
+        super::parse_scalar_assignment("x[y[3]]=a", &options)?;
         Ok(())
+    }
+
+    #[test]
+    fn parse_compound_assignment_value() {
+        let options = ParserOptions::default();
+        let parse = |value| super::parse_compound_assignment_value(value, &options);
+
+        assert_matches!(parse("()").as_deref(), Some([]));
+
+        assert_matches!(parse("(1 2)").as_deref(), Some([(None, first), (None, second)])
+            if first.value == "1" && second.value == "2");
+
+        assert_matches!(
+            parse(r#"([key]=value "other one")"#).as_deref(),
+            Some([(Some(key), value), (None, other)])
+                if key.value == "key"
+                    && value.value == "value"
+                    && other.value == r#""other one""#);
+
+        // Text that is not exclusively a compound value must not be accepted; otherwise trailing
+        // shell syntax hidden in an expanded value would be silently dropped.
+        assert!(parse(r#"(x); printf "INJECTED\n"; #"#).is_none());
+        assert!(parse("(unterminated").is_none());
+        assert!(parse("plain text").is_none());
+        assert!(parse("").is_none());
     }
 }


### PR DESCRIPTION
Rename parse_assignment_word to parse_scalar_assignment (now taking ParserOptions), add parse_compound_assignment_value for reinterpreting expanded text as compound array values, and extract parse_array_elements as a shared helper. Add AssignmentName::base_name() to access the variable name without subscripts.

No behavioral change; new functions are not yet called outside the parser.