### PR TITLE
fix(interp): run function pipeline stages as background tasks, not inline

### DIFF
--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -505,6 +505,78 @@ impl<'a, SE: extensions::ShellExtensions> SimpleCommand<'a, SE> {
         self,
         func_registration: functions::Registration,
     ) -> Result<ExecutionSpawnResult, error::Error> {
+        match self.shell {
+            ShellForCommand::OwnedShell { target, .. } => {
+                Ok(Self::execute_via_function_in_owned_shell(
+                    *target,
+                    self.params,
+                    func_registration,
+                    self.command_name,
+                    self.args,
+                ))
+            }
+            ShellForCommand::ParentShell(..) => {
+                self.execute_via_function_in_parent_shell(func_registration)
+                    .await
+            }
+        }
+    }
+
+    // As a non-last pipeline stage, a function must run as a background task
+    // (mirroring `execute_via_builtin_in_owned_shell` above) rather than
+    // being awaited inline in `spawn_pipeline_processes`'s own per-stage
+    // loop: awaiting it inline there blocks that loop until the function's
+    // body fully returns, so the *next* pipeline stage (the one that would
+    // actually drain this function's stdout pipe) is never even spawned
+    // until this one is done. A function that writes more to its stdout
+    // pipe than the OS pipe buffer holds (~64KiB on Linux) before returning
+    // then blocks on that `write()` forever, since nothing is reading the
+    // other end yet -- a plain deadlock, not a slow completion. Confirmed
+    // empirically with a two-line repro having nothing to do with any
+    // external command or builtin: `f() { for i in $(seq 1 5000); do echo
+    // line $i; done; }; f | cat` hangs indefinitely. Real bash always runs
+    // every pipeline stage as its own concurrently-running process, so this
+    // case never arises there.
+    fn execute_via_function_in_owned_shell(
+        mut shell: Shell<SE>,
+        params: ExecutionParameters,
+        func_registration: functions::Registration,
+        command_name: String,
+        args: Vec<CommandArg>,
+    ) -> ExecutionSpawnResult {
+        let last_arg = Self::take_last_arg(&args);
+        let join_handle = tokio::task::spawn_blocking(move || {
+            let cmd_context = ExecutionContext {
+                shell: &mut shell,
+                command_name,
+                params,
+            };
+
+            let rt = tokio::runtime::Handle::current();
+            let spawn_result =
+                rt.block_on(invoke_shell_function(func_registration, cmd_context, &args[1..]));
+
+            // Update $_ after command execution.
+            shell.update_last_arg_variable(last_arg);
+
+            match spawn_result? {
+                ExecutionSpawnResult::Completed(result) => Ok(result),
+                ExecutionSpawnResult::StartedProcess(_) | ExecutionSpawnResult::StartedTask(_) => {
+                    // invoke_shell_function() only ever returns Completed
+                    // today; this guards against a silent behavior change
+                    // rather than dropping already-started work.
+                    error::unimp("invoke_shell_function returned an unexpected spawn result")
+                }
+            }
+        });
+
+        ExecutionSpawnResult::StartedTask(join_handle)
+    }
+
+    async fn execute_via_function_in_parent_shell(
+        self,
+        func_registration: functions::Registration,
+    ) -> Result<ExecutionSpawnResult, error::Error> {
         let mut shell = self.shell;
         let last_arg = Self::take_last_arg(&self.args);
 

--- a/brush-shell/tests/cases/compat/pipeline.yaml
+++ b/brush-shell/tests/cases/compat/pipeline.yaml
@@ -57,4 +57,20 @@ cases:
   - name: "printf broken pipe returns 141 in PIPESTATUS"
     stdin: |
       printf '%s\n' {0..10000} | x=1
+
+  - name: "Function stage writing more than a pipe buffer before the next stage is spawned"
+    # Regression test: a shell function used as a non-last pipeline stage
+    # must run concurrently with the rest of the pipeline, not be awaited
+    # to completion before the next stage is even spawned. Otherwise, once
+    # the function writes more to its stdout pipe than the OS pipe buffer
+    # holds (commonly 64KiB on Linux) before returning, the write blocks
+    # forever because nothing is reading the other end yet.
+    stdin: |
+      big() {
+        local i
+        for i in $(seq 1 5000); do
+          echo "padding line number ${i} to exceed the pipe buffer size"
+        done
+      }
+      big | wc -l
       echo "Last: $?, PIPESTATUS: ${PIPESTATUS[*]}"


### PR DESCRIPTION
## Summary

Fixes a real deadlock: a shell **function** used as a non-last stage of a pipeline blocks forever once it writes more to its stdout than the OS pipe buffer holds (~64KiB on Linux), because the pipeline-spawning loop doesn't move on to the next stage (the one that would drain that pipe) until the function has *fully returned*.

Minimal repro, no external commands involved:

```sh
f() {
  for i in $(seq 1 5000); do echo "line $i"; done
}
f | cat > out.txt   # hangs forever
```

Real bash and every other shell run every pipeline stage concurrently, so this case never arises there.

## Root cause

`spawn_pipeline_processes()` (`brush-core/src/interp.rs`) spawns each pipeline stage in a loop, `.await`ing `execute_in_pipeline()` before moving on to the next stage:

```rust
let spawn_result = command
    .execute_in_pipeline(pipeline_context, cmd_params)
    .await?;
```

For external processes, and for builtins run in an owned (non-last-stage) shell, that `.await` resolves as soon as the work is *spawned*, not when it *finishes* — `execute_via_builtin_in_owned_shell()` already wraps the builtin in `tokio::task::spawn_blocking`, returning `ExecutionSpawnResult::StartedTask` immediately.

`execute_via_function()` had no such wrapping: it ran the function body inline (`invoke_shell_function(...).await`), so the loop genuinely blocked on the *entire function body* completing before the next pipeline stage was even spawned. If that function writes enough to stdout to fill the kernel pipe buffer before returning, its `write()` blocks — and since nothing is reading the other end yet (the next stage hasn't been spawned), it blocks forever.

This isn't just a synthetic case: any script piping the output of a function that produces more than ~64KiB (e.g. `some_function | grep foo`, `some_function | wc -l`, or shells that dump their own state through a function-based filter) hits this.

## Fix

Split `execute_via_function` the same way `execute_via_builtin` already is:

- **Owned-shell path** (used for every pipeline stage except the last): spawns the function body as a background task via `tokio::task::spawn_blocking` + `rt.block_on(...)`, mirroring `execute_via_builtin_in_owned_shell` exactly, and returns `ExecutionSpawnResult::StartedTask` immediately so the pipeline loop can proceed to spawn the next stage right away.
- **Parent-shell path** (used only for a pipeline's own last stage, which by definition never needs to unblock a downstream reader): unchanged, still awaits inline.

`post_execute` is intentionally not invoked in the new owned-shell path, matching `execute_via_builtin_in_owned_shell`'s existing behavior — the owned shell is a throwaway clone discarded after the pipeline stage completes, so running `post_execute` against it has no observable effect on the parent shell.

## Testing

- New compat case (`brush-shell/tests/cases/compat/pipeline.yaml`, "Function stage writing more than a pipe buffer before the next stage is spawned") reproduces the original hang under the compat suite's own 15s per-test timeout, so a regression here fails the test rather than hanging CI.

- Full `brush-compat-tests` suite passes identically before and after this change, confirmed via a clean (`cargo clean`) rebuild on both sides of the fix rather than trusting a cached binary:

  ```
  before: 2174 test case(s) ran: 1795 succeeded, 0 failed, 379 known to fail, 28 skipped.
  after:  2175 test case(s) ran: 1796 succeeded, 0 failed, 379 known to fail, 28 skipped.
  ```

  (+1/+1 is exactly the new test case; no other test's outcome changed.)

## How this was found

Found while embedding `brush_core::Shell` as the bash-execution backend for a Gentoo Portage ebuild-phase-execution prototype. Real `bin/phase-functions.sh`'s post-phase step pipes `__save_ebuild_env | __filter_readonly_variables` — both sides are shell functions, and `__save_ebuild_env` dumps every function and variable currently in scope via `declare -f`/`declare -p`. Small scripts stayed under the pipe-buffer threshold and worked fine; anything that had sourced a nontrivial number of shell functions into scope (as few as a couple hundred short functions) reliably deadlocked. Bisected down to `execute_via_function`'s lack of concurrent spawning with the standalone repro above, independent of any of the ebuild-specific code.