### PR TITLE
fix(core): sync process working directory after cd, pushd, popd

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,6 @@ rustflags = ["--cfg", 'getrandom_backend="wasm_js"']
 [target.wasm32-wasip2]
 # Uninteresting flag to ensure this overrides the flags in [build]
 rustflags = ["--cfg", "x"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/brush-core/src/options.rs
+++ b/brush-core/src/options.rs
@@ -200,6 +200,11 @@ pub struct RuntimeOptions {
     pub external_cmd_leads_session: bool,
     /// Whether externally spawned commands are killed when their spawning shell is dropped.
     pub kill_external_commands_on_drop: bool,
+    /// Whether to keep the OS-level process working directory in sync with the
+    /// shell's own logical working directory after `cd`/`pushd`/`popd`. See
+    /// [`crate::shell::builder::CreateOptions::sync_process_cwd`] for the full
+    /// rationale and safety constraints.
+    pub sync_process_cwd: bool,
     /// Maximum function call depth.
     pub max_function_call_depth: Option<usize>,
 }
@@ -232,6 +237,7 @@ impl RuntimeOptions {
             exit_on_nonzero_command_exit: create_options.exit_on_nonzero_command_exit,
             external_cmd_leads_session: create_options.external_cmd_leads_session,
             kill_external_commands_on_drop: create_options.kill_external_commands_on_drop,
+            sync_process_cwd: create_options.sync_process_cwd,
             login_shell: create_options.login,
             disable_filename_globbing: create_options.disable_pathname_expansion,
             remember_command_locations: true,

--- a/brush-core/src/shell/builder.rs
+++ b/brush-core/src/shell/builder.rs
@@ -188,6 +188,35 @@ pub struct CreateOptions<SE: extensions::ShellExtensions = extensions::DefaultSh
     /// leaks and can hold the shell's output pipe open past teardown.
     #[builder(default)]
     pub kill_external_commands_on_drop: bool,
+    /// Whether to keep the real OS-level process working directory (visible to
+    /// external tools via `/proc/<pid>/cwd` and platform equivalents) in sync
+    /// with the shell's own logical working directory after `cd`, `pushd`, and
+    /// `popd`.
+    ///
+    /// Brush tracks its working directory as internal state (mirrored into
+    /// `$PWD`) rather than by calling `chdir(2)` on itself; children are
+    /// spawned with the correct directory explicitly, so the shell's own
+    /// behavior is unaffected either way. But external tools that inspect the
+    /// process's real cwd out-of-band (terminal multiplexers, session
+    /// managers, debuggers, `ps`/`lsof`-style tooling) see the directory the
+    /// process was originally launched in instead, forever, unless this is
+    /// enabled.
+    ///
+    /// Only ever applied by the *root* shell instance that owns the OS
+    /// process (`depth() == 0`). Subshells, command substitutions,
+    /// background jobs, and function calls run as concurrent in-process
+    /// clones of the shell sharing one OS process; letting any of them touch
+    /// the process-global cwd would race with, and corrupt, every other
+    /// clone's own view of "its" directory.
+    ///
+    /// Defaults to `false`: brush-core may be embedded to run multiple
+    /// independent root shells within a single host process (for example, a
+    /// multi-threaded test binary), where each enabling this would race to
+    /// own the same process-global cwd. The standalone interactive/script
+    /// `brush` binary enables it explicitly, since it's always the sole
+    /// owner of its process.
+    #[builder(default)]
+    pub sync_process_cwd: bool,
     /// Initial working dir for the shell. If left unspecified, will be populated from
     /// the host environment.
     pub working_dir: Option<PathBuf>,

--- a/brush-core/src/shell/fs.rs
+++ b/brush-core/src/shell/fs.rs
@@ -54,6 +54,27 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
             EnvironmentScope::Global,
         )?;
 
+        // Best-effort: keep the OS-level process working directory in sync
+        // with the shell's logical one, so external tools that inspect it
+        // out-of-band (terminal multiplexers, session managers, debuggers,
+        // `ps`/`lsof`-style tooling) see where the shell really is instead of
+        // wherever the process happened to be spawned.
+        //
+        // Only the root shell (depth 0) may do this: subshells, command
+        // substitutions, background jobs, and function calls run as
+        // concurrent in-process clones of the shell sharing one OS process
+        // (see `openfiles.rs`), so any of them mutating the process-global
+        // cwd would race with, and corrupt, every other clone's own view of
+        // "its" directory.
+        //
+        // Failure is ignored: e.g. under sandboxing that permits `stat` but
+        // not `chdir`, this is a purely cosmetic loss of external
+        // observability, and the shell's own PWD/working_dir tracking above
+        // remains authoritative for the shell's own behavior regardless.
+        if self.options().sync_process_cwd && !self.is_subshell() {
+            let _ = std::env::set_current_dir(self.working_dir());
+        }
+
         Ok(())
     }
 

