### PR TITLE
feat(builtins): implement declare/local -I; honor += in declarations

### DIFF
--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -5,7 +5,6 @@ use std::{io::Write, sync::LazyLock};
 use brush_core::{
     ErrorKind, ExecutionResult, builtins,
     env::{self, EnvironmentLookup, EnvironmentScope},
-    error,
     parser::ast,
     variables::{
         self, ArrayLiteral, ShellValue, ShellValueLiteral, ShellValueUnsetType, ShellVariable,
@@ -139,10 +138,6 @@ impl builtins::Command for DeclareCommand {
             return Ok(ExecutionResult::general_error());
         }
 
-        if self.locals_inherit_from_prev_scope {
-            return error::unimp("declare -I");
-        }
-
         let mut result = ExecutionResult::success();
         if !self.declarations.is_empty() {
             for declaration in &self.declarations {
@@ -253,7 +248,7 @@ impl DeclareCommand {
         }
 
         // Extract the variable name and the initial value being assigned (if any).
-        let (name, assigned_index, initial_value, name_is_array) =
+        let (name, assigned_index, initial_value, name_is_array, append) =
             Self::declaration_to_name_and_value(declaration)?;
 
         // Special-case: `local -`
@@ -281,6 +276,41 @@ impl DeclareCommand {
             EnvironmentLookup::Anywhere
         };
 
+        // `local -I x[=v]` / `declare -I` (bash 5.0+): the new local inherits
+        // value and attributes from the nearest same-name variable in an
+        // enclosing scope instead of starting unset; `+=` appends to the
+        // inherited value. With no same-name variable anywhere, fall through
+        // to ordinary creation.
+        if self.locals_inherit_from_prev_scope && create_var_local {
+            let inherited = context
+                .shell
+                .env()
+                .get_using_policy(name.as_str(), EnvironmentLookup::Anywhere)
+                .cloned();
+
+            if let Some(mut var) = inherited {
+                self.apply_attributes_before_update(&mut var)?;
+
+                if let Some(initial_value) = initial_value {
+                    var.assign(initial_value, append || assigned_index.is_some())?;
+                }
+
+                if context.shell.options().export_variables_on_modification
+                    && !var.value().is_array()
+                {
+                    var.export();
+                }
+
+                self.apply_attributes_after_update(&mut var, verb)?;
+
+                context
+                    .shell
+                    .env_mut()
+                    .add(name, var, EnvironmentScope::Local)?;
+                return Ok(true);
+            }
+        }
+
         // Look up the variable.
         if let Some(var) = context
             .shell
@@ -297,8 +327,9 @@ impl DeclareCommand {
             self.apply_attributes_before_update(var)?;
 
             if let Some(initial_value) = initial_value {
-                // We append if the declaration included an explicit index.
-                var.assign(initial_value, assigned_index.is_some())?;
+                // We append for `name+=value`, or if the declaration included
+                // an explicit index.
+                var.assign(initial_value, append || assigned_index.is_some())?;
             }
 
             self.apply_attributes_after_update(var, verb)?;
@@ -318,7 +349,7 @@ impl DeclareCommand {
             self.apply_attributes_before_update(&mut var)?;
 
             if let Some(initial_value) = initial_value {
-                var.assign(initial_value, false)?;
+                var.assign(initial_value, append)?;
             }
 
             if context.shell.options().export_variables_on_modification && !var.value().is_array() {
@@ -339,13 +370,24 @@ impl DeclareCommand {
         Ok(true)
     }
 
+    #[expect(clippy::type_complexity)]
     fn declaration_to_name_and_value(
         declaration: &brush_core::CommandArg,
-    ) -> Result<(String, Option<String>, Option<ShellValueLiteral>, bool), brush_core::Error> {
+    ) -> Result<
+        (
+            String,
+            Option<String>,
+            Option<ShellValueLiteral>,
+            bool,
+            bool,
+        ),
+        brush_core::Error,
+    > {
         let name;
         let assigned_index;
         let initial_value;
         let name_is_array;
+        let append;
 
         match declaration {
             brush_core::CommandArg::String(s) => {
@@ -377,6 +419,7 @@ impl DeclareCommand {
                     name_is_array = false;
                 }
                 initial_value = None;
+                append = false;
             }
             brush_core::CommandArg::Assignment(assignment) => {
                 match &assignment.name {
@@ -393,6 +436,8 @@ impl DeclareCommand {
                         assigned_index = Some(index.to_owned());
                     }
                 }
+
+                append = assignment.append;
 
                 match &assignment.value {
                     ast::AssignmentValue::Scalar(s) => {
@@ -421,7 +466,7 @@ impl DeclareCommand {
             }
         }
 
-        Ok((name, assigned_index, initial_value, name_is_array))
+        Ok((name, assigned_index, initial_value, name_is_array, append))
     }
 
     fn display_matching_env_declarations(

--- a/brush-shell/tests/cases/compat/builtins/declare.yaml
+++ b/brush-shell/tests/cases/compat/builtins/declare.yaml
@@ -162,7 +162,6 @@ cases:
       echo "var: ${var}"
 
   - name: "Appending via declare"
-    known_failure: true # TODO: declare improvements required
     stdin: |
       declare var="value"
       declare -p var

--- a/brush-shell/tests/cases/compat/variables.yaml
+++ b/brush-shell/tests/cases/compat/variables.yaml
@@ -42,3 +42,75 @@ cases:
       arr2=(hello world)
       echo "${#arr2[5]}"
       echo "${#arr2[0]}"
+
+  - name: "local -I inherits from enclosing scope"
+    stdin: |
+      g=global-value
+      f() {
+          local -I g
+          echo "[$g]"
+      }
+      f
+      echo "[$g]"
+
+  - name: "local -I with append"
+    stdin: |
+      v=base
+      f() {
+          local -I v+=" +more"
+          echo "[$v]"
+      }
+      f
+      echo "[$v]"
+
+  - name: "local -I combined flags (-Ix)"
+    stdin: |
+      f() {
+          local -Ix e
+          declare -p e
+      }
+      f
+
+  - name: "local -I without an enclosing variable falls through to normal creation"
+    stdin: |
+      f() {
+          local -I nosuch="fresh"
+          echo "[$nosuch]"
+      }
+      f
+
+  - name: "local -I inherits from enclosing scope"
+    stdin: |
+      g=global-value
+      f() {
+          local -I g
+          echo "[$g]"
+      }
+      f
+      echo "[$g]"
+
+  - name: "local -I with append"
+    stdin: |
+      v=base
+      f() {
+          local -I v+=" +more"
+          echo "[$v]"
+      }
+      f
+      echo "[$v]"
+
+  - name: "local -I combined flags (-Ix)"
+    stdin: |
+      f() {
+          local -Ix e
+          declare -p e
+      }
+      f
+
+  - name: "local -I without an enclosing variable falls through to normal creation"
+    stdin: |
+      f() {
+          local -I nosuch="fresh"
+          echo "[$nosuch]"
+      }
+      f


### PR DESCRIPTION
Implements `declare`/`local -I` (bash 5.0+): a local declaration inherits value and attributes from the nearest same-name variable in an enclosing scope instead of starting unset. Combined with `+=`, the assignment appends to the inherited value. With no same-name variable anywhere it falls through to ordinary creation.

While there: the parser already records `+=` on assignments, but `declare`/`local` ignored it and *replaced* — declarations now honor the append flag (the existing "Appending via declare" oracle case is un-marked as known_failure).

## Motivation

Real-world ebuild shell scripts use both:

- `go-env.eclass`: `local -I $(all-flag-vars)`
- `cargo.eclass`: `local -Ix CARGO_TARGET_*_RUSTFLAGS+=" ..."`

Gentoo ebuilds hitting these failed outright at declaration time (`local: not yet implemented: declare -I`), which is what surfaced this.

## Testing

- 4 new oracle cases in `variables.yaml` (inherit, append, combined `-Ix`, no-inherit fallthrough), verified byte-for-byte against real bash
- "Appending via declare" oracle case now passes
- Full suite green apart from one pre-existing flake (`run_suspend_and_fg`, fails on clean `main` here too)

Draft for review — happy to split the `+=` part into its own PR if preferred.