### PR TITLE
fix(expansion): keep the leading zeros in a numeric brace sequence

### DIFF
--- a/brush-core/src/braceexpansion.rs
+++ b/brush-core/src/braceexpansion.rs
@@ -34,14 +34,23 @@ fn expand_brace_expr_member(bem: word::BraceExpressionMember) -> Box<dyn Iterato
             start,
             end,
             increment,
+            zero_padded_width,
         } => {
             let mut increment = increment.unsigned_abs() as usize;
             if increment == 0 {
                 increment = 1;
             }
 
+            // A bound written with a leading zero asks for every member to be padded
+            // out to the width of the longer bound, so `{01..10}` counts `01 02 ...`
+            // and not `1 2 ...`. The sign takes one of those columns.
+            let format = move |n: i64| match zero_padded_width {
+                Some(width) => std::format!("{n:0width$}"),
+                None => n.to_string(),
+            };
+
             if start <= end {
-                Box::new((start..=end).step_by(increment).map(|n| n.to_string()))
+                Box::new((start..=end).step_by(increment).map(format))
             } else {
                 // Iterate from start down to end by decrementing.
                 #[allow(clippy::cast_possible_wrap)]
@@ -51,7 +60,7 @@ fn expand_brace_expr_member(bem: word::BraceExpressionMember) -> Box<dyn Iterato
                         let next = n - increment;
                         (next >= end).then_some(next)
                     })
-                    .map(|n| n.to_string()),
+                    .map(format),
                 )
             }
         }

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -504,6 +504,9 @@ pub enum BraceExpressionMember {
         end: i64,
         /// Increment value.
         increment: i64,
+        /// Width to zero pad each member out to, set when either bound was
+        /// written with a leading zero.
+        zero_padded_width: Option<usize>,
     },
     /// An inclusive character sequence.
     CharSequence {
@@ -654,6 +657,41 @@ pub(crate) fn parse_array_assignment(
     })
 }
 
+/// Parses one bound of a numeric brace sequence, e.g. `-007`.
+///
+/// Returns `None` when the bound does not fit in an `i64`, which lets the sequence
+/// rule decline rather than panic on something like `{99999999999999999999..1}`.
+///
+/// The sign goes to the parser along with the digits, so `i64::MIN` is accepted even
+/// though its digits alone are one past `i64::MAX`.
+///
+/// # Arguments
+///
+/// * `text` - The bound as it was written, sign included.
+fn parse_sequence_bound(text: &str) -> Option<i64> {
+    text.parse().ok()
+}
+
+/// Returns the width the members of a numeric brace sequence should be zero
+/// padded out to, or `None` if they should be written as plain numbers.
+///
+/// A leading zero in either bound asks for padding, and the width is then the
+/// longer of the two bounds as they were written, sign included. A lone `0` is
+/// not a leading zero, and neither is a zero that follows a `+`.
+///
+/// # Arguments
+///
+/// * `start` - The start bound as it was written.
+/// * `end` - The end bound as it was written.
+fn zero_padded_width(start: &str, end: &str) -> Option<usize> {
+    fn has_leading_zero(bound: &str) -> bool {
+        let digits = bound.strip_prefix('-').unwrap_or(bound);
+        digits.len() > 1 && digits.starts_with('0')
+    }
+
+    (has_leading_zero(start) || has_leading_zero(end)).then(|| start.len().max(end.len()))
+}
+
 /// Parses literal array element text into optionally-keyed element words.
 ///
 /// # Arguments
@@ -748,12 +786,24 @@ peg::parser! {
             }
 
         pub(crate) rule brace_sequence_expr() -> BraceExpressionMember =
