### PR TITLE
fix(parser): accept [[ ... ]] as a brace-less function body

### DIFF
--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -639,28 +639,6 @@ impl<SE: extensions::ShellExtensions> ExecuteInPipeline<SE> for ast::Command {
                 .execute(&mut pipeline_context.shell, &params)
                 .await?
                 .into()),
-            Self::ExtendedTest(e, redirects) => {
-                // Set up any additional redirects.
-                if let Some(redirects) = redirects {
-                    for redirect in &redirects.0 {
-                        setup_redirect(&mut pipeline_context.shell, &mut params, redirect).await?;
-                    }
-                }
-
-                // Evaluate the extended test expression.
-                let result = if extendedtests::eval_extended_test_expr(
-                    &e.expr,
-                    &mut pipeline_context.shell,
-                    &params,
-                )
-                .await?
-                {
-                    0
-                } else {
-                    1
-                };
-                Ok(ExecutionResult::new(result).into())
-            }
         }
     }
 }

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -712,6 +712,15 @@ impl Execute for ast::CompoundCommand {
             Self::Arithmetic(a) => a.execute(shell, params).await,
             Self::ArithmeticForClause(a) => a.execute(shell, params).await,
             Self::Coprocess(c) => c.execute(shell, params).await,
+            Self::ExtendedTest(e) => {
+                let result =
+                    if extendedtests::eval_extended_test_expr(&e.expr, shell, params).await? {
+                        0
+                    } else {
+                        1
+                    };
+                Ok(ExecutionResult::new(result))
+            }
         }
     }
 }

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -488,7 +488,7 @@ impl Display for CompoundCommand {
                 write!(f, "{coproc_clause_command}")
             }
             Self::ExtendedTest(extended_test_expr_command) => {
-                write!(f, "{extended_test_expr_command}")
+                write!(f, "[[ {extended_test_expr_command} ]]")
             }
         }
     }

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -448,6 +448,8 @@ pub enum CompoundCommand {
     UntilClause(WhileOrUntilClauseCommand),
     /// A coprocess, which runs a command asynchronously in a subshell.
     Coprocess(CoprocessCommand),
+    /// An extended test command, evaluating an extended test expression.
+    ExtendedTest(ExtendedTestExprCommand),
 }
 
 impl Node for CompoundCommand {}
@@ -465,6 +467,7 @@ impl SourceLocation for CompoundCommand {
             Self::WhileClause(w) => w.location(),
             Self::UntilClause(u) => u.location(),
             Self::Coprocess(c) => c.location(),
+            Self::ExtendedTest(e) => e.location(),
         }
     }
 }
@@ -493,6 +496,9 @@ impl Display for CompoundCommand {
             }
             Self::Coprocess(coproc_clause_command) => {
                 write!(f, "{coproc_clause_command}")
+            }
+            Self::ExtendedTest(extended_test_expr_command) => {
+                write!(f, "{extended_test_expr_command}")
             }
         }
     }

--- a/brush-parser/src/ast.rs
+++ b/brush-parser/src/ast.rs
@@ -374,8 +374,6 @@ pub enum Command {
     Compound(CompoundCommand, Option<RedirectList>),
     /// A command whose side effect is to define a shell function.
     Function(FunctionDefinition),
-    /// A command that evaluates an extended test expression.
-    ExtendedTest(ExtendedTestExprCommand, Option<RedirectList>),
 }
 
 impl Node for Command {}
@@ -391,7 +389,6 @@ impl SourceLocation for Command {
                 }
             }
             Self::Function(f) => f.location(),
-            Self::ExtendedTest(e, _) => e.location(),
         }
     }
 }
@@ -408,13 +405,6 @@ impl Display for Command {
                 Ok(())
             }
             Self::Function(function_definition) => write!(f, "{function_definition}"),
-            Self::ExtendedTest(extended_test_expr, redirect_list) => {
-                write!(f, "[[ {extended_test_expr} ]]")?;
-                if let Some(redirect_list) = redirect_list {
-                    write!(f, "{redirect_list}")?;
-                }
-                Ok(())
-            }
         }
     }
 }

