### PR TITLE
fix(builtins): avoid deadlock when a builtin reads a process substitution

### DIFF
--- a/brush-builtins/Cargo.toml
+++ b/brush-builtins/Cargo.toml
@@ -171,3 +171,4 @@ procfs = "0.18.0"
 [dev-dependencies]
 anyhow = "1.0.102"
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }
+tokio = { version = "1.52.3", features = ["time"] }

--- a/brush-builtins/src/lib.rs
+++ b/brush-builtins/src/lib.rs
@@ -118,6 +118,23 @@ mod wait;
 
 mod builder;
 mod factory;
+
+async fn run_blocking_io<T>(
+    f: impl FnOnce() -> Result<T, brush_core::Error> + Send + 'static,
+) -> Result<T, brush_core::Error>
+where
+    T: Send + 'static,
+{
+    #[cfg(any(unix, windows))]
+    {
+        tokio::task::spawn_blocking(f).await?
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        f()
+    }
+}
 mod unimp;
 
 pub use builder::ShellBuilderExt;

--- a/brush-builtins/src/mapfile.rs
+++ b/brush-builtins/src/mapfile.rs
@@ -82,8 +82,10 @@ impl builtins::Command for MapFileCommand {
             .try_fd(self.fd)
             .ok_or_else(|| ErrorKind::BadFileDescriptor(self.fd))?;
 
-        // Read!
-        let results = self.read_entries(input_file)?;
+        // Read! The read is synchronous and can block until the write end is closed,
+        // so it must not hold onto the runtime worker while it waits.
+        let results =
+            brush_core::openfiles::without_parking_worker(|| self.read_entries(input_file))?;
 
         if let Some(origin) = self.origin {
             // -O: preserve existing array, assign at offset.

--- a/brush-builtins/src/mapfile.rs
+++ b/brush-builtins/src/mapfile.rs
@@ -82,10 +82,15 @@ impl builtins::Command for MapFileCommand {
             .try_fd(self.fd)
             .ok_or_else(|| ErrorKind::BadFileDescriptor(self.fd))?;
 
-        // Read! The read is synchronous and can block until the write end is closed,
-        // so it must not hold onto the runtime worker while it waits.
-        let results =
-            brush_core::openfiles::without_parking_worker(|| self.read_entries(input_file))?;
+        let read_config = MapFileReadConfig {
+            delimiter: self.delimiter.clone(),
+            max_count: self.max_count,
+            skip_count: self.skip_count,
+            remove_delimiter: self.remove_delimiter,
+        };
+
+        // Read synchronously without blocking an async runtime worker.
+        let results = crate::run_blocking_io(move || read_config.read_entries(input_file)).await?;
 
         if let Some(origin) = self.origin {
             // -O: preserve existing array, assign at offset.
@@ -117,7 +122,14 @@ impl builtins::Command for MapFileCommand {
     }
 }
 
-impl MapFileCommand {
+struct MapFileReadConfig {
+    delimiter: Option<String>,
+    max_count: i64,
+    skip_count: i64,
+    remove_delimiter: bool,
+}
+
+impl MapFileReadConfig {
     fn read_entries(
         &self,
         mut input_file: brush_core::openfiles::OpenFile,

--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -114,8 +114,12 @@ impl builtins::Command for ReadCommand {
         // Convert timeout to Duration.
         let timeout = self.timeout_in_seconds.map(Duration::from_secs_f64);
 
-        // Perform the read operation (potentially with timeout).
-        let read_result = self.read_line(input_stream, context.stderr(), timeout)?;
+        // Perform the read operation (potentially with timeout). Without -t this blocks
+        // until the write end is closed, so it must not hold onto the runtime worker
+        // while it waits.
+        let read_result = brush_core::openfiles::without_parking_worker(|| {
+            self.read_line(input_stream, context.stderr(), timeout)
+        })?;
 
         // Determine whether to skip IFS splitting (for -N option).
         let skip_ifs_splitting = self.return_after_n_chars_no_delimiter.is_some();

--- a/brush-builtins/src/read.rs
+++ b/brush-builtins/src/read.rs
@@ -114,12 +114,34 @@ impl builtins::Command for ReadCommand {
         // Convert timeout to Duration.
         let timeout = self.timeout_in_seconds.map(Duration::from_secs_f64);
 
-        // Perform the read operation (potentially with timeout). Without -t this blocks
-        // until the write end is closed, so it must not hold onto the runtime worker
-        // while it waits.
-        let read_result = brush_core::openfiles::without_parking_worker(|| {
-            self.read_line(input_stream, context.stderr(), timeout)
-        })?;
+        let term_mode = self.setup_terminal_settings(&input_stream)?;
+
+        // Display prompt on stderr, but only if input is from a terminal (per bash behavior).
+        if let Some(prompt) = &self.prompt
+            && input_stream.is_terminal()
+        {
+            let mut stderr_file = context.stderr();
+            write!(stderr_file, "{prompt}")?;
+            stderr_file.flush()?;
+        }
+
+        let config = self.line_reader_config();
+
+        // Perform the synchronous descriptor read away from the async runtime workers.
+        let read_result = crate::run_blocking_io(move || {
+            let mut reader = InputReader::new(input_stream, timeout, term_mode);
+
+            if timeout == Some(Duration::ZERO) {
+                return Ok(if reader.check_input_available() {
+                    ReadResult::InputReady
+                } else {
+                    ReadResult::InputNotReady
+                });
+            }
+
+            read_line_with_reader(&mut reader, &config)
+        })
+        .await?;
 
         // Determine whether to skip IFS splitting (for -N option).
         let skip_ifs_splitting = self.return_after_n_chars_no_delimiter.is_some();
@@ -505,28 +527,7 @@ fn read_line_with_reader(
 }
 
 impl ReadCommand {
-    /// Reads a line of input, optionally with a timeout.
-    ///
-    /// Handles backslash escape processing:
-    /// - Without `-r`: backslash-newline is line continuation, other backslashes escape the next
-    ///   char
-    /// - With `-r`: backslash is treated as a literal character
-    fn read_line(
-        &self,
-        input_file: brush_core::openfiles::OpenFile,
-        mut stderr_file: impl std::io::Write,
-        timeout: Option<Duration>,
-    ) -> Result<ReadResult, brush_core::Error> {
-        let term_mode = self.setup_terminal_settings(&input_file)?;
-
-        // Display prompt on stderr, but only if input is from a terminal (per bash behavior).
-        if let Some(prompt) = &self.prompt {
-            if input_file.is_terminal() {
-                write!(stderr_file, "{prompt}")?;
-                stderr_file.flush()?;
-            }
-        }
-
+    fn line_reader_config(&self) -> LineReaderConfig {
         // Determine delimiter based on options.
         let delimiter = if self.return_after_n_chars_no_delimiter.is_some() {
             None
@@ -544,26 +545,11 @@ impl ReadCommand {
             .return_after_n_chars_no_delimiter
             .or(self.return_after_n_chars);
 
-        // Create the input reader.
-        let mut reader = InputReader::new(input_file, timeout, term_mode);
-
-        // Handle -t 0 special case: just check if input is available without reading.
-        if timeout == Some(Duration::ZERO) {
-            return Ok(if reader.check_input_available() {
-                ReadResult::InputReady
-            } else {
-                ReadResult::InputNotReady
-            });
-        }
-
-        // Configure and perform the read.
-        let config = LineReaderConfig {
+        LineReaderConfig {
             delimiter,
             char_limit,
             process_escapes: !self.raw_mode,
-        };
-
-        read_line_with_reader(&mut reader, &config)
+        }
     }
 
     fn setup_terminal_settings(

--- a/brush-builtins/tests/runtime_read_tests.rs
+++ b/brush-builtins/tests/runtime_read_tests.rs
@@ -1,0 +1,161 @@
+//! Regression tests for synchronous builtin reads in embedded Tokio runtimes.
+
+#![cfg(unix)]
+#![cfg(test)]
+#![allow(clippy::expect_used)]
+
+use std::time::Duration;
+
+use brush_builtins::ShellBuilderExt as _;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+const CHILD_TEST_ENV: &str = "BRUSH_RUNTIME_READ_TEST_CHILD";
+
+async fn run_script(script: &str) {
+    let mut shell = brush_core::Shell::builder()
+        .do_not_inherit_env(true)
+        .skip_well_known_vars(true)
+        .default_builtins(brush_builtins::BuiltinSet::BashMode)
+        .build()
+        .await
+        .expect("shell should build");
+    let params = shell.default_exec_params();
+    let result = shell
+        .run_string(script, &brush_core::SourceInfo::default(), &params)
+        .await
+        .expect("script should execute");
+
+    assert!(
+        result.is_success(),
+        "script failed with exit code {}",
+        u8::from(result.exit_code)
+    );
+}
+
+fn run_on_multi_thread_runtime(script: &str) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("multi-thread runtime should build");
+    let local_set = tokio::task::LocalSet::new();
+
+    runtime.block_on(local_set.run_until(async {
+        tokio::time::timeout(TEST_TIMEOUT, run_script(script))
+            .await
+            .expect("script deadlocked");
+    }));
+}
+
+fn run_on_current_thread_runtime(script: &str) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread runtime should build");
+    let local_set = tokio::task::LocalSet::new();
+
+    runtime.block_on(local_set.run_until(async {
+        tokio::time::timeout(TEST_TIMEOUT, run_script(script))
+            .await
+            .expect("script deadlocked");
+    }));
+}
+
+fn run_current_thread_test_in_subprocess(
+    test_name: &str,
+    script: &str,
+) -> Result<(), std::io::Error> {
+    if std::env::var_os(CHILD_TEST_ENV).is_some_and(|value| value == test_name) {
+        run_on_current_thread_runtime(script);
+        return Ok(());
+    }
+
+    let mut child = std::process::Command::new(std::env::current_exe()?)
+        .arg(test_name)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env(CHILD_TEST_ENV, test_name)
+        .spawn()?;
+    let deadline = std::time::Instant::now() + TEST_TIMEOUT;
+
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return if status.success() {
+                Ok(())
+            } else {
+                Err(std::io::Error::other(
+                    "runtime regression subprocess failed",
+                ))
+            };
+        }
+
+        if std::time::Instant::now() >= deadline {
+            child.kill()?;
+            let _ = child.wait();
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "runtime regression subprocess deadlocked",
+            ));
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn read_process_substitution_completes_in_local_set_on_multi_thread_runtime() {
+    run_on_multi_thread_runtime(
+        r#"
+result=$(
+    while IFS= read -r line; do
+        printf '<%s>' "$line"
+    done < <(printf 'one\ntwo\n')
+)
+[[ $result == '<one><two>' ]]
+"#,
+    );
+}
+
+#[test]
+fn mapfile_process_substitution_completes_in_local_set_on_multi_thread_runtime() {
+    run_on_multi_thread_runtime(
+        r#"
+result=$(
+    mapfile -t lines < <(printf 'one\ntwo\n')
+    printf '%s' "${lines[*]}"
+)
+[[ $result == 'one two' ]]
+"#,
+    );
+}
+
+#[test]
+fn read_does_not_use_block_in_place_on_current_thread_runtime() {
+    run_current_thread_test_in_subprocess(
+        "read_does_not_use_block_in_place_on_current_thread_runtime",
+        r#"
+result=$(
+    while IFS= read -r line; do
+        printf '<%s>' "$line"
+    done < <(printf 'one\ntwo\n')
+)
+[[ $result == '<one><two>' ]]
+"#,
+    )
+    .expect("current-thread read scenario should complete");
+}
+
+#[test]
+fn mapfile_does_not_use_block_in_place_on_current_thread_runtime() {
+    run_current_thread_test_in_subprocess(
+        "mapfile_does_not_use_block_in_place_on_current_thread_runtime",
+        r#"
+result=$(
+    mapfile -t lines < <(printf 'one\ntwo\n')
+    printf '%s' "${lines[*]}"
+)
+[[ $result == 'one two' ]]
+"#,
+    )
+    .expect("current-thread mapfile scenario should complete");
+}

--- a/brush-core/src/openfiles.rs
+++ b/brush-core/src/openfiles.rs
@@ -102,44 +102,6 @@ pub fn null() -> Result<OpenFile, error::Error> {
     Ok(file.into())
 }
 
-/// Runs a closure that may block indefinitely on a descriptor, without parking the
-/// runtime worker it is running on.
-///
-/// Builtins that consume a descriptor (`mapfile`, `read`) read it synchronously, and
-/// they run inline on the task that invoked them. On the multi-threaded runtime that
-/// task is a worker thread, and a worker sitting in `read(2)` cannot poll the tasks
-/// held in its own queues. That deadlocks whenever one of those tasks is the producer
-/// responsible for closing the write end being read from.
-///
-/// `mapfile -t lines < <(cmd)` inside a command substitution is exactly that shape: the
-/// producer for `<(cmd)` is spawned from the very worker that then blocks, so it lands
-/// in that worker's LIFO slot, which other workers cannot steal. Nothing ever writes the
-/// data or drops the write end, so EOF never arrives and the read never returns.
-///
-/// [`tokio::task::block_in_place`] hands the current worker's queues to another worker
-/// before blocking, which keeps the producer runnable.
-#[cfg(any(unix, windows))]
-pub fn without_parking_worker<T>(f: impl FnOnce() -> T) -> T {
-    // `block_in_place` is only meaningful on the multi-threaded runtime, and panics on
-    // the current-thread one. Outside a runtime there is no worker to park.
-    if tokio::runtime::Handle::try_current()
-        .is_ok_and(|h| h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
-    {
-        tokio::task::block_in_place(f)
-    } else {
-        f()
-    }
-}
-
-/// Runs a closure that may block indefinitely on a descriptor.
-///
-/// This target only ever runs a current-thread runtime, so there is no worker to hand
-/// off to and the closure is run inline.
-#[cfg(not(any(unix, windows)))]
-pub fn without_parking_worker<T>(f: impl FnOnce() -> T) -> T {
-    f()
-}
-
 impl Clone for OpenFile {
     fn clone(&self) -> Self {
         match self {

--- a/brush-core/src/openfiles.rs
+++ b/brush-core/src/openfiles.rs
@@ -102,6 +102,44 @@ pub fn null() -> Result<OpenFile, error::Error> {
     Ok(file.into())
 }
 
+/// Runs a closure that may block indefinitely on a descriptor, without parking the
+/// runtime worker it is running on.
+///
+/// Builtins that consume a descriptor (`mapfile`, `read`) read it synchronously, and
+/// they run inline on the task that invoked them. On the multi-threaded runtime that
+/// task is a worker thread, and a worker sitting in `read(2)` cannot poll the tasks
+/// held in its own queues. That deadlocks whenever one of those tasks is the producer
+/// responsible for closing the write end being read from.
+///
+/// `mapfile -t lines < <(cmd)` inside a command substitution is exactly that shape: the
+/// producer for `<(cmd)` is spawned from the very worker that then blocks, so it lands
+/// in that worker's LIFO slot, which other workers cannot steal. Nothing ever writes the
+/// data or drops the write end, so EOF never arrives and the read never returns.
+///
+/// [`tokio::task::block_in_place`] hands the current worker's queues to another worker
+/// before blocking, which keeps the producer runnable.
+#[cfg(any(unix, windows))]
+pub fn without_parking_worker<T>(f: impl FnOnce() -> T) -> T {
+    // `block_in_place` is only meaningful on the multi-threaded runtime, and panics on
+    // the current-thread one. Outside a runtime there is no worker to park.
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|h| h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(f)
+    } else {
+        f()
+    }
+}
+
+/// Runs a closure that may block indefinitely on a descriptor.
+///
+/// This target only ever runs a current-thread runtime, so there is no worker to hand
+/// off to and the closure is run inline.
+#[cfg(not(any(unix, windows)))]
+pub fn without_parking_worker<T>(f: impl FnOnce() -> T) -> T {
+    f()
+}
+
 impl Clone for OpenFile {
     fn clone(&self) -> Self {
         match self {

--- a/brush-shell/tests/cases/compat/builtins/mapfile.yaml
+++ b/brush-shell/tests/cases/compat/builtins/mapfile.yaml
@@ -200,3 +200,48 @@ cases:
       declare -n ref=target
       mapfile -t -O 2 ref < <(echo -e "a\nb")
       declare -p target
+
+  #
+  # Process substitution inside command substitution.
+  #
+  # These deadlocked before the read was moved off the runtime worker: the
+  # producer for `<(...)` is spawned from the same worker that mapfile then
+  # blocked on, so it could never run to close the write end.
+  #
+  - name: "mapfile from process substitution inside command substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      x=$(mapfile -t arr < <(echo -e "a\nb"); echo "${arr[*]}")
+      echo "$x"
+
+  - name: "mapfile from process substitution in function in command substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      f() {
+        mapfile -t arr < <(echo -e "a\nb")
+        echo "${arr[*]}"
+      }
+      x=$(f)
+      echo "$x"
+
+  - name: "repeated mapfile from process substitution in command substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      f() {
+        mapfile -t a < <(echo one)
+        mapfile -t b < <(echo two)
+        echo "${a[*]} ${b[*]}"
+      }
+      x=$(f)
+      echo "$x"
+
+  - name: "mapfile from process substitution nested two command substitutions deep"
+    timeout_in_seconds: 10
+    stdin: |
+      g() {
+        mapfile -t arr < <(echo deep)
+        echo "${arr[*]}"
+      }
+      f() { echo "$(g)"; }
+      x=$(f)
+      echo "$x"

--- a/brush-shell/tests/cases/compat/builtins/read.yaml
+++ b/brush-shell/tests/cases/compat/builtins/read.yaml
@@ -390,3 +390,33 @@ cases:
       echo "arr[0]: ${arr[0]}"
       echo "arr[1]: ${arr[1]}"
       echo "arr[2]: ${arr[2]}"
+
+  #
+  # Process substitution inside command substitution.
+  #
+  # These deadlocked before the read was moved off the runtime worker: the
+  # producer for `<(...)` is spawned from the same worker that read then
+  # blocked on, so it could never run to close the write end.
+  #
+  - name: "while read loop fed by process substitution inside command substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      x=$(while read -r line; do echo "got $line"; done < <(echo -e "a\nb"))
+      echo "$x"
+
+  - name: "while read loop fed by process substitution in function in command substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      f() {
+        while read -r line; do
+          echo "got $line"
+        done < <(echo -e "a\nb")
+      }
+      x=$(f)
+      echo "$x"
+
+  - name: "read from process substitution inside command substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      x=$(read -r line < <(echo hello); echo "$line")
+      echo "$x"

--- a/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
+++ b/brush-shell/tests/cases/compat/word_expansion/command_substitution.yaml
@@ -251,3 +251,21 @@ cases:
 
       $($(:))
       echo "exit code: $?"
+
+  #
+  # A command substitution whose body redirects a builtin from a process
+  # substitution. The producer for `<(...)` is spawned from the worker running
+  # the substitution, so a builtin that reads it synchronously must not hold
+  # that worker while it waits.
+  #
+  - name: "Command substitution containing a builtin fed by process substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      x=$(mapfile -t arr < <(echo -e "one\ntwo"); echo "${arr[*]}")
+      echo "$x"
+
+  - name: "Command substitution containing an external command fed by process substitution"
+    timeout_in_seconds: 10
+    stdin: |
+      x=$(cat < <(echo hello))
+      echo "$x"


### PR DESCRIPTION
## Overview

Fix a deadlock when an in-process builtin reads from a process substitution inside a command substitution.

This change was made by GitHub Copilot at my direction.

## Details

Commands such as the following previously never returned:

```bash
x=$(mapfile -t lines < <(printf "one\ntwo\n"); echo "${lines[*]}")
```

The process-substitution producer is spawned on the async runtime, while `mapfile` and `read` synchronously consume its descriptor. Blocking the runtime worker can prevent the producer from running and closing the write end.

The synchronous descriptor reads now run through an awaited private `spawn_blocking` path on Unix and Windows. This works on multi-thread runtimes, current-thread runtimes, and inside `LocalSet`. Non-threaded targets such as WASM retain inline behavior. No new `brush-core` public API is introduced.

Regression coverage includes Bash-oracle compatibility cases plus Rust integration tests for `read` and `mapfile` under `LocalSet` and current-thread runtimes. Current-thread deadlock checks run in externally timed subprocesses so the test harness can terminate a regression.

## Testing

- `cargo test --package brush-builtins --test runtime_read_tests`
- `cargo test --test brush-compat-tests -- mapfile`
- `cargo test --test brush-compat-tests -- "while read loop fed by process substitution"`
- `cargo test --test brush-compat-tests -- "Command substitution containing"`
- `cargo clippy --package brush-core --package brush-builtins --package brush-shell --all-features --all-targets`
- `cargo check --package brush-builtins --target wasm32-wasip2`
- `cargo xtask check fmt`
- `cargo xtask test integration --coverage` (2697 passed; 2 unrelated environment failures because `which` is unavailable; report generated)
