### PR TITLE
refactor: remove cached macro usages from parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,6 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "bon",
- "cached",
  "criterion",
  "getrandom 0.4.3",
  "indenter",

--- a/brush-core/src/prompt.rs
+++ b/brush-core/src/prompt.rs
@@ -58,7 +58,6 @@ pub(crate) async fn expand_prompt(
     Ok(formatted_prompt)
 }
 
-#[cached::macros::cached(max_size = 64, key = "String", convert = r#"{ spec.to_owned() }"#)]
 fn parse_prompt(
     spec: &str,
 ) -> Result<Vec<brush_parser::prompt::PromptPiece>, brush_parser::WordParseError> {

--- a/brush-core/src/shell/parsing.rs
+++ b/brush-core/src/shell/parsing.rs
@@ -45,11 +45,6 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
     }
 }
 
-#[cached::macros::cached(
-    max_size = 64,
-    key = "(String, brush_parser::ParserOptions)",
-    convert = r#"{ (s.to_owned(), parser_options.to_owned()) }"#
-)]
 fn parse_string_impl(
     s: &str,
     parser_options: &brush_parser::ParserOptions,

--- a/brush-parser/Cargo.toml
+++ b/brush-parser/Cargo.toml
@@ -27,7 +27,6 @@ winnow-parser = ["dep:winnow"]
 [dependencies]
 arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
 bon = "3.9.1"
-cached = "2.0.2"
 indenter = "0.3.4"
 miette = { version = "7.6.0", optional = true, default-features = false, features = [
     "derive",

--- a/brush-parser/src/arithmetic.rs
+++ b/brush-parser/src/arithmetic.rs
@@ -9,11 +9,6 @@ use crate::error;
 ///
 /// * `input` - The arithmetic expression to parse, in string form.
 pub fn parse(input: &str) -> Result<ast::ArithmeticExpr, error::WordParseError> {
-    cacheable_parse(input)
-}
-
-#[cached::macros::cached(max_size = 64, key = "String", convert = r#"{ input.to_owned() }"#)]
-fn cacheable_parse(input: &str) -> Result<ast::ArithmeticExpr, error::WordParseError> {
     tracing::debug!(target: "arithmetic", "parsing arithmetic expression: '{input}'");
     arithmetic::full_expression(input)
         .map_err(|e| error::WordParseError::ArithmeticExpression(e.into()))

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -491,19 +491,6 @@ pub fn tokenize_str_with_options(
     input: &str,
     options: &TokenizerOptions,
 ) -> Result<Vec<Token>, TokenizerError> {
-    uncached_tokenize_string(input, options)
-}
-
-#[cached::macros::cached(
-    name = "TOKENIZE_CACHE",
-    max_size = 64,
-    key = "(String, TokenizerOptions)",
-    convert = r#"{ (input.to_owned(), options.to_owned()) }"#
-)]
-fn uncached_tokenize_string(
-    input: &str,
-    options: &TokenizerOptions,
-) -> Result<Vec<Token>, TokenizerError> {
     uncached_tokenize_str(input, options)
 }
 

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -528,18 +528,6 @@ pub fn parse(
     word: &str,
     options: &ParserOptions,
 ) -> Result<Vec<WordPieceWithSource>, error::WordParseError> {
-    cacheable_parse(word, options)
-}
-
-#[cached::macros::cached(
-    max_size = 64,
-    key = "(String, ParserOptions)",
-    convert = r#"{ (word.to_owned(), options.to_owned()) }"#
-)]
-fn cacheable_parse(
-    word: &str,
-    options: &ParserOptions,
-) -> Result<Vec<WordPieceWithSource>, error::WordParseError> {
     tracing::debug!(target: "expansion", "Parsing word '{}'", word);
 
     let pieces = expansion_parser::unexpanded_word(word, options)

--- a/brush-shell/benches/shell.rs
+++ b/brush-shell/benches/shell.rs
@@ -49,6 +49,67 @@ mod unix {
         let _ = shell.eval_arithmetic(&parsed_expr).unwrap();
     }
 
+    /// A realistic script exercising a mixed set of shell constructs.
+    const MIXED_SCRIPT: &str = r#"
+declare x=10
+x=$((x * 2 + 5))
+y=${x:-0}
+name="brush"
+echo "$name-$y" > /dev/null
+printf '%s\n' "$y" > /dev/null
+acc=0
+for i in 1 2 3 4 5; do
+    acc=$((acc + i))
+done
+n=0
+while [ "$n" -lt 10 ]; do
+    n=$((n + 1))
+done
+if [ "$y" -gt 20 ]; then
+    result="large"
+elif [ "$y" -gt 10 ]; then
+    result="medium"
+else
+    result="small"
+fi
+case "$result" in
+    large) echo big ;;
+    small) echo little ;;
+    *) echo mid ;;
+esac > /dev/null
+greet() {
+    echo "hello $1"
+}
+greet world > /dev/null
+out=$(echo nested)
+arr=(one two three)
+echo "${arr[1]}" > /dev/null
+set -- alpha beta gamma
+[ $# -eq 3 ]
+[ -n "$y" ] && echo nonempty > /dev/null
+[ -z "" ] || echo fallback > /dev/null
+command -v echo > /dev/null
+read -r line < /dev/null
+echo done
+"#;
+
+    /// A pool of distinct commands, sized so that it exceeds the 64-entry parse
+    /// cache and the cache cannot serve every command.
+    fn mixed_command_pool() -> Vec<String> {
+        let mut pool = Vec::with_capacity(128);
+        for i in 0..128 {
+            match i % 6 {
+                0 => pool.push(format!("echo cmd_{i} > /dev/null")),
+                1 => pool.push(format!("n_{i}=$(({i} * 2))")),
+                2 => pool.push(format!("echo ${{n_{i}:-{i}}} > /dev/null")),
+                3 => pool.push(format!("[ {i} -gt 0 ]")),
+                4 => pool.push(format!("printf '%s\\n' {i} > /dev/null")),
+                _ => pool.push(format!("x_{i}={i}")),
+            }
+        }
+        pool
+    }
+
     /// This function defines core shell benchmarks.
     pub(crate) fn criterion_benchmark(c: &mut Criterion) {
         // Construct a runtime for us to run async code on.
@@ -152,6 +213,34 @@ mod unix {
                 || shell.clone(),
                 |s| {
                     rt.block_on(run_one_command(s, "for ((i = 0; i < 10; i++)); do :; done"));
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        // Benchmark: running a realistic script with a mixed set of commands.
+        let shell = rt.block_on(instantiate_shell());
+        c.bench_function("run_mixed_script", |b| {
+            b.iter_batched_ref(
+                || shell.clone(),
+                |s| {
+                    rt.block_on(run_one_command(s, MIXED_SCRIPT));
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        // Benchmark: running a mixed set of distinct commands one at a time.
+        // The pool exceeds the 64-entry parse cache, so most commands miss.
+        let shell = rt.block_on(instantiate_shell());
+        let mixed_commands = mixed_command_pool();
+        c.bench_function("run_mixed_commands", |b| {
+            b.iter_batched_ref(
+                || shell.clone(),
+                |s| {
+                    for command in &mixed_commands {
+                        rt.block_on(run_one_command(s, command));
+                    }
                 },
                 criterion::BatchSize::SmallInput,
             );


### PR DESCRIPTION
## Summary

Drop the `#[cached(...)]` attribute invocations in word, tokenizer, arithmetic, prompt, and shell parsing. Where a public function delegated to a private cached wrapper, the wrapper is inlined into the public function. The now-unused `cached` dependency is removed from `brush-parser`; `brush-core` keeps it because `brush-core/src/regex.rs` still uses `cached::LruCache` directly (not the macro).

## Motivation

This is an initial experiment to establish a baseline for benchmarking. It removes the `cached` crate macro usage so we can measure the cost/benefit of the caching before deciding how to replace or tune it.

## Changes

- `brush-parser/src/word.rs` — inline `cacheable_parse` into `parse`
- `brush-parser/src/tokenizer.rs` — drop the `uncached_tokenize_string` wrapper; `tokenize_str_with_options` calls `uncached_tokenize_str` directly
- `brush-parser/src/arithmetic.rs` — inline `cacheable_parse` into `parse`
- `brush-core/src/prompt.rs` — drop attribute on `parse_prompt`
- `brush-core/src/shell/parsing.rs` — drop attribute on `parse_string_impl`
- `brush-parser/Cargo.toml` + `Cargo.lock` — remove `cached` dependency

## Testing

- `cargo clippy --package brush-parser --package brush-core` passes
- `cargo test --package brush-parser --package brush-core` passes

Assisted-by: opencode:deepseek-v4-flash-free