### PR TITLE
fix(parser): decline out-of-range numeric values instead of unwrapping

### DIFF
--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -707,9 +707,13 @@ peg::parser! {
             [Token::Word(w, num_loc) if w.chars().all(|c: char| c.is_ascii_digit())]
             &([Token::Operator(o, redir_loc) if
                     o.starts_with(['<', '>']) &&
-                    locations_are_contiguous(num_loc, redir_loc)]) {
+                    locations_are_contiguous(num_loc, redir_loc)]) {?
 
-                w.parse().unwrap()
+                // A run of ASCII digits still need not fit in an `IoFd`; e.g.
+                // `echo 99999999999999999999>&1` overflows. Decline the rule
+                // instead of unwrapping, so the token is reconsidered as an
+                // ordinary word rather than panicking the parser.
+                w.parse().map_err(|_| "io number out of range")
             }
 
         //

--- a/brush-parser/src/parser/tests/redirections.rs
+++ b/brush-parser/src/parser/tests/redirections.rs
@@ -189,3 +189,30 @@ fn parse_here_string_with_variable() -> Result<()> {
     });
     Ok(())
 }
+
+// Out-of-range I/O numbers
+
+#[test]
+fn parse_io_number_out_of_range_does_not_panic() -> Result<()> {
+    // Regression: the `io_number` rule unwrapped the integer parse, so a run of
+    // digits too large for an `IoFd` panicked the parser rather than declining
+    // the rule. The digits are reinterpreted as an ordinary word instead.
+    let input = "echo 99999999999999999999>&1";
+    let result = test_with_snapshot(input)?;
+    assert_snapshot_redacted!(ParseResult {
+        input,
+        result: &result
+    });
+    Ok(())
+}
+
+#[test]
+fn parse_io_number_in_range_still_recognized() -> Result<()> {
+    let input = "echo 2>&1";
+    let result = test_with_snapshot(input)?;
+    assert_snapshot_redacted!(ParseResult {
+        input,
+        result: &result
+    });
+    Ok(())
+}

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__redirections__parse_io_number_in_range_still_recognized.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__redirections__parse_io_number_in_range_still_recognized.snap
@@ -1,0 +1,31 @@
+---
+source: brush-parser/src/parser/tests/redirections.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "echo 2>&1",
+  result: Program(
+    complete_commands: [
+      CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            seq: [
+              Simple(SimpleCommand(
+                word_or_name: Some(Word(
+                  value: "echo",
+                  loc: "[location]",
+                )),
+                suffix: Some(CommandSuffix([
+                  IoRedirect(File(Some(2), DuplicateOutput, Duplicate(Word(
+                    value: "1",
+                    loc: "[location]",
+                  )))),
+                ])),
+              )),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__redirections__parse_io_number_out_of_range_does_not_panic.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__redirections__parse_io_number_out_of_range_does_not_panic.snap
@@ -1,0 +1,35 @@
+---
+source: brush-parser/src/parser/tests/redirections.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "echo 99999999999999999999>&1",
+  result: Program(
+    complete_commands: [
+      CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            seq: [
+              Simple(SimpleCommand(
+                word_or_name: Some(Word(
+                  value: "echo",
+                  loc: "[location]",
+                )),
+                suffix: Some(CommandSuffix([
+                  Word(Word(
+                    value: "99999999999999999999",
+                    loc: "[location]",
+                  )),
+                  IoRedirect(File(None, DuplicateOutput, Duplicate(Word(
+                    value: "1",
+                    loc: "[location]",
+                  )))),
+                ])),
+              )),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -1011,9 +1011,9 @@ peg::parser! {
             // N.B. A run of digits need not fit in a `usize`; decline the rule
             // when it does not, so the word falls through to being treated as a
             // (non-existent) user name instead of panicking the parser.
-            plus:("+"?) n:$(['0'..='9']*) &tilde_terminator() {? n.parse().map(|n| TildeExpr::NthDirFromTopOfDirStack { n, plus_used: plus.is_some() }).map_err(|_| "dir stack index out of range") } /
+            plus:("+"?) n:$(['0'..='9']*) &tilde_terminator() {? n.parse().map_or_else(|_| Err("dir stack index out of range"), |n| Ok(TildeExpr::NthDirFromTopOfDirStack { n, plus_used: plus.is_some() })) } /
             "-" &tilde_terminator() { TildeExpr::OldWorkingDir } /
-            "-" n:$(['0'..='9']*) &tilde_terminator() {? n.parse().map(|n| TildeExpr::NthDirFromBottomOfDirStack { n }).map_err(|_| "dir stack index out of range") } /
+            "-" n:$(['0'..='9']*) &tilde_terminator() {? n.parse().map_or_else(|_| Err("dir stack index out of range"), |n| Ok(TildeExpr::NthDirFromBottomOfDirStack { n })) } /
             user:$(portable_filename_char()*) &tilde_terminator() { TildeExpr::UserHome(user.to_owned()) }
 
         rule tilde_terminator() = ['/' | ':' | ';' | '}'] / ![_]

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -1008,9 +1008,12 @@ peg::parser! {
         rule tilde_expression() -> TildeExpr =
             &tilde_terminator() { TildeExpr::Home } /
             "+" &tilde_terminator() { TildeExpr::WorkingDir } /
-            plus:("+"?) n:$(['0'..='9']*) &tilde_terminator() { TildeExpr::NthDirFromTopOfDirStack { n: n.parse().unwrap(), plus_used: plus.is_some() } } /
+            // N.B. A run of digits need not fit in a `usize`; decline the rule
+            // when it does not, so the word falls through to being treated as a
+            // (non-existent) user name instead of panicking the parser.
+            plus:("+"?) n:$(['0'..='9']*) &tilde_terminator() {? n.parse().map(|n| TildeExpr::NthDirFromTopOfDirStack { n, plus_used: plus.is_some() }).map_err(|_| "dir stack index out of range") } /
             "-" &tilde_terminator() { TildeExpr::OldWorkingDir } /
-            "-" n:$(['0'..='9']*) &tilde_terminator() { TildeExpr::NthDirFromBottomOfDirStack { n: n.parse().unwrap() } } /
+            "-" n:$(['0'..='9']*) &tilde_terminator() {? n.parse().map(|n| TildeExpr::NthDirFromBottomOfDirStack { n }).map_err(|_| "dir stack index out of range") } /
             user:$(portable_filename_char()*) &tilde_terminator() { TildeExpr::UserHome(user.to_owned()) }
 
         rule tilde_terminator() = ['/' | ':' | ';' | '}'] / ![_]
@@ -1302,6 +1305,47 @@ mod tests {
     #[test]
     fn parse_ansi_c_quoted_escape_seq() -> Result<()> {
         assert_ron_snapshot!(test_parse(r"$'\\'")?);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_tilde_with_out_of_range_dir_stack_index() -> Result<()> {
+        // Regression: the dir-stack index was unwrapped, so a run of digits too
+        // large for a `usize` panicked the parser. It should fall through to
+        // being treated as a user name, which is what bash does with it.
+        // `~N` and `~-N` fall through to a user name; `~+N` cannot, because '+'
+        // is not a valid user-name character, so it stays literal text. Both
+        // match what bash does with an out-of-range index.
+        let parsed = super::parse("~99999999999999999999", &ParserOptions::default())?;
+        assert_eq!(parsed.len(), 1);
+        assert_matches!(
+            parsed[0].piece,
+            WordPiece::TildeExpansion(TildeExpr::UserHome(_))
+        );
+
+        let parsed = super::parse("~-99999999999999999999", &ParserOptions::default())?;
+        assert_eq!(parsed.len(), 1);
+        assert_matches!(
+            parsed[0].piece,
+            WordPiece::TildeExpansion(TildeExpr::UserHome(_))
+        );
+
+        let parsed = super::parse("~+99999999999999999999", &ParserOptions::default())?;
+        assert_eq!(parsed.len(), 1);
+        assert_matches!(parsed[0].piece, WordPiece::Text(_));
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_tilde_with_in_range_dir_stack_index() -> Result<()> {
+        let parsed = super::parse("~+2", &ParserOptions::default())?;
+        assert_eq!(parsed.len(), 1);
+        assert_matches!(
+            parsed[0].piece,
+            WordPiece::TildeExpansion(TildeExpr::NthDirFromTopOfDirStack { n: 2, .. })
+        );
+
         Ok(())
     }
 

--- a/brush-shell/tests/cases/compat/redirection.yaml
+++ b/brush-shell/tests/cases/compat/redirection.yaml
@@ -260,6 +260,23 @@ cases:
       echo "[10]"
       cat fd10.txt
 
+  - name: "Redirection with out-of-range io number falls back to a word"
+    stdin: |
+      # A run of digits too large to fit an io number isn't a valid redirection
+      # prefix, so it's treated as an ordinary word argument instead.
+      echo hi 299999999999999999999999999999999999999999999999999999>out.txt
+      cat out.txt
+
+  - name: "Redirection with out-of-range io number duplicated to a valid fd"
+    stdin: |
+      echo 99999999999999999999>&1
+
+  - name: "Redirection with out-of-range io numbers on both sides of a dup"
+    ignore_stderr: true # Error message wording differs between shells.
+    stdin: |
+      echo hi 299999999999999999999999999999999999999999999999999999>&20000000000000000000000000000000000000000000
+      echo "exit: $?"
+
   - name: "Inheritance of fds from parent"
     test_files:
       - path: "test.sh"

--- a/brush-shell/tests/cases/compat/word_expansion/tilde.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/tilde.yaml
@@ -140,6 +140,20 @@ cases:
       echo "Assign colon-tilde: ${myvar3:=~:~/bin}"
       echo "myvar3 after := ${myvar3}"
 
+  - name: "Tilde expansion: out-of-range dir stack index"
+    stdin: |
+      # A run of digits too large to fit the dir-stack index type isn't a valid
+      # index, so the tilde word falls back to (failed) username lookup and is
+      # left unexpanded, same as an ordinary nonexistent user.
+      D=~99999999999999999999
+      echo "D: $D"
+
+      D=~-99999999999999999999
+      echo "D: $D"
+
+      D=~+99999999999999999999
+      echo "D: $D"
+
   - name: "Tilde expansion in list"
     known_failure: true
     env:


### PR DESCRIPTION
Two grammar rules match a run of ASCII digits and then unwrap the integer parse,
so a value too large for the target type panics the parser instead of failing to
match:

```console
$ echo 99999999999999999999>&1
thread 'main' panicked at brush-parser/src/parser/peg.rs:703:27:
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: PosOverflow }

$ echo ~99999999999999999999
thread 'main' panicked at brush-parser/src/word.rs:913:115:
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: PosOverflow }
```

The first is `io_number`, which parses into an `i32`. The second is the tilde
directory-stack index, which parses into a `usize`, in both the `~+N` and `~-N`
forms.

The digit-run guard is what makes these look safe: every character is
`is_ascii_digit`, so the parse cannot fail on shape. It can still fail on range,
and that is the case neither rule handles.

## The change

Both become fallible peg actions, so the rule declines and the input is
reconsidered by later alternatives instead of taking the process down.

The resulting parses match what bash prints:

| Input | bash | after this change |
|---|---|---|
| `~99999999999999999999` | prints literally | tilde expansion of a (non-existent) user name |
| `~-99999999999999999999` | prints literally | tilde expansion of a user name |
| `~+99999999999999999999` | prints literally | plain text, since `+` is not a valid user-name character |

## One deliberate divergence, worth your call

For the redirection case bash accepts the number at parse time and fails when the
redirection is performed:

```console
$ echo 99999999999999999999>&1
bash: file descriptor out of range: Bad file descriptor
```

Declining the rule instead means the digits parse as an ordinary word argument,
so `echo` prints them. That keeps the change local to the parser. Matching bash
properly would mean representing an out-of-range descriptor in the AST and
diagnosing it at redirection time, which means widening `IoFd` and touching the
executor.

I went with the local fix because the goal here was removing the panic, but I am
happy to do it the other way if you would prefer the AST stay faithful.

## Note on the crate's lint configuration

`brush-parser/Cargo.toml` sets `clippy::unwrap_used = "deny"`, which would have
caught both of these, but `lib.rs` disables it crate-wide:

```rust
// TODO(unwrap): remove or scope this allow attribute
#![allow(clippy::unwrap_used)]
```

Not part of this PR, but retiring that allow (or narrowing it to the specific
sites that need it) would stop this class recurring. There are other `unwrap`
calls behind it that I have not audited.

## Testing

- `cargo test -p brush-parser`: 228 passed, 0 failed. That is the existing 224
  plus 4 added here, covering both out-of-range forms and the in-range forms
  still being recognized.
- `cargo clippy -p brush-parser --all-targets`: clean.
- `cargo test -p brush-shell --test brush-compat-tests`: identical to a pristine
  checkout on the same machine.
- The tilde case was found by a structured fuzzer over shell metacharacters, and
  only after the `io_number` panic was fixed, because that one was firing first
  and masking it. 500,000 iterations report no panics with both fixed.

Assisted-by: Claude Opus 5 (Claude Code)
