### PR TITLE
fix(trap): report signals ignored on shell entry in `trap -p`

### DIFF
--- a/brush-builtins/src/trap.rs
+++ b/brush-builtins/src/trap.rs
@@ -71,6 +71,23 @@ impl TrapCommand {
         for (signal, _) in context.shell.traps().iter_handlers() {
             Self::display_handlers_for(context, signal)?;
         }
+
+        // Report any signals that were ignored when the shell started (e.g.,
+        // `SIGRTMIN` in some environments), mirroring bash's `trap -p` output.
+        // Registered handlers take precedence and are displayed above.
+        for signal_number in context.shell.traps().iter_signals_ignored_on_entry() {
+            let has_handler = TrapSignal::try_from(signal_number)
+                .ok()
+                .is_some_and(|signal| context.shell.traps().get_handler(signal).is_some());
+            if !has_handler {
+                writeln!(
+                    context.stdout(),
+                    "trap -- '' {}",
+                    brush_core::traps::signal_name_for_number(signal_number)
+                )?;
+            }
+        }
+
         Ok(())
     }
 
@@ -84,6 +101,18 @@ impl TrapCommand {
                 "trap -- '{}' {signal_type}",
                 handler.command
             )?;
+        } else if let Ok(signal_number) = i32::try_from(signal_type) {
+            if context
+                .shell
+                .traps()
+                .is_signal_ignored_on_entry(signal_number)
+            {
+                writeln!(
+                    context.stdout(),
+                    "trap -- '' {}",
+                    brush_core::traps::signal_name_for_number(signal_number)
+                )?;
+            }
         }
         Ok(())
     }

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -230,6 +230,12 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
         // Add in any open files provided.
         shell.open_files.update_from(options.fds.into_iter());
 
+        // Record any signals that were ignored when the shell started so that
+        // `trap -p` can report them (mirroring bash).
+        shell
+            .traps
+            .set_signals_ignored_on_entry(crate::sys::signal::ignored_signals_on_entry());
+
         // TODO(patterns): Without this a script that sets extglob will fail because we
         // parse the entire script with the same settings.
         shell.options.extended_globbing = true;

--- a/brush-core/src/sys/stubs/signal.rs
+++ b/brush-core/src/sys/stubs/signal.rs
@@ -32,6 +32,15 @@ impl TryFrom<i32> for Signal {
     }
 }
 
+/// Returns the numbers of all signals that currently have a `SIG_IGN`
+/// disposition.
+///
+/// This is a stub implementation that returns no signals, as signals are not
+/// supported on this platform.
+pub fn ignored_signals_on_entry() -> Vec<i32> {
+    Vec::new()
+}
+
 pub(crate) fn continue_process(_pid: sys::process::ProcessId) -> Result<(), error::Error> {
     Err(error::ErrorKind::NotSupportedOnThisPlatform("continuing process").into())
 }

--- a/brush-core/src/sys/unix/signal.rs
+++ b/brush-core/src/sys/unix/signal.rs
@@ -4,6 +4,58 @@ use crate::{error, sys, traps};
 
 pub(crate) use nix::sys::signal::Signal;
 
+/// Returns the numbers of all signals that currently have a `SIG_IGN`
+/// disposition.
+///
+/// This is used to mirror bash's behavior of reporting signals that were
+/// ignored when the shell started (e.g., `SIGRTMIN` in some environments) via
+/// `trap -p`.
+pub fn ignored_signals_on_entry() -> Vec<i32> {
+    let mut ignored = Vec::new();
+
+    let mut consider = |n: i32| {
+        if signal_is_ignored(n) {
+            ignored.push(n);
+        }
+    };
+
+    for signal in Signal::iterator() {
+        consider(signal as i32);
+    }
+
+    // Real-time signals (e.g., `SIGRTMIN`) aren't part of the `Signal` enum,
+    // so query them separately where they're supported.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        for n in nix::libc::SIGRTMIN()..=nix::libc::SIGRTMAX() {
+            consider(n);
+        }
+    }
+
+    // The Rust runtime always sets SIGPIPE to `SIG_IGN` at startup, so it does
+    // not reflect the disposition inherited from the parent process. bash (a C
+    // program) starts with `SIGPIPE` at its inherited disposition (typically
+    // `SIG_DFL`) and so does not report it. Skip `SIGPIPE` to match bash.
+    ignored.retain(|&n| n != nix::libc::SIGPIPE);
+
+    ignored
+}
+
+/// Returns whether the given signal number currently has a `SIG_IGN`
+/// disposition.
+fn signal_is_ignored(signal_number: i32) -> bool {
+    // SAFETY: `sigaction` is a plain integer-initialized struct; zeroing it
+    // produces a valid value to receive the current action.
+    let mut old_action: nix::libc::sigaction = unsafe { std::mem::zeroed() };
+
+    // SAFETY: Querying the current action (by passing a null new-action
+    // pointer) is safe and does not modify any signal handler state.
+    let result =
+        unsafe { nix::libc::sigaction(signal_number, std::ptr::null(), &raw mut old_action) };
+
+    result == 0 && old_action.sa_sigaction == nix::libc::SIG_IGN
+}
+
 pub(crate) fn continue_process(pid: sys::process::ProcessId) -> Result<(), error::Error> {
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), nix::sys::signal::SIGCONT)
         .map_err(|_errno| error::ErrorKind::FailedToSendSignal)?;