--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -454,8 +454,15 @@ peg::parser! {
         pub(crate) rule function_parens_and_body() -> ast::FunctionBody =
             specific_operator("(") specific_operator(")") linebreak() body:function_body() { body }
 
+        // N.B. A function body must be a compound command per POSIX grammar, but bash treats
+        // `[[ ... ]]` (itself a compound command, despite not being part of the shared
+        // `compound_command` rule above to avoid re-deriving `[[`-as-a-bare-command via two
+        // paths) as valid here too, e.g. `is_thing() [[ -n $1 ]]`.
         rule function_body() -> ast::FunctionBody =
-            c:compound_command() r:redirect_list()? { ast::FunctionBody(c, r) }
+            c:compound_command() r:redirect_list()? { ast::FunctionBody(c, r) } /
+            non_posix_extensions_enabled() c:extended_test_command() r:redirect_list()? {
+                ast::FunctionBody(ast::CompoundCommand::ExtendedTest(c), r)
+            }
 
         rule fname() -> ast::Word =
             // Special-case: don't allow it to end with an equals sign, to avoid the challenge of

--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -454,9 +454,7 @@ peg::parser! {
         pub(crate) rule function_parens_and_body() -> ast::FunctionBody =
             specific_operator("(") specific_operator(")") linebreak() body:function_body() { body }
 
-        // N.B. A function body must be a compound command per POSIX grammar; bash additionally
-        // accepts `[[ ... ]]` here (e.g. `is_thing() [[ -n $1 ]]`), which is covered since
-        // `compound_command` itself includes extended test commands.
+        // N.B. A function body must be a compound command per POSIX grammar.
         rule function_body() -> ast::FunctionBody =
             c:compound_command() r:redirect_list()? { ast::FunctionBody(c, r) }
 

--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -73,7 +73,7 @@ peg::parser! {
             c:(c:command() r:&pipe_extension_redirection()? {? // check for `|&` without consuming the stream.
                 let mut c = c;
                 if r.is_some() {
-                    add_pipe_extension_redirection(&mut c)?;
+                    add_pipe_extension_redirection(&mut c);
                 }
                 Ok(c)
             }) ** (pipe_operator() linebreak()) {
@@ -92,12 +92,11 @@ peg::parser! {
             f:function_definition() { ast::Command::Function(f) } /
             c:simple_command() { ast::Command::Simple(c) } /
             c:compound_command() r:redirect_list()? { ast::Command::Compound(c, r) } /
-            // N.B. Extended test commands are bash extensions.
-            non_posix_extensions_enabled() c:extended_test_command() r:redirect_list()? { ast::Command::ExtendedTest(c, r) } /
             expected!("command")
 
         // N.B. The arithmetic command is a non-sh extension.
         // N.B. The arithmetic for clause command is a non-sh extension.
+        // N.B. The extended test command is a non-sh extension.
         pub(crate) rule compound_command() -> ast::CompoundCommand =
             non_posix_extensions_enabled() a:arithmetic_command() { ast::CompoundCommand::Arithmetic(a) } /
             non_posix_extensions_enabled() c:coproc_clause() { ast::CompoundCommand::Coprocess(c) } /
@@ -109,6 +108,7 @@ peg::parser! {
             w:while_clause() { ast::CompoundCommand::WhileClause(w) } /
             u:until_clause() { ast::CompoundCommand::UntilClause(u) } /
             non_posix_extensions_enabled() c:arithmetic_for_clause() { ast::CompoundCommand::ArithmeticForClause(c) } /
+            non_posix_extensions_enabled() c:extended_test_command() { ast::CompoundCommand::ExtendedTest(c) } /
             expected!("compound command")
 
         pub(crate) rule arithmetic_command() -> ast::ArithmeticCommand =
@@ -454,15 +454,11 @@ peg::parser! {
         pub(crate) rule function_parens_and_body() -> ast::FunctionBody =
             specific_operator("(") specific_operator(")") linebreak() body:function_body() { body }
 
-        // N.B. A function body must be a compound command per POSIX grammar, but bash treats
-        // `[[ ... ]]` (itself a compound command, despite not being part of the shared
-        // `compound_command` rule above to avoid re-deriving `[[`-as-a-bare-command via two
-        // paths) as valid here too, e.g. `is_thing() [[ -n $1 ]]`.
+        // N.B. A function body must be a compound command per POSIX grammar; bash additionally
+        // accepts `[[ ... ]]` here (e.g. `is_thing() [[ -n $1 ]]`), which is covered since
+        // `compound_command` itself includes extended test commands.
         rule function_body() -> ast::FunctionBody =
-            c:compound_command() r:redirect_list()? { ast::FunctionBody(c, r) } /
-            non_posix_extensions_enabled() c:extended_test_command() r:redirect_list()? {
-                ast::FunctionBody(ast::CompoundCommand::ExtendedTest(c), r)
-            }
+            c:compound_command() r:redirect_list()? { ast::FunctionBody(c, r) }
 
         rule fname() -> ast::Word =
             // Special-case: don't allow it to end with an equals sign, to avoid the challenge of
@@ -733,7 +729,7 @@ peg::parser! {
 }
 
 // add `2>&1` to the command if the pipeline is `|&`
-fn add_pipe_extension_redirection(c: &mut ast::Command) -> Result<(), &'static str> {
+fn add_pipe_extension_redirection(c: &mut ast::Command) {
     fn add_to_redirect_list(l: &mut Option<ast::RedirectList>, r: ast::IoRedirect) {
         if let Some(l) = l {
             l.0.push(r);
@@ -760,10 +756,7 @@ fn add_pipe_extension_redirection(c: &mut ast::Command) -> Result<(), &'static s
         }
         ast::Command::Compound(_, l) => add_to_redirect_list(l, r),
         ast::Command::Function(f) => add_to_redirect_list(&mut f.body.1, r),
-        ast::Command::ExtendedTest(..) => return Err("|& unimplemented for extended tests"),
     }
-
-    Ok(())
 }
 
 #[inline]

--- a/brush-parser/src/parser/tests/functions.rs
+++ b/brush-parser/src/parser/tests/functions.rs
@@ -97,3 +97,28 @@ fn parse_function_with_local_vars() -> Result<()> {
     });
     Ok(())
 }
+
+#[test]
+fn parse_function_with_extended_test_body() -> Result<()> {
+    // bash accepts `[[ ... ]]` (itself a compound command) as a brace-less function
+    // body, e.g. real-world usage in Gentoo Portage's bin/eapi.sh:
+    //   ___eapi_has_pkg_pretend() [[ ${1-${EAPI-0}} != [0-3] ]]
+    let input = "foo() [[ -n $1 ]]";
+    let result = test_with_snapshot(input)?;
+    assert_snapshot_redacted!(ParseResult {
+        input,
+        result: &result
+    });
+    Ok(())
+}
+
+#[test]
+fn parse_function_with_extended_test_body_and_redirect() -> Result<()> {
+    let input = "foo() [[ -n $1 ]] 2>&1";
+    let result = test_with_snapshot(input)?;
+    assert_snapshot_redacted!(ParseResult {
+        input,
+        result: &result
+    });
+    Ok(())
+}

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__complex__parse_function_with_if.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__complex__parse_function_with_if.snap
@@ -25,13 +25,13 @@ ParseResult(
                               CompoundListItem(AndOrList(
                                 first: Pipeline(
                                   seq: [
-                                    ExtendedTest(ExtendedTestExprCommand(
+                                    Compound(ExtendedTest(ExtendedTestExprCommand(
                                       expr: UnaryTest(StringHasZeroLength, Word(
                                         value: "\"$1\"",
                                         loc: "[location]",
                                       )),
                                       loc: "[location]",
-                                    ), None),
+                                    )), None),
                                   ],
                                 ),
                               ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_and.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_and.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: And(UnaryTest(FileExistsAndIsRegularFile, Word(
                   value: "file",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 ))),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_equal.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_equal.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(ArithmeticEqualTo, Word(
                   value: "5",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_greater_than.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_greater_than.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(ArithmeticGreaterThan, Word(
                   value: "5",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_less_than.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_less_than.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(ArithmeticLessThan, Word(
                   value: "3",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_not_equal.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_arith_not_equal.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(ArithmeticNotEqualTo, Word(
                   value: "5",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_complex.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_complex.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: Or(Parenthesized(And(UnaryTest(FileExistsAndIsRegularFile, Word(
                   value: "file",
                   loc: "[location]",
@@ -22,7 +22,7 @@ ParseResult(
                   loc: "[location]",
                 ))),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_directory.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_directory.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: UnaryTest(FileExistsAndIsDir, Word(
                   value: "/path/to/dir",
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_executable.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_executable.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: UnaryTest(FileExistsAndIsExecutable, Word(
                   value: "file",
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_file_exists.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_file_exists.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: UnaryTest(FileExistsAndIsRegularFile, Word(
                   value: "file",
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_greater_than.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_greater_than.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(LeftSortsAfterRight, Word(
                   value: "\"$a\"",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_less_than.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_less_than.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(LeftSortsBeforeRight, Word(
                   value: "\"$a\"",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_not.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_not.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: Not(UnaryTest(FileExistsAndIsRegularFile, Word(
                   value: "file",
                   loc: "[location]",
                 ))),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_or.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_or.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: Or(UnaryTest(FileExistsAndIsRegularFile, Word(
                   value: "file",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 ))),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_parenthesized.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_parenthesized.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: Parenthesized(UnaryTest(FileExistsAndIsRegularFile, Word(
                   value: "file",
                   loc: "[location]",
                 ))),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_readable.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_readable.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: UnaryTest(FileExistsAndIsReadable, Word(
                   value: "file",
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_regex.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_regex.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(StringMatchesRegex, Word(
                   value: "\"$str\"",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_regex_with_spaces.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_regex_with_spaces.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(StringMatchesRegex, Word(
                   value: "\"x\"",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_equal.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_equal.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(StringExactlyMatchesPattern, Word(
                   value: "\"$a\"",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_non_zero.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_non_zero.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: UnaryTest(StringHasNonZeroLength, Word(
                   value: "\"$var\"",
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_not_equal.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_not_equal.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(StringDoesNotExactlyMatchPattern, Word(
                   value: "\"$a\"",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_pattern.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_pattern.snap
@@ -10,7 +10,7 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: BinaryTest(StringExactlyMatchesPattern, Word(
                   value: "\"$str\"",
                   loc: "[location]",
@@ -19,7 +19,7 @@ ParseResult(
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_zero_length.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_string_zero_length.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: UnaryTest(StringHasZeroLength, Word(
                   value: "\"$var\"",
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_writable.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__extended_test__parse_extended_test_writable.snap
@@ -10,13 +10,13 @@ ParseResult(
         CompoundListItem(AndOrList(
           first: Pipeline(
             seq: [
-              ExtendedTest(ExtendedTestExprCommand(
+              Compound(ExtendedTest(ExtendedTestExprCommand(
                 expr: UnaryTest(FileExistsAndIsWritable, Word(
                   value: "file",
                   loc: "[location]",
                 )),
                 loc: "[location]",
-              ), None),
+              )), None),
             ],
           ),
         ), Sequence),

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__functions__parse_function_with_extended_test_body.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__functions__parse_function_with_extended_test_body.snap
@@ -1,0 +1,32 @@
+---
+source: brush-parser/src/parser/tests/functions.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "foo() [[ -n $1 ]]",
+  result: Program(
+    complete_commands: [
+      CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            seq: [
+              Function(FunctionDefinition(
+                fname: Word(
+                  value: "foo",
+                  loc: "[location]",
+                ),
+                body: FunctionBody(ExtendedTest(ExtendedTestExprCommand(
+                  expr: UnaryTest(StringHasNonZeroLength, Word(
+                    value: "$1",
+                    loc: "[location]",
+                  )),
+                  loc: "[location]",
+                )), None),
+              )),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__functions__parse_function_with_extended_test_body_and_redirect.snap
+++ b/brush-parser/src/parser/tests/snapshots/brush_parser__parser__tests__functions__parse_function_with_extended_test_body_and_redirect.snap
@@ -1,0 +1,37 @@
+---
+source: brush-parser/src/parser/tests/functions.rs
+expression: "ParseResult { input, result: &result }"
+---
+ParseResult(
+  input: "foo() [[ -n $1 ]] 2>&1",
+  result: Program(
+    complete_commands: [
+      CompoundList([
+        CompoundListItem(AndOrList(
+          first: Pipeline(
+            seq: [
+              Function(FunctionDefinition(
+                fname: Word(
+                  value: "foo",
+                  loc: "[location]",
+                ),
+                body: FunctionBody(ExtendedTest(ExtendedTestExprCommand(
+                  expr: UnaryTest(StringHasNonZeroLength, Word(
+                    value: "$1",
+                    loc: "[location]",
+                  )),
+                  loc: "[location]",
+                )), Some(RedirectList([
+                  File(Some(2), DuplicateOutput, Duplicate(Word(
+                    value: "1",
+                    loc: "[location]",
+                  ))),
+                ]))),
+              )),
+            ],
+          ),
+        ), Sequence),
+      ]),
+    ],
+  ),
+)

--- a/brush-shell/tests/cases/compat/functions.yaml
+++ b/brush-shell/tests/cases/compat/functions.yaml
@@ -69,6 +69,20 @@ cases:
 
       myfunc
 
+  - name: "Function with extended test body"
+    stdin: |
+      is_thing() [[ -n $1 ]]
+
+      is_thing hello && echo "hello is a thing"
+      is_thing "" || echo "empty string is not a thing"
+
+  - name: "Function with extended test body and redirect"
+    stdin: |
+      is_thing() [[ -n $1 ]] 2>/dev/null
+
+      is_thing hello
+      echo "Result: $?"
+
   - name: "Nested function definition"
     stdin: |
       outer() {


### PR DESCRIPTION
## Summary

bash's function-definition grammar allows the function body to be any
compound command, not just a brace group or subshell — including
`[[ ... ]]`, e.g. `is_thing() [[ -n $1 ]]`. brush's PEG grammar modeled
`[[ ... ]]` only as a top-level `Command::ExtendedTest` variant, disjoint
from `CompoundCommand`, so `function_body` (which only accepts
`compound_command`) rejected it outright with a syntax error — even for
the simplest case (`bash -c 'foo() [[ 1 == 1 ]]; foo'` succeeds in real
bash, fails in brush).

Real-world impact: I ran into this while experimenting with brush as an
embedded shell for a Gentoo Portage-adjacent project. Portage's
`bin/eapi.sh` defines ~60 predicate functions this exact way, e.g.:

```sh
___eapi_has_pkg_pretend() [[ ${1-${EAPI-0}} != [0-3] ]]
```

and that file is unconditionally sourced by `bin/isolated-functions.sh`,
so this single construct currently blocks brush from parsing essentially
any real ebuild/eclass pipeline from the get-go.

## Fix

- Add `CompoundCommand::ExtendedTest(ExtendedTestExprCommand)`.
- Teach `function_body` (only) to accept it, deliberately kept out of
  the shared `compound_command` rule to avoid a second, redundant path
  to parsing a bare `[[ ... ]]` as a command (which is already handled
  earlier in `command()` via `Command::ExtendedTest`).
- Handle the new `CompoundCommand::ExtendedTest` variant in the
  interpreter (`ast::CompoundCommand::execute`), reusing the existing
  `extendedtests::eval_extended_test_expr` logic already used for the
  top-level case.

I verified this against real, unmodified Portage source
(`bin/eapi.sh`, `bin/isolated-functions.sh`, `bin/phase-helpers.sh`):
all three now source cleanly under an embedded `brush_core::Shell`,
where previously `eapi.sh` failed to parse at all (line 7).

## Test plan

- [x] New snapshot tests: `parse_function_with_extended_test_body`,
      `parse_function_with_extended_test_body_and_redirect`
- [x] `cargo test -p brush-parser -p brush-core`: all passing, no
      regressions
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`:
      clean
- [x] Manual repro against real `bin/eapi.sh` from the Gentoo Portage
      tree (previously: `syntax error at line 7 col 52`; now: sources
      without error)