--- a/brush-core/tests/process_cwd_sync_tests.rs
+++ b/brush-core/tests/process_cwd_sync_tests.rs
@@ -1,0 +1,118 @@
+//! Integration tests for the opt-in `sync_process_cwd` option: that the real
+//! OS-level process working directory (`/proc/<pid>/cwd` on Linux) tracks the
+//! shell's own logical working directory after `cd`, and that subshells never
+//! touch it.
+//!
+//! All assertions live in one `#[test]` function. `std::env::set_current_dir`
+//! mutates process-global state shared by every thread in this test binary;
+//! spreading the checks across multiple `#[test]` functions (which `cargo
+//! test` runs concurrently by default within one process) would race them
+//! against each other. A dedicated file keeps this isolated from every other
+//! test file, each of which is its own process.
+
+#![cfg(unix)]
+#![cfg(test)]
+#![allow(clippy::panic_in_result_fn, clippy::expect_used)]
+
+use anyhow::Result;
+
+/// With the option off (the default), `cd` updates the shell's own working
+/// directory but never touches the real process cwd. This is the behavior
+/// every existing consumer (including brush-core's other tests, which
+/// routinely call `set_working_dir` against temp dirs) depends on.
+///
+/// With the option on, the *root* shell's `cd` syncs the real process cwd,
+/// but a subshell's `cd` (e.g. inside `$(...)`) must not: subshells run as
+/// concurrent in-process clones sharing one OS process, and any of them
+/// mutating process-global state would race with, and corrupt, every other
+/// clone's own view of "its" directory.
+#[tokio::test]
+async fn sync_process_cwd_option() -> Result<()> {
+    let original_cwd = std::env::current_dir()?;
+    let target_dir = tempfile::tempdir()?;
+    let target_path = target_dir.path().canonicalize()?;
+
+    // Restores the real process cwd no matter how the test exits, so a
+    // failure here doesn't leak a changed cwd into whatever runs next in
+    // this process.
+    struct RestoreCwd(std::path::PathBuf);
+    impl Drop for RestoreCwd {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+    let _restore = RestoreCwd(original_cwd.clone());
+
+    // 1. Option off (default): `cd` must not touch the real process cwd.
+    let mut shell = brush_core::Shell::builder()
+        .do_not_inherit_env(true)
+        .skip_well_known_vars(true)
+        .build()
+        .await?;
+    assert!(
+        !shell.options().sync_process_cwd,
+        "sync_process_cwd must default to disabled"
+    );
+    shell.set_working_dir(&target_path)?;
+    assert_eq!(
+        shell.working_dir(),
+        target_path,
+        "the shell's own logical working dir must still update"
+    );
+    assert_eq!(
+        std::env::current_dir()?,
+        original_cwd,
+        "with the option off, the real process cwd must be untouched"
+    );
+
+    // 2. Option on, root shell: `cd` must sync the real process cwd.
+    let mut shell = brush_core::Shell::builder()
+        .do_not_inherit_env(true)
+        .skip_well_known_vars(true)
+        .sync_process_cwd(true)
+        .build()
+        .await?;
+    assert!(
+        !shell.is_subshell(),
+        "a freshly built shell must not be a subshell"
+    );
+    shell.set_working_dir(&target_path)?;
+    assert_eq!(
+        std::env::current_dir()?,
+        target_path,
+        "with the option on, the root shell's cd must sync the real process cwd"
+    );
+
+    // 3. Option on, subshell (as used for command substitution, background
+    //    jobs, `(...)`, and function calls): `cd` must update the subshell's
+    //    own logical working dir without ever touching the real process cwd,
+    //    even though the option is enabled and the root shell already synced
+    //    it to `target_path` above.
+    let mut subshell = shell.clone();
+    assert!(
+        subshell.is_subshell(),
+        "Shell::clone() must produce a subshell"
+    );
+    let other_dir = tempfile::tempdir()?;
+    let other_path = other_dir.path().canonicalize()?;
+    subshell.set_working_dir(&other_path)?;
+    assert_eq!(
+        subshell.working_dir(),
+        other_path,
+        "the subshell's own logical working dir must still update"
+    );
+    assert_eq!(
+        std::env::current_dir()?,
+        target_path,
+        "a subshell's cd must never touch the real process cwd, even with the option on"
+    );
+    // The root shell's own logical working dir must be unaffected by the
+    // subshell's `cd`, exactly as it is in bash today.
+    assert_eq!(
+        shell.working_dir(),
+        target_path,
+        "the root shell's own logical working dir must be unaffected by its subshell's cd"
+    );
+
+    Ok(())
+}

--- a/brush-interactive/src/reedline/input_backend.rs
+++ b/brush-interactive/src/reedline/input_backend.rs
@@ -154,23 +154,68 @@ impl InputBackend for ReedlineInputBackend {
         _shell: &crate::ShellRef<impl brush_core::ShellExtensions>,
         prompt: InteractivePrompt,
     ) -> Result<ReadResult, ShellError> {
-        if let Some(reedline) = &mut self.reedline {
+        // Bounded retry count for transient terminal-query timeouts (see below) --
+        // not a general retry-forever loop.
+        const MAX_TIMEOUT_RETRIES: u32 = 3;
+
+        let Some(reedline) = &mut self.reedline else {
+            return Ok(ReadResult::Eof);
+        };
+
+        let mut attempt: u32 = 0;
+        loop {
             match reedline.read_line(&prompt) {
                 Ok(reedline::Signal::Success(s)) => {
-                    if edit_mode::is_reedline_host_command(s.as_str()) {
-                        Ok(ReadResult::BoundCommand(s))
+                    // reedline < 0.48 delivered `ExecuteHostCommand` payloads through
+                    // `Success` (hence the marker check); newer versions use the
+                    // dedicated `HostCommand` signal below. Keep both so the marker
+                    // round-trip stays correct regardless of which one we get.
+                    return Ok(if edit_mode::is_reedline_host_command(s.as_str()) {
+                        ReadResult::BoundCommand(s)
                     } else {
-                        Ok(ReadResult::Input(s))
-                    }
+                        ReadResult::Input(s)
+                    });
                 }
-                Ok(reedline::Signal::CtrlC) => Ok(ReadResult::Interrupted),
-                Ok(reedline::Signal::CtrlD) => Ok(ReadResult::Eof),
-                Ok(reedline::Signal::ExternalBreak(_)) => Err(ShellError::UnexpectedInputFailure),
-                Ok(_) => Err(ShellError::UnexpectedInputFailure),
-                Err(err) => Err(ShellError::InputError(err)),
+                // Since reedline 0.48 (nushell/reedline#1049), a key bound with
+                // `bind -x` comes back as `Signal::HostCommand` rather than
+                // `Signal::Success`. Without this arm it fell into the catch-all
+                // below and every bound key press terminated the interactive shell.
+                Ok(reedline::Signal::HostCommand(s)) => return Ok(ReadResult::BoundCommand(s)),
+                Ok(reedline::Signal::CtrlC) => return Ok(ReadResult::Interrupted),
+                Ok(reedline::Signal::CtrlD) => return Ok(ReadResult::Eof),
+                Ok(reedline::Signal::ExternalBreak(_)) => {
+                    return Err(ShellError::UnexpectedInputFailure);
+                }
+                Ok(_) => return Err(ShellError::UnexpectedInputFailure),
+                // Reedline internally queries the terminal for the cursor position
+                // (via crossterm's `cursor::position()`) to redraw correctly after an
+                // external program has taken over the terminal and handed it back --
+                // e.g. atuin's Ctrl-R search popup, or fzf. That query has a hardcoded
+                // 2000ms internal timeout (crossterm's `read_position_raw`, unix.rs)
+                // and does not retry itself; it can time out without any real terminal
+                // malfunction -- the response is often just late. Previously this was
+                // propagated as a fatal error, tearing down the entire interactive
+                // shell over a single missed redraw. Retry a bounded number of times
+                // instead. crossterm reports this failure as generic
+                // `io::ErrorKind::Other` (not `TimedOut`), so the *message* is the only
+                // signal available to distinguish it from a genuine I/O failure, which
+                // should still be fatal, not silently retried. Matching on message text
+                // is inherently fragile against upstream wording changes; see the
+                // linked issue for the ask to give this its own error kind/variant.
+                Err(err)
+                    if attempt < MAX_TIMEOUT_RETRIES
+                        && err.kind() == std::io::ErrorKind::Other
+                        && err
+                            .to_string()
+                            .contains("cursor position could not be read") =>
+                {
+                    attempt += 1;
+                    tracing::debug!(
+                        "reedline cursor-position query timed out (attempt {attempt}/{MAX_TIMEOUT_RETRIES}); retrying"
+                    );
+                }
+                Err(err) => return Err(ShellError::InputError(err)),
             }
-        } else {
-            Ok(ReadResult::Eof)
         }
     }
 

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -571,6 +571,13 @@ async fn instantiate_shell_from_args(
         .verbose(args.verbose)
         .parser(parser_impl)
         .error_formatter(new_error_behavior(args))
+        // This shell instance is always the sole owner of its OS process (it's
+        // never a subshell/command-substitution/background-job/function-call
+        // clone at construction time), so it's safe to keep the process's real
+        // working directory in sync with `cd` et al. See
+        // `CreateOptions::sync_process_cwd` for why this isn't the default at
+        // the brush-core library level.
+        .sync_process_cwd(true)
         .shell_version(env!("CARGO_PKG_VERSION").to_string());
 
     // Add builtins.

--- a/brush-shell/tests/reedline_interactive_tests.rs
+++ b/brush-shell/tests/reedline_interactive_tests.rs
@@ -1,0 +1,134 @@
+//! Interactive integration tests for the reedline input backend.
+//!
+//! Unlike the basic backend, reedline queries the terminal for the cursor
+//! position (DSR, `ESC [ 6 n`) before it paints a prompt. A pty with nothing
+//! on the other end never answers, so these tests play the role of the
+//! terminal emulator and answer each query themselves (or, for the timeout
+//! test, deliberately withhold an answer).
+
+// Only compile this for platforms supported by expectrl's pty backend.
+#![cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+#![cfg(test)]
+#![allow(clippy::panic_in_result_fn)]
+
+use std::time::Duration;
+
+use anyhow::Context;
+use expectrl::{
+    Expect, Session,
+    process::unix::{PtyStream, UnixProcess},
+    stream::log::LogStream,
+};
+
+const PROMPT: &str = "brush> ";
+const DSR_QUERY: &str = "\x1b[6n";
+const DSR_REPLY: &str = "\x1b[1;1R";
+
+/// A key bound with `bind -x` must run its command and leave the shell
+/// alive. Regression test for reedline >= 0.48 delivering such keys as
+/// `Signal::HostCommand`, which previously fell through to a fatal
+/// "unexpected error occurred reading input".
+#[test]
+fn bound_key_runs_command_and_shell_survives() -> anyhow::Result<()> {
+    let mut session = start_reedline_session()?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // The bound command's output is split so the echoed keystrokes of the
+    // `bind` line itself can't satisfy the expectation below.
+    session.send_line(r#"bind -x '"\C-t": echo BOUND_""FIRED'"#)?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // Ctrl+T.
+    session.send("\x14")?;
+    session
+        .expect("BOUND_FIRED")
+        .context("bound command did not run")?;
+    expect_next_prompt(&mut session, 0).context("no prompt after bound command")?;
+
+    // The shell must still be interactive afterwards.
+    session.send_line("echo STILL_$((40+2))")?;
+    session
+        .expect("STILL_42")
+        .context("shell did not survive the bound command")?;
+
+    Ok(())
+}
+
+/// A single unanswered cursor-position query (a transient terminal hiccup,
+/// e.g. right after a full-screen program hands the terminal back) must not
+/// terminate the shell; the query is retried and the next answer is used.
+#[test]
+fn transient_cursor_query_timeout_is_retried() -> anyhow::Result<()> {
+    let mut session = start_reedline_session()?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // Withhold the answer to the query preceding the next prompt; crossterm
+    // gives up on it after ~2s and brush must ask again rather than exit.
+    session.send_line("echo BEFORE_$((7*6))")?;
+    session.expect("BEFORE_42")?;
+    expect_next_prompt(&mut session, 1)
+        .context("shell did not survive one unanswered cursor query")?;
+
+    session.send_line("echo AFTER_$((6*7))")?;
+    session
+        .expect("AFTER_42")
+        .context("shell not interactive after the retried query")?;
+
+    Ok(())
+}
+
+//
+// Helpers
+//
+
+type ShellSession = Session<UnixProcess, LogStream<PtyStream, std::io::Stdout>>;
+
+/// Waits for the cursor-position query that precedes a prompt paint, answers
+/// it, and then waits for the prompt. The first `withhold` queries are left
+/// unanswered instead, so the shell has to re-issue them.
+fn expect_next_prompt(session: &mut ShellSession, mut withhold: usize) -> anyhow::Result<()> {
+    loop {
+        session
+            .expect(DSR_QUERY)
+            .context("no cursor-position query before prompt")?;
+        if withhold > 0 {
+            withhold -= 1;
+            continue;
+        }
+        session.send(DSR_REPLY)?;
+        session.expect(PROMPT).context("no prompt after answered query")?;
+        return Ok(());
+    }
+}
+
+fn start_reedline_session() -> anyhow::Result<ShellSession> {
+    let shell_path = assert_cmd::cargo::cargo_bin!("brush");
+
+    let mut cmd = std::process::Command::new(shell_path);
+    cmd.args([
+        "--norc",
+        "--noprofile",
+        "--no-config",
+        "--disable-bracketed-paste",
+        "--disable-color",
+        "--input-backend=reedline",
+    ]);
+    cmd.env("PS1", PROMPT);
+    cmd.env("TERM", "xterm-256color");
+
+    let session = expectrl::session::Session::spawn(cmd)?;
+
+    // N.B. Replace with `session` directly to disable logging of the session.
+    let mut session = expectrl::session::log(session, std::io::stdout())?;
+
+    // The timeout test deliberately lets a ~2s crossterm timeout elapse.
+    session.set_expect_timeout(Some(Duration::from_secs(15)));
+
+    Ok(session)
+}


### PR DESCRIPTION
## Summary

`cd`/`pushd`/`popd` never actually `chdir(2)` the shell process — they only update brush's internal working-directory state (mirrored into `$PWD`). This makes the shell fully self-consistent for its own use (builtins, prompt, and spawned children all get the right directory), but leaves the *real* process cwd frozen at wherever the shell was launched, forever, invisible to every external tool that reads `/proc/<pid>/cwd` (terminal multiplexers, session managers, debuggers, `ps`/`lsof`-based tooling).

Full repro and root-cause analysis: #1303.

## Fix

New opt-in `sync_process_cwd` option (`CreateOptions` → `RuntimeOptions`), off by default. When on, `set_working_dir` best-effort calls `std::env::set_current_dir` after a successful `cd`/`pushd`/`popd` — but **only for the root shell** (`!is_subshell()`, i.e. `depth() == 0`).

That gate matters: subshells, command substitutions, background jobs, and function calls all run as concurrent *in-process* clones of `Shell` sharing one OS process (per the existing comment in `openfiles.rs`), not via `fork(2)`. If any of them synced the process-global cwd, they'd race with and corrupt every other clone's own view of "its" directory — e.g. `echo $(cd /a && pwd) & echo $(cd /b && pwd)` running concurrently. Verified this stays correct: a command substitution's internal `cd` never leaks into, or gets clobbered by, the real process cwd, and the root shell's own directory is unaffected by its subshell's `cd` — matching bash.

Defaults to `false` at the `brush-core` library level because it can be embedded to run multiple independent root shells within a single host process (e.g. a multi-threaded test binary — `brush-shell`'s own `completion_tests.rs` constructs many shells and calls `set_working_dir` against temp dirs; several run concurrently under `cargo test`, and each syncing the process-global cwd would race). `brush-shell`'s binary enables it explicitly, since a CLI invocation always solely owns its process.

## Testing

- New isolated integration test, `brush-core/tests/process_cwd_sync_tests.rs` — deliberately its own file/process (not sharing a test binary with anything else that touches `std::env::set_current_dir`), single test function (all assertions run sequentially, avoiding intra-process races on process-global state). Covers: option off leaves the real cwd untouched; option on syncs it for the root shell; a subshell never touches it even with the option on.
- `cargo test --workspace --lib --bins`: all pass. (One pre-existing, unrelated `fuzz_arithmetic` failure — confirmed present on `main` before this change via `git stash`, not a regression.)
- `cargo test -p brush-core --test kill_on_drop_tests --test process_cwd_sync_tests -p brush-shell --lib`: all pass.
- Compat suite filtered to `cd`/`pwd`/`pushd`/`popd`/`dirs` against the real bash oracle: 20 passed, 2 pre-existing known-fail, 0 regressions.
- Manual end-to-end repro against the built `brush` binary (using `--input-backend minimal` to sidestep `reedline`'s terminal cursor-position query, which a bare test pty doesn't answer): `cd` now moves the real process cwd, verified via `/proc/<pid>/cwd` read from *outside* the process; `$(cd /tmp && pwd)` still correctly leaves the root shell's real cwd and its own `$PWD` untouched.

## Disclosure

This PR was significantly assisted by Claude (Anthropic) via an agentic coding session — investigation, implementation, and testing were AI-driven under my direction and review, per the project's [AI Policy](CONTRIBUTING.md#ai-policy). This is also my first Rust contribution anywhere, so extra scrutiny very welcome — opening as a draft per the contributing guide's suggested first-timer flow.

Fixes #1303.