--- a/brush-core/src/traps.rs
+++ b/brush-core/src/traps.rs
@@ -129,7 +129,7 @@ fn real_time_signal_name(n: i32) -> Option<String> {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
-fn real_time_signal_name(_n: i32) -> Option<String> {
+const fn real_time_signal_name(_n: i32) -> Option<String> {
     None
 }
 
@@ -310,8 +310,14 @@ mod tests {
     #[test]
     fn test_signal_name_for_number() {
         assert_eq!(signal_name_for_number(0), "EXIT");
-        assert_eq!(signal_name_for_number(1), "SIGHUP");
-        assert_eq!(signal_name_for_number(13), "SIGPIPE");
+
+        // Only platforms with a real `Signal` enum can map signal numbers to
+        // names; the stubbed platforms (e.g., Windows) cannot.
+        #[cfg(unix)]
+        {
+            assert_eq!(signal_name_for_number(1), "SIGHUP");
+            assert_eq!(signal_name_for_number(13), "SIGPIPE");
+        }
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {

--- a/brush-core/src/traps.rs
+++ b/brush-core/src/traps.rs
@@ -92,6 +92,47 @@ pub fn format_signals(
     Ok(())
 }
 
+/// Returns the name bash uses for the given signal number, including
+/// real-time signals like `SIGRTMIN`.
+pub fn signal_name_for_number(n: i32) -> String {
+    if let Ok(signal) = TrapSignal::try_from(n) {
+        return signal.as_str().to_owned();
+    }
+    real_time_signal_name(n).unwrap_or_else(|| n.to_string())
+}
+
+/// Computes the name bash uses for a real-time signal (e.g., `SIGRTMIN`,
+/// `SIGRTMIN+1`, `SIGRTMAX-1`).
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn real_time_signal_name(n: i32) -> Option<String> {
+    let rtmin = nix::libc::SIGRTMIN();
+    let rtmax = nix::libc::SIGRTMAX();
+    if n < rtmin || n > rtmax {
+        return None;
+    }
+    let rtcnt = (rtmax - rtmin) / 2;
+    if n - rtmin <= rtcnt {
+        let offset = n - rtmin;
+        if offset == 0 {
+            Some("SIGRTMIN".to_owned())
+        } else {
+            Some(format!("SIGRTMIN+{offset}"))
+        }
+    } else {
+        let offset = rtmax - n;
+        if offset == 0 {
+            Some("SIGRTMAX".to_owned())
+        } else {
+            Some(format!("SIGRTMAX-{offset}"))
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn real_time_signal_name(_n: i32) -> Option<String> {
+    None
+}
+
 // implement s.parse::<TrapSignal>()
 impl FromStr for TrapSignal {
     type Err = error::Error;
@@ -178,6 +219,12 @@ pub struct TrapHandler {
 pub struct TrapHandlerConfig {
     /// Registered handlers for traps; maps signal type to command.
     handlers: HashMap<TrapSignal, TrapHandler>,
+    /// Signal numbers that had a `SIG_IGN` disposition when the shell started.
+    ///
+    /// These are reported by `trap -p` the same way bash reports signals that
+    /// were ignored on entry.
+    #[cfg_attr(feature = "serde", serde(default))]
+    signals_ignored_on_entry: Vec<i32>,
 }
 
 impl TrapHandlerConfig {
@@ -186,6 +233,28 @@ impl TrapHandlerConfig {
         self.handlers
             .iter()
             .map(|(signal, handler)| (*signal, handler))
+    }
+
+    /// Sets the signal numbers that were ignored (had a `SIG_IGN` disposition)
+    /// when the shell started.
+    ///
+    /// # Arguments
+    ///
+    /// * `signals` - The signal numbers that were ignored on shell entry.
+    pub fn set_signals_ignored_on_entry(&mut self, signals: Vec<i32>) {
+        self.signals_ignored_on_entry = signals;
+    }
+
+    /// Iterates over the signal numbers that were ignored when the shell
+    /// started.
+    pub fn iter_signals_ignored_on_entry(&self) -> impl Iterator<Item = i32> + '_ {
+        self.signals_ignored_on_entry.iter().copied()
+    }
+
+    /// Returns whether the given signal number was ignored when the shell
+    /// started.
+    pub fn is_signal_ignored_on_entry(&self, signal_number: i32) -> bool {
+        self.signals_ignored_on_entry.contains(&signal_number)
     }
 
     /// Tries to find the handler associated with the given signal.
@@ -231,5 +300,33 @@ impl TrapHandlerConfig {
     /// * `signal_type` - The type of signal to remove handlers for.
     pub fn remove_handlers(&mut self, signal_type: TrapSignal) {
         self.handlers.remove(&signal_type);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signal_name_for_number() {
+        assert_eq!(signal_name_for_number(0), "EXIT");
+        assert_eq!(signal_name_for_number(1), "SIGHUP");
+        assert_eq!(signal_name_for_number(13), "SIGPIPE");
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            let rtmin = nix::libc::SIGRTMIN();
+            let rtmax = nix::libc::SIGRTMAX();
+            let rtcnt = (rtmax - rtmin) / 2;
+
+            assert_eq!(signal_name_for_number(rtmin), "SIGRTMIN");
+            assert_eq!(signal_name_for_number(rtmin + 1), "SIGRTMIN+1");
+            assert_eq!(
+                signal_name_for_number(rtmin + rtcnt),
+                format!("SIGRTMIN+{rtcnt}")
+            );
+            assert_eq!(signal_name_for_number(rtmax), "SIGRTMAX");
+            assert_eq!(signal_name_for_number(rtmax - 1), "SIGRTMAX-1");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Bash reports signals that were ignored (`SIG_IGN` disposition) when the shell started — e.g. `trap -- '' SIGRTMIN` — via `trap -p`. Brush currently only prints explicitly registered handlers, so environments that ignore a signal on entry (like the GitHub Actions runner ignoring `SIGRTMIN`) produce a `trap -p` diff against bash.

This PR makes brush capture the ignored-on-entry signals at shell creation and report them in `trap -p`, matching bash.

## Changes

- `brush-core/src/sys/unix/signal.rs`: new `ignored_signals_on_entry()` queries each signal's disposition via `sigaction`, including real-time signals (`SIGRTMIN`..`SIGRTMAX`) on Linux/Android.
  - `SIGPIPE` is excluded: the Rust runtime always sets it to `SIG_IGN` at startup for every Rust program, which does not reflect the parent's disposition, while bash (a C program) starts with `SIG_DFL` in comparable spawn scenarios.
- `brush-core/src/sys/stubs/signal.rs`: stub returns an empty set.
- `brush-core/src/traps.rs`: `TrapHandlerConfig` stores the ignored-on-entry signal numbers; new `signal_name_for_number()` names signals the way bash does, including real-time naming (`SIGRTMIN`, `SIGRTMIN+1`, `SIGRTMAX-1`, …).
- `brush-core/src/shell.rs`: captures ignored-on-entry signals in `Shell::new`.
- `brush-builtins/src/trap.rs`: `trap -p` and `trap -p <sig>` report ignored-on-entry signals as `trap -- '' <SIG>`.

## Validation

- Full compat suite run under a parent that ignores `SIGRTMIN` (replicating the CI environment): 2174 test cases, 0 failed (the previously-failing `trap -p - with no args shows all traps` case now passes).
- `cargo clippy` and `cargo fmt --check` clean; brush-core unit tests pass.

Fixes the CI failure seen on the OS-target test jobs in e.g. #1267.