### PR TITLE
fix(parser): stop the tokenizer hanging and overflowing on hostile input

### DIFF
--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -137,6 +137,10 @@ pub enum TokenizerError {
     #[error("unterminated here document sequence; tag(s) [{0}] found at: [{1}]")]
     UnterminatedHereDocuments(String, String),
 
+    /// Nested expansions were encountered more deeply than the tokenizer supports.
+    #[error("expansions nested too deeply (limit: {0})")]
+    ExpansionNestingTooDeep(u32),
+
     /// An I/O error occurred while reading from the input stream.
     #[error("failed to read input")]
     ReadError(#[from] std::io::Error),
@@ -242,11 +246,24 @@ impl Default for TokenizerOptions {
     }
 }
 
+/// Maximum depth of nested expansions -- `$(...)`, `$[...]` and friends -- that
+/// the tokenizer will descend into.
+///
+/// `consume_nested_construct` and `next_token_until` are mutually recursive, and
+/// the input alone decides how deep that goes, so without a bound a sufficiently
+/// nested command line overflows the stack and aborts the process. The limit is
+/// far above any plausible real script while staying well inside even a small
+/// (2 MB) thread stack: an unoptimized build uses roughly 8 KB of stack per
+/// level, so this bounds the recursion to about half a megabyte.
+const MAX_EXPANSION_NESTING: u32 = 64;
+
 /// A tokenizer for shell scripts.
 pub(crate) struct Tokenizer<'a, R: ?Sized + std::io::BufRead> {
     char_reader: std::iter::Peekable<utf8_chars::Chars<'a, R>>,
     cross_state: CrossTokenParseState,
     options: TokenizerOptions,
+    /// Current depth of nested expansion consumption; see [`MAX_EXPANSION_NESTING`].
+    expansion_depth: u32,
 }
 
 /// Encapsulates the current token parsing state.
@@ -553,6 +570,7 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
                 queued_tokens: vec![],
                 arithmetic_expansion: false,
             },
+            expansion_depth: 0,
         }
     }
 
@@ -611,6 +629,32 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
     ///   `[`).
     /// * `initial_nesting` - The initial nesting count (e.g., 2 for `$((`, 1 for `$[`).
     fn consume_nested_construct(
+        &mut self,
+        state: &mut TokenParseState,
+        terminating_char: char,
+        nesting_open: &str,
+        nesting_count: u32,
+    ) -> Result<(), TokenizerError> {
+        // This function and `next_token_until` are mutually recursive, driven by
+        // how deeply the *input* nests expansions; bound it so hostile or merely
+        // pathological input cannot overflow the stack.
+        if self.expansion_depth >= MAX_EXPANSION_NESTING {
+            return Err(TokenizerError::ExpansionNestingTooDeep(
+                MAX_EXPANSION_NESTING,
+            ));
+        }
+        self.expansion_depth += 1;
+        let result = self.consume_nested_construct_inner(
+            state,
+            terminating_char,
+            nesting_open,
+            nesting_count,
+        );
+        self.expansion_depth -= 1;
+        result
+    }
+
+    fn consume_nested_construct_inner(
         &mut self,
         state: &mut TokenParseState,
         terminating_char: char,
@@ -736,7 +780,16 @@ impl<'a, R: ?Sized + std::io::BufRead> Tokenizer<'a, R> {
 
                 // Verify we're not in a here document.
                 if !matches!(self.cross_state.here_state, HereState::None) {
-                    if self.remove_here_end_tag(&mut state, &mut result, false)? {
+                    // Only look for a here-document *end* tag if we are actually
+                    // inside a here-document body. In any other here state the
+                    // body never started, so there is no end tag to find; asking
+                    // anyway can spuriously succeed against the empty current
+                    // token, and because that path only queues a token onto the
+                    // pending here tag it makes no progress -- leaving this loop
+                    // spinning forever and allocating on every pass.
+                    if matches!(self.cross_state.here_state, HereState::InHereDocs)
+                        && self.remove_here_end_tag(&mut state, &mut result, false)?
+                    {
                         // If we hit end tag without a trailing newline, try to get next token.
                         continue;
                     }
@@ -1487,6 +1540,47 @@ SOMETHING
 ",
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn tokenize_unterminated_here_tag_with_unterminated_expansion() {
+        // Regression: an unterminated here tag whose text contains an
+        // unterminated expansion used to spin forever at end-of-input, growing
+        // the pending-token list on every pass until the process was killed.
+        // Two trailing blanks were needed to reach the bad state; one was fine.
+        for input in [
+            "<<E$[\t\t",
+            "<<E$[\t ",
+            "<<E$[ \t",
+            "<<-E$[\t\t",
+            "<<E$(\t\t",
+            "<<E$((\t\t",
+            "<<IFSdountil\"$[\t\t",
+        ] {
+            assert!(
+                tokenize_str(input).is_err(),
+                "expected an error for {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tokenize_deeply_nested_expansions_is_bounded() {
+        // Regression: `consume_nested_construct` and `next_token_until` are
+        // mutually recursive over input nesting, so this used to overflow the
+        // stack and abort the process instead of returning an error.
+        let input = std::format!("echo {}x{}", "$(".repeat(10_000), ")".repeat(10_000));
+        assert!(matches!(
+            tokenize_str(input.as_str()),
+            Err(TokenizerError::ExpansionNestingTooDeep(_))
+        ));
+    }
+
+    #[test]
+    fn tokenize_nesting_within_limit_still_works() {
+        let depth = 32;
+        let input = std::format!("echo {}x{}", "$(".repeat(depth), ")".repeat(depth));
+        assert!(tokenize_str(input.as_str()).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Two ways a short, malformed command line could take the process down rather than
return an error. Both are in the tokenizer, both are reachable from a single
string, and neither depends on anything unusual about the environment.

I found these while evaluating `brush-parser` for a tool that parses command
lines it did not write, so untrusted input on a deadline is the case I care
about. They will matter less for interactive use, where you are already running
the shell, but they are cheap to fix either way.

## 1. Unterminated here tag with an unterminated expansion hangs and allocates forever

```console
$ printf '<<E$[\t\t' | your-parser-harness
```

Seven bytes. Before this change that reaches roughly 10 GB resident within
seconds on my machine and never returns; I only ever saw it end by being killed.

`next_token_until` looks for a here-document *end* tag whenever the here state
is anything other than `None`. In `NextLineIsHereDoc` the body has not started,
so there is no end tag to find, but `remove_here_end_tag` still succeeds against
the empty current token. That path goes to the `delimit_current_token` branch
that only pushes onto `pending_tokens_after` and returns `Ok(None)`, so no token
is produced, no here tag is consumed, and the state is exactly what it was. The
loop goes round again and allocates again.

`consume_nested_construct` then makes it unbounded rather than merely stuck,
because it accumulates each of those here-document tokens into
`pending_here_doc_tokens`.

The fix only attempts the end-tag lookup while we are actually inside a
here-document body. The input above now reports an unterminated here document.

For what it is worth, `bash -n` also rejects it:

```console
$ printf '<<E$[\t\t' > t.sh && bash -n t.sh
t.sh: line 1: unexpected EOF while looking for matching `]'
t.sh: line 2: syntax error: unexpected end of file
```

Variants that hit the same path: `$[`, `$(` and `$((` as the unterminated
expansion, `<<-` as well as `<<`. Curiously it needs exactly two trailing blanks;
one is fine and so are three, which is what made it look so arbitrary before the
cause was clear.

## 2. Nested expansions recurse without bound and abort on stack overflow

```console
$ printf 'echo %s%s' "$(printf '$(%.0s' {1..8000})" "$(printf ')%.0s' {1..8000})" | your-parser-harness
```

`consume_nested_construct` and `next_token_until` are mutually recursive, and the
input alone decides how deep that goes. On my machine it aborts somewhere between
6500 and 7000 levels on an 8 MB main thread, but under 2000 on a 2 MB one, which
is a command line of about 4 KB. Where the parse happens changes the threshold by
roughly 4x, which is worth knowing if a caller parses on a worker thread.

This adds a depth bound and a `TokenizerError::ExpansionNestingTooDeep` rather
than letting it run into the guard page. I picked the limit by measurement rather
than taste: an unoptimized build uses roughly 8 KB of stack per level, so 64
levels stays around half a megabyte and is comfortable even on a small thread
stack. My first attempt at 256 still overflowed a 2 MB debug test thread, which
is how I arrived at the number.

If you would rather have this configurable through `TokenizerOptions`, or set to
a different value, say the word and I will rework it.

## Not the same as #948

Worth stating explicitly since the symptom is identical. #948
(`nproc(){ nproc; }` then `echo $(nproc)`) is runtime recursion through a
self-referencing function during expansion, and it still reproduces with this
change applied. It is a different code path and this PR does not claim to fix it.

## Testing

- `cargo test -p brush-parser`: 227 passed, 0 failed. That is the existing 224
  plus 3 added here.
- `cargo clippy -p brush-parser --all-targets`: clean under the crate's existing
  lint configuration.
- `cargo test -p brush-shell --test brush-compat-tests`: 1388 succeeded, 405
  failed, 366 known to fail, 43 skipped, which is byte for byte what a pristine
  checkout produces on the same machine. The here-document change is the risky
  one, so I ran that baseline specifically to show it moves nothing.
- A structured fuzzer over shell metacharacters, 500,000 iterations, found the
  first of these bugs originally and reports no hangs or panics afterwards.

Added tests cover the hanging inputs, the depth bound firing, and nesting within
the limit still tokenizing normally.

Assisted-by: Claude Opus 5 (Claude Code)