-            start:number() ".." end:number() increment:(".." n:number() { n })? {
-                BraceExpressionMember::NumberSequence { start, end, increment: increment.unwrap_or(1) }
+            start:sequence_bound() ".." end:sequence_bound() increment:(".." n:number() { n })? {
+                BraceExpressionMember::NumberSequence {
+                    start: start.0,
+                    end: end.0,
+                    increment: increment.unwrap_or(1),
+                    zero_padded_width: zero_padded_width(start.1, end.1),
+                }
             } /
             start:character() ".." end:character() increment:(".." n:number() { n })? {
                 BraceExpressionMember::CharSequence { start, end, increment: increment.unwrap_or(1) }
             }
+
+        // A bound of a numeric sequence, kept alongside the text it was written as.
+        // Whether the members come out zero padded is decided by that text and not
+        // by the value, so `{01..3}` and `{1..3}` have to stay distinguishable.
+        rule sequence_bound() -> (i64, &'input str) = text:$(number_sign()? ['0'..='9']+) {?
+            parse_sequence_bound(text).map(|n| (n, text)).ok_or("number out of range")
+        }
 
         rule number() -> i64 = sign:number_sign()? n:$(['0'..='9']+) {
             let sign = sign.unwrap_or(1);
@@ -1459,5 +1509,45 @@ mod tests {
         assert!(parse("(unterminated").is_none());
         assert!(parse("plain text").is_none());
         assert!(parse("").is_none());
+    }
+
+    #[test]
+    fn parse_sequence_bound() {
+        assert_eq!(super::parse_sequence_bound("3"), Some(3));
+        assert_eq!(super::parse_sequence_bound("007"), Some(7));
+        assert_eq!(super::parse_sequence_bound("+7"), Some(7));
+        assert_eq!(super::parse_sequence_bound("-007"), Some(-7));
+        assert_eq!(super::parse_sequence_bound("0"), Some(0));
+        assert_eq!(super::parse_sequence_bound("-0"), Some(0));
+        assert_eq!(super::parse_sequence_bound("99999999999999999999"), None);
+
+        // The digits of `i64::MIN` are one past `i64::MAX`, so the sign has to be parsed with them.
+        assert_eq!(super::parse_sequence_bound("-9223372036854775808"), Some(i64::MIN));
+        assert_eq!(super::parse_sequence_bound("9223372036854775807"), Some(i64::MAX));
+        assert_eq!(super::parse_sequence_bound("-9223372036854775809"), None);
+    }
+
+    #[test]
+    fn zero_padded_width() {
+        let width = super::zero_padded_width;
+
+        // Neither bound was written with a leading zero.
+        assert_eq!(width("1", "5"), None);
+        assert_eq!(width("0", "10"), None);
+        assert_eq!(width("-0", "3"), None);
+
+        // The width is the longer bound as written, whichever one asked for padding.
+        assert_eq!(width("01", "5"), Some(2));
+        assert_eq!(width("1", "005"), Some(3));
+        assert_eq!(width("0009", "11"), Some(4));
+
+        // A sign takes one of the columns.
+        assert_eq!(width("-01", "01"), Some(3));
+        assert_eq!(width("00", "-3"), Some(2));
+
+        // A zero after a plus does not ask for padding, though the text still
+        // counts toward the width once the other bound has asked.
+        assert_eq!(width("+01", "3"), None);
+        assert_eq!(width("+01", "05"), Some(3));
     }
 }

--- a/brush-parser/src/word.rs
+++ b/brush-parser/src/word.rs
@@ -1522,8 +1522,14 @@ mod tests {
         assert_eq!(super::parse_sequence_bound("99999999999999999999"), None);
 
         // The digits of `i64::MIN` are one past `i64::MAX`, so the sign has to be parsed with them.
-        assert_eq!(super::parse_sequence_bound("-9223372036854775808"), Some(i64::MIN));
-        assert_eq!(super::parse_sequence_bound("9223372036854775807"), Some(i64::MAX));
+        assert_eq!(
+            super::parse_sequence_bound("-9223372036854775808"),
+            Some(i64::MIN)
+        );
+        assert_eq!(
+            super::parse_sequence_bound("9223372036854775807"),
+            Some(i64::MAX)
+        );
         assert_eq!(super::parse_sequence_bound("-9223372036854775809"), None);
     }
 

--- a/brush-shell/tests/cases/compat/word_expansion/braces.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/braces.yaml
@@ -143,3 +143,47 @@ cases:
       for i in ${array[@]%a}; do
           echo "Element: '$i'"
       done
+
+  - name: "Expansion with curly braces: zero-padded numeric sequences"
+    stdin: |
+      echo {01..05}
+      echo {1..05}
+      echo {001..3}
+      echo {09..11}
+      echo {0..03}
+      echo {0009..11}
+      echo {05..01}
+      echo {010..1..3}
+      echo {01..10..2}
+      echo x{01..03}y
+
+  - name: "Expansion with curly braces: a lone zero does not pad"
+    stdin: |
+      echo {0..3}
+      echo {0..10}
+      echo {10..0}
+      echo {-0..3}
+      echo {1..5}
+
+  - name: "Expansion with curly braces: zero padding with signs"
+    stdin: |
+      echo {-01..01}
+      echo {005..-2}
+      echo {-1..01}
+      echo {-001..2}
+      echo {01..-1}
+      echo {-01..-05}
+      echo {00..-3}
+      echo {+01..3}
+      echo {+01..05}
+
+  - name: "Expansion with curly braces: numeric bound too large for the sequence"
+    stdin: |
+      echo {99999999999999999999..1}
+      echo {1..99999999999999999999}
+      echo {-9223372036854775809..-9223372036854775807}
+
+  - name: "Expansion with curly braces: numeric bounds at the edge of the range"
+    stdin: |
+      echo {-9223372036854775808..-9223372036854775806}
+      echo {9223372036854775805..9223372036854775807}


### PR DESCRIPTION
A numeric brace sequence written with a leading zero counts with the zero kept: `{01..05}` is `01 02 03 04 05`. brush dropped it and produced `1 2 3 4 5`, because the bounds were parsed into `i64` and the text they were written as was gone by the time the sequence was generated.

```
$ echo {01..05}
bash:   01 02 03 04 05
before: 1 2 3 4 5
after:  01 02 03 04 05

$ echo {0009..11}
bash:   0009 0010 0011
before: 9 10 11
after:  0009 0010 0011
```

It is quiet when it goes wrong. `for i in {01..12}` over a directory of `01.log` through `12.log` just stops matching anything.

The rule, taken from bash by measurement rather than from the manual, which does not spell all of it out:

- A leading zero in either bound turns padding on. A lone `0` is not a leading zero, so `{0..10}` stays `0 1 2 ... 10`.
- The width is the longer of the two bounds as they were written, sign included: `{-01..01}` gives `-01 000 001`, and `{1..005}` gives `001` through `005`.
- A zero that follows a `+` does not turn padding on, though the text still counts toward the width once the other bound has asked for it. `{+01..3}` is `1 2 3` and `{+01..05}` is `001` through `005`.
- The increment has no say in either question. `{1..10..03}` is `1 4 7 10`.

Checked against bash for 53 sequences, covering both directions, both signs, a step, a prefix and a suffix, and the cases where padding must not happen.

**Public API change**, since the checklist asks for these to be called out: `BraceExpressionMember::NumberSequence` gains a `zero_padded_width: Option<usize>` field. Nothing else in the workspace constructs or matches that variant, but it is a breaking change for anyone outside it who does. The alternative is carrying the two bounds' source text on the variant instead, which is a wider change for the same information; happy to go that way if you would rather keep the decision out of the parser.

One thing came along for the ride. The new bound rule declines when a bound does not fit in an `i64` instead of unwrapping, so `echo {99999999999999999999..1}` now prints itself back the way bash does, where before it panicked the parser:

```
thread 'main' panicked at brush-parser/src/word.rs:760:38:
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: PosOverflow }
```

Sign and digits go to the parser together, so the bottom of the range still expands, which it would not if the digits went in on their own:

```
$ echo {-9223372036854775808..-9223372036854775806}
bash:  -9223372036854775808 -9223372036854775807 -9223372036854775806
brush: -9223372036854775808 -9223372036854775807 -9223372036854775806
```

That is the same class of thing #1271 is fixing in `io_number`, in a different rule. The sequence increment still goes through the old `number()` rule and still unwraps; I left it alone rather than widening this beyond the bounds it needs.

