### PR TITLE
#972 rebased onto main, plus `exec` builtin filter coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "procfs",
  "rlimit",
  "strum 0.28.0",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tracing",

--- a/brush-builtins/Cargo.toml
+++ b/brush-builtins/Cargo.toml
@@ -170,4 +170,6 @@ procfs = "0.18.0"
 
 [dev-dependencies]
 anyhow = "1.0.102"
+tempfile = "3.27.0"
+tokio = { version = "1.53.1", features = ["macros", "rt-multi-thread"] }
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }

--- a/brush-builtins/src/exec.rs
+++ b/brush-builtins/src/exec.rs
@@ -1,7 +1,11 @@
 use clap::Parser;
 use std::{borrow::Cow, os::unix::process::CommandExt};
 
-use brush_core::{ErrorKind, ExecutionExitCode, ExecutionResult, builtins, commands};
+use brush_core::{
+    ErrorKind, ExecutionExitCode, ExecutionResult, builtins, commands,
+    filter::{CmdExecFilter as _, ExternalCmdParams, ExternalCommand, PreFilterResult},
+    results::ExecutionWaitResult,
+};
 
 /// Exec the provided command.
 #[derive(Parser)]
@@ -64,11 +68,66 @@ impl builtins::Command for ExecCommand {
             argv0 = Cow::Owned(std::format!("-{argv0}"));
         }
 
+        // `exec` replaces this process image outright, so it never reaches
+        // `commands::execute_external_command` and is not covered by the filtering applied
+        // there. Run the same `pre_external_cmd` filter here, before `cmd.exec()`.
+        //
+        // The program is resolved first so the filter is shown the executable that will
+        // actually run, matching what `execute_via_external` passes it; otherwise the OS
+        // would redo its own `PATH` search against the child environment, which need not
+        // match the shell's.
+        let resolved = commands::resolve_external_program(context.shell, &self.args[0]);
+        let program = resolved
+            .as_deref()
+            .unwrap_or_else(|| std::path::Path::new(self.args[0].as_str()));
+
+        let mut ext_cmd = ExternalCommand::new(program);
+        for arg in &self.args[1..] {
+            ext_cmd.arg(arg);
+        }
+
+        let filter_params = ExternalCmdParams::new(context.shell, ext_cmd);
+        let ext_cmd = match context
+            .shell
+            .cmd_exec_filter()
+            .pre_external_cmd(filter_params)
+            .await
+        {
+            PreFilterResult::Continue(params) => params.command,
+            // A filter short-circuited. A denial is the `Err` case and is the point of this
+            // hook; an `Ok` spawn result is unusual here but is honored rather than dropped.
+            PreFilterResult::Return(output) => {
+                let spawn_result = output?;
+                return match spawn_result.wait().await? {
+                    ExecutionWaitResult::Completed(result) => Ok(result),
+                    ExecutionWaitResult::Stopped(_) => brush_core::error::unimp(
+                        "filter returned a stopped process from the exec builtin",
+                    ),
+                };
+            }
+            // `PreFilterResult` is `#[non_exhaustive]`. This site is about to replace the
+            // process image, so an unrecognized decision must fail closed and loudly rather
+            // than be guessed at as "continue".
+            _ => {
+                return brush_core::error::unimp(
+                    "unrecognized pre_external_cmd filter result at the exec builtin; \
+                     refusing to replace the process image",
+                );
+            }
+        };
+
+        let program_to_launch = ext_cmd.program().to_string_lossy().into_owned();
+        let filtered_args: Vec<String> = ext_cmd
+            .args()
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
         let mut cmd = commands::compose_std_command(
             &context,
-            &self.args[0],
+            program_to_launch.as_str(),
             argv0.as_str(),
-            &self.args[1..],
+            filtered_args.as_slice(),
             self.empty_environment,
         )?;
 

--- a/brush-builtins/tests/exec_filter_tests.rs
+++ b/brush-builtins/tests/exec_filter_tests.rs
@@ -1,0 +1,240 @@
+//! Regression tests for the `exec` builtin's authorization.
+//!
+//! `exec` outside a subshell replaces the shell process image. It composes its
+//! `std::process::Command` directly and calls `CommandExt::exec`, so it never reaches
+//! `commands::execute_external_command` and is not covered by that path's authorization.
+//! If the builtin fails to authorize, the process is *replaced* — a broken implementation
+//! would silently run the denied program and destroy the test runner along with it.
+//!
+//! Every case therefore runs in a dedicated child process: this same test binary, re-invoked
+//! with `CHILD_DIR_ENV` set, running only `exec_interceptor_child`. The child records what
+//! the interceptor saw and exits with the shell's status; the parent asserts on the record,
+//! the exit status, and the absence of the side effect the denied program would have had. If
+//! authorization regresses, the child is replaced by `touch`, the marker appears, and the
+//! parent fails.
+#![cfg(all(unix, feature = "builtin.exec"))]
+#![cfg(test)]
+#![allow(clippy::panic_in_result_fn)]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use brush_core::extensions::DefaultErrorFormatter;
+use brush_core::extensions::ShellExtensionsImpl;
+use brush_core::filter::{CmdExecFilter, ExternalCmdParams, NoOpSourceFilter, PreFilterResult};
+
+/// Set on the child to the scratch directory it should work in.
+const CHILD_DIR_ENV: &str = "BRUSH_EXEC_INTERCEPTOR_CHILD_DIR";
+/// Set on the child to the shell script it should run.
+const CHILD_SCRIPT_ENV: &str = "BRUSH_EXEC_INTERCEPTOR_CHILD_SCRIPT";
+/// Placeholder in a test script for the marker path the denied program would create.
+const MARKER: &str = "@MARKER@";
+
+/// Denies every external command, appending one tab-separated line per consultation to
+/// `record`. `Clone`/`Default` are required by `CmdExecFilter`; the shared state is behind
+/// `Arc` so the clones brush makes all record into one place.
+#[derive(Clone, Default)]
+struct RecordingDenier {
+    record: PathBuf,
+    seen: Arc<Mutex<usize>>,
+}
+
+/// Wires the denier in as the shell's command-execution filter.
+type DenyingExtensions =
+    ShellExtensionsImpl<DefaultErrorFormatter, RecordingDenier, NoOpSourceFilter>;
+
+impl CmdExecFilter for RecordingDenier {
+    async fn pre_external_cmd<'a, SE: brush_core::extensions::ShellExtensions>(
+        &self,
+        params: ExternalCmdParams<'a, SE>,
+    ) -> PreFilterResult<ExternalCmdParams<'a, SE>, brush_core::filter::ExternalCmdOutput> {
+        *self.seen.lock().unwrap() += 1;
+        let line = format!(
+            "{}\t{}\n",
+            params.command.program().to_string_lossy(),
+            params
+                .command
+                .args()
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        // Append, so a second (unexpected) consultation is visible to the parent.
+        let existing = std::fs::read_to_string(&self.record).unwrap_or_default();
+        std::fs::write(&self.record, existing + &line).unwrap();
+
+        PreFilterResult::Return(Err(brush_core::ErrorKind::FailedToExecuteCommand(
+            params.command.program().to_string_lossy().into_owned(),
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "denied by test policy",
+            ),
+        )
+        .into()))
+    }
+}
+
+/// The child. A no-op in an ordinary test run; does the work only when re-invoked with
+/// `CHILD_DIR_ENV` set.
+#[tokio::test]
+async fn exec_interceptor_child() {
+    let (Ok(dir), Ok(script)) = (
+        std::env::var(CHILD_DIR_ENV),
+        std::env::var(CHILD_SCRIPT_ENV),
+    ) else {
+        return;
+    };
+    let dir = PathBuf::from(dir);
+
+    let policy = RecordingDenier {
+        record: dir.join("record"),
+        seen: Arc::new(Mutex::new(0)),
+    };
+
+    let builtins =
+        brush_builtins::default_builtins::<DenyingExtensions>(brush_builtins::BuiltinSet::BashMode);
+
+    let mut shell = brush_core::Shell::builder_with_extensions::<DenyingExtensions>()
+        .cmd_exec_filter(policy.clone())
+        .builtins(builtins)
+        .do_not_inherit_env(true)
+        .skip_well_known_vars(true)
+        .build()
+        .await
+        .unwrap();
+
+    shell
+        .set_env_global(
+            "PATH",
+            brush_core::variables::ShellVariable::new("/bin:/usr/bin"),
+        )
+        .unwrap();
+
+    let params = shell.default_exec_params();
+    let code = match shell
+        .run_string(&script, &brush_core::SourceInfo::default(), &params)
+        .await
+    {
+        Ok(result) => u8::from(result.exit_code),
+        // A denial surfaces as an error out of the builtin; report what the shell would.
+        Err(e) => u8::from(brush_core::ExecutionExitCode::from(&e)),
+    };
+
+    std::fs::write(dir.join("seen"), policy.seen.lock().unwrap().to_string()).unwrap();
+    // Exit explicitly: reaching here at all is the point, and the status is an assertion.
+    std::process::exit(i32::from(code));
+}
+
+struct ChildRun {
+    exit_code: Option<i32>,
+    consultations: usize,
+    record: Vec<Vec<String>>,
+    dir: tempfile::TempDir,
+}
+
+impl ChildRun {
+    fn marker(&self) -> PathBuf {
+        self.dir.path().join("marker")
+    }
+}
+
+/// Runs `script` in a dedicated child process. The `MARKER` placeholder in the script is
+/// replaced with a path inside the child's scratch directory that nothing else creates.
+fn run_in_child(script: &str) -> Result<ChildRun> {
+    let dir = tempfile::tempdir()?;
+    let marker = dir.path().join("marker");
+    let script = script.replace(MARKER, &marker.display().to_string());
+
+    let output = std::process::Command::new(std::env::current_exe()?)
+        .args(["exec_interceptor_child", "--exact", "--test-threads=1"])
+        .env(CHILD_DIR_ENV, dir.path())
+        .env(CHILD_SCRIPT_ENV, &script)
+        .output()?;
+
+    let record = std::fs::read_to_string(dir.path().join("record"))
+        .unwrap_or_default()
+        .lines()
+        .map(|l| l.split('\t').map(str::to_string).collect())
+        .collect();
+    let consultations = std::fs::read_to_string(dir.path().join("seen"))
+        .unwrap_or_default()
+        .trim()
+        .parse()
+        .unwrap_or(0);
+
+    Ok(ChildRun {
+        exit_code: output.status.code(),
+        consultations,
+        record,
+        dir,
+    })
+}
+
+/// The load-bearing case. `exec` must consult the interceptor and refuse, rather than
+/// replacing the process with the denied program.
+#[test]
+fn denied_exec_builtin_does_not_replace_the_process() -> Result<()> {
+    let run = run_in_child("exec /usr/bin/touch @MARKER@")?;
+
+    assert!(
+        !run.marker().exists(),
+        "the denied program ran and replaced the shell: {} exists",
+        run.marker().display()
+    );
+    assert_eq!(
+        run.exit_code,
+        Some(126),
+        "a denied exec should report 'cannot execute' (126); record: {:?}",
+        run.record
+    );
+    assert_eq!(
+        run.consultations, 1,
+        "the interceptor should be consulted exactly once; saw {:?}",
+        run.record
+    );
+    Ok(())
+}
+
+/// A bare name reaches the filter already resolved.
+///
+/// N.B. The filter cannot also see the spelling the user typed: `ExternalCmdParams` carries
+/// only an `ExternalCommand` (program, args, envs, cwd), with no `command_name` and no
+/// `argv0`. So a policy cannot distinguish `exec /usr/bin/touch` from
+/// `exec -a impostor /usr/bin/touch`, and cannot match on what was written. Tests for those
+/// two distinctions were dropped from this port because the mechanism does not expose them
+/// -- that is feedback for #972, not something to assert around.
+#[test]
+fn exec_request_separates_command_name_from_resolved_program() -> Result<()> {
+    let run = run_in_child("exec touch @MARKER@")?;
+
+    assert!(!run.marker().exists());
+    assert_eq!(run.record.len(), 1, "record: {:?}", run.record);
+    let entry = &run.record[0];
+    // Which directory wins depends on PATH order and the platform's layout, so assert the
+    // contract -- resolved and absolute -- rather than one distribution's answer.
+    assert!(
+        Path::new(&entry[0]).is_absolute() && entry[0].ends_with("/touch"),
+        "the filter should see the resolved absolute executable, got {:?}",
+        entry[0]
+    );
+    Ok(())
+}
+
+/// Sanity: the fixture really can create the marker when nothing denies it, so the
+/// assertions above are not passing for the wrong reason.
+#[test]
+fn fixture_can_create_the_marker_when_unconfined() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let marker = dir.path().join("marker");
+    let status = std::process::Command::new("/usr/bin/touch")
+        .arg(&marker)
+        .status()?;
+    assert!(status.success());
+    assert!(
+        marker.exists(),
+        "if this fails, the deny-side assertions prove nothing"
+    );
+    Ok(())
+}

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -158,6 +158,26 @@ impl<SE: extensions::ShellExtensions> std::ops::DerefMut for ShellForCommand<'_,
     }
 }
 
+/// Resolves `command_name` to the executable brush would actually run.
+///
+/// Mirrors external command dispatch: a name containing a path separator is taken as
+/// written, anything else is looked up in `PATH` (using the shell's hash cache). Returns
+/// `None` when a bare name is not found.
+///
+/// Callers that launch a process outside [`SimpleCommand`]'s dispatch -- the `exec` builtin
+/// is the one in-tree case -- use this so the command-execution filter is shown the same
+/// resolved program that ordinary dispatch would show it.
+pub fn resolve_external_program<SE: extensions::ShellExtensions>(
+    shell: &mut Shell<SE>,
+    command_name: &str,
+) -> Option<PathBuf> {
+    if sys::fs::contains_path_separator(command_name) {
+        Some(PathBuf::from(command_name))
+    } else {
+        shell.find_first_executable_in_path_using_cache(command_name)
+    }
+}
+
 /// Composes a `std::process::Command` to execute the given command. Appropriately
 /// configures the command name and arguments, redirections, injected file
 /// descriptors, environment variables, etc.

--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -16,6 +16,7 @@ use crate::{
     ErrorKind, ExecutionControlFlow, ExecutionExitCode, ExecutionParameters, ExecutionResult,
     Shell, ShellFd, builtins, commands, env, error, escape,
     extensions::{self, ShellExtensions},
+    filter::{CmdExecFilter as _, ExternalCmdParams, ExternalCommand, SimpleCmdParams},
     functions,
     interp::{self, Execute, ProcessGroupPolicy},
     openfiles::{self, OpenFile, OpenFiles},
@@ -355,7 +356,26 @@ impl<'a, SE: extensions::ShellExtensions> SimpleCommand<'a, SE> {
         clippy::missing_panics_doc,
         reason = "these unwrap calls should not panic"
     )]
-    pub async fn execute(mut self) -> Result<ExecutionSpawnResult, error::Error> {
+    pub async fn execute(self) -> Result<ExecutionSpawnResult, error::Error> {
+        // Create filter params with lazy arg conversion - no allocation unless filter inspects args
+        let filter_params = SimpleCmdParams::from_command_args(
+            &*self.shell,
+            self.command_name.as_str(),
+            &self.args,
+        );
+
+        crate::with_filter!(
+            self.shell,
+            cmd_exec_filter,
+            pre_simple_cmd,
+            post_simple_cmd,
+            filter_params,
+            self.execute_impl().await
+        )
+    }
+
+    /// Internal implementation of command execution (called after pre-filter).
+    async fn execute_impl(mut self) -> Result<ExecutionSpawnResult, error::Error> {
         // First see if it's the name of a builtin.
         let builtin = self.shell.builtins().get(&self.command_name).cloned();
 
@@ -402,7 +422,7 @@ impl<'a, SE: extensions::ShellExtensions> SimpleCommand<'a, SE> {
             };
 
             if let Some(path) = path {
-                self.execute_via_external(&path)
+                self.execute_via_external(&path).await
             } else {
                 // Bash updates $_ even when the command is not found, so mirror
                 // that here before reporting the error.
@@ -417,7 +437,7 @@ impl<'a, SE: extensions::ShellExtensions> SimpleCommand<'a, SE> {
             }
         } else {
             let command_name = PathBuf::from(self.command_name.clone());
-            self.execute_via_external(command_name.as_path())
+            self.execute_via_external(command_name.as_path()).await
         }
     }
 
@@ -530,33 +550,67 @@ impl<'a, SE: extensions::ShellExtensions> SimpleCommand<'a, SE> {
         result
     }
 
-    fn execute_via_external(self, path: &Path) -> Result<ExecutionSpawnResult, error::Error> {
-        let mut shell = self.shell;
-        let last_arg = Self::take_last_arg(&self.args);
-
-        let cmd_context = ExecutionContext {
-            shell: &mut shell,
-            command_name: self.command_name,
-            params: self.params,
-        };
-
-        let resolved_path = path.to_string_lossy();
-        let result = execute_external_command(
-            cmd_context,
-            resolved_path.as_ref(),
-            self.process_group_id,
-            self.argv0.as_deref(),
-            &self.args[1..],
-        );
-
-        // Update $_ after command execution.
-        shell.update_last_arg_variable(last_arg);
-
-        if let Some(post_execute) = self.post_execute {
-            let _ = post_execute(&mut shell);
+    async fn execute_via_external(self, path: &Path) -> Result<ExecutionSpawnResult, error::Error> {
+        // Build an ExternalCommand for the filter to inspect/modify.
+        let mut ext_cmd = ExternalCommand::new(path);
+        for arg in &self.args[1..] {
+            if let CommandArg::String(s) = arg {
+                ext_cmd.arg(s);
+            }
         }
 
-        result
+        // Extract fields from self before creating params (which borrows shell).
+        let last_arg = Self::take_last_arg(&self.args);
+        let mut shell = self.shell;
+        let command_name = self.command_name;
+        let params = self.params;
+        let process_group_id = self.process_group_id;
+        let argv0 = self.argv0;
+        let post_execute = self.post_execute;
+
+        // Create filter params.
+        let filter_params = ExternalCmdParams::new(&shell, ext_cmd);
+
+        crate::with_filter!(
+            shell,
+            cmd_exec_filter,
+            pre_external_cmd,
+            post_external_cmd,
+            filter_params,
+            p => {
+                // Extract the (possibly modified) command info.
+                let ext_cmd = p.command;
+                let new_path = PathBuf::from(ext_cmd.program());
+                let new_args: Vec<CommandArg> = ext_cmd
+                    .args()
+                    .iter()
+                    .map(|a| CommandArg::String(a.to_string_lossy().to_string()))
+                    .collect();
+
+                let cmd_context = ExecutionContext {
+                    shell: &mut shell,
+                    command_name,
+                    params,
+                };
+
+                let resolved_path = new_path.to_string_lossy();
+                execute_external_command(
+                    cmd_context,
+                    resolved_path.as_ref(),
+                    process_group_id,
+                    argv0.as_deref(),
+                    &new_args,
+                )
+            },
+            finally {
+                // Update $_ after command execution.
+                shell.update_last_arg_variable(last_arg);
+
+                if let Some(post_execute) = post_execute {
+                    let _ = post_execute(&mut shell);
+                }
+            }
+        )
     }
 }
 

--- a/brush-core/src/filter.rs
+++ b/brush-core/src/filter.rs
@@ -1,0 +1,1371 @@
+//! Filter infrastructure for intercepting and modifying shell operations.
+//!
+//! This module provides a zero-cost abstraction for pre/post-operation filtering.
+//! Filters can observe, modify, or short-circuit operations like command execution,
+//! word expansion, and script sourcing.
+//!
+//! # Design
+//!
+//! Filters are defined as traits with async methods that receive operation-specific
+//! parameters and return filter results. The default implementations pass through
+//! unchanged, enabling zero-cost behavior when no custom filtering is needed.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use brush_core::filter::{CmdExecFilter, PreFilterResult, PostFilterResult};
+//!
+//! #[derive(Clone, Default)]
+//! struct LoggingFilter;
+//!
+//! impl CmdExecFilter for LoggingFilter {
+//!     async fn pre_simple_cmd<SE: ShellExtensions>(
+//!         &self,
+//!         params: SimpleCmdParams<'_, SE>,
+//!     ) -> PreFilterResult<SimpleCmdParams<'_, SE>, SimpleCmdOutput> {
+//!         println!("Executing: {}", params.command_name());
+//!         PreFilterResult::Continue(params)
+//!     }
+//! }
+//! ```
+
+use std::borrow::Cow;
+use std::path::Path;
+
+use crate::commands::CommandArg;
+use crate::error;
+use crate::extensions::ShellExtensions;
+use crate::results::{ExecutionResult, ExecutionSpawnResult};
+use crate::shell::Shell;
+
+//
+// Filter result types
+//
+
+/// Result of a pre-operation filter.
+///
+/// Determines whether the operation should proceed (possibly with modified input)
+/// or be short-circuited with an immediate result.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum PreFilterResult<I, O> {
+    /// Continue with the operation using the (possibly modified) input.
+    Continue(I),
+    /// Short-circuit the operation and return this output immediately.
+    Return(O),
+}
+
+/// Result of a post-operation filter.
+///
+/// Allows the filter to observe or transform the operation's output.
+/// Future versions may add variants for retry semantics.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum PostFilterResult<O> {
+    /// Return this (possibly modified) output.
+    Return(O),
+}
+
+//
+// Operation-specific output type aliases
+//
+
+/// Output type for simple command execution.
+pub type SimpleCmdOutput = Result<ExecutionSpawnResult, error::Error>;
+
+/// Output type for external command execution.
+pub type ExternalCmdOutput = Result<ExecutionSpawnResult, error::Error>;
+
+/// Output type for script sourcing.
+pub type SourceScriptOutput = Result<ExecutionResult, error::Error>;
+
+//
+// Filter parameter types
+//
+
+/// Parameters for simple command execution filtering.
+///
+/// Provides access to command details and shell state for filtering decisions.
+#[non_exhaustive]
+pub struct SimpleCmdParams<'a, SE: ShellExtensions> {
+    /// The shell executing the command.
+    pub shell: &'a Shell<SE>,
+    /// The name of the command being executed.
+    pub command_name: Cow<'a, str>,
+    /// The arguments to the command (including argv[0]).
+    ///
+    /// This field stores pre-allocated strings. For zero-cost construction when
+    /// the filter won't inspect args, use [`SimpleCmdParams::from_command_args`]
+    /// which defers string conversion.
+    pub args: Cow<'a, [String]>,
+    /// Raw command arguments (if constructed via `from_command_args`).
+    /// This allows zero-allocation construction when filters don't inspect args.
+    raw_args: Option<&'a [CommandArg]>,
+}
+
+impl<'a, SE: ShellExtensions> SimpleCmdParams<'a, SE> {
+    /// Creates new simple command parameters with pre-allocated string args.
+    pub fn new(
+        shell: &'a Shell<SE>,
+        command_name: impl Into<Cow<'a, str>>,
+        args: impl Into<Cow<'a, [String]>>,
+    ) -> Self {
+        Self {
+            shell,
+            command_name: command_name.into(),
+            args: args.into(),
+            raw_args: None,
+        }
+    }
+
+    /// Creates new simple command parameters from raw [`CommandArg`] slice.
+    ///
+    /// This constructor is zero-cost for filters that don't inspect arguments.
+    /// String conversion is deferred until [`args()`](Self::args) or
+    /// [`args_to_strings()`](Self::args_to_strings) is called.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let params = SimpleCmdParams::from_command_args(&shell, "echo", &args);
+    /// // No allocation yet - args are stored by reference
+    ///
+    /// // Allocation happens here, only if needed:
+    /// let string_args = params.args_to_strings();
+    /// ```
+    pub fn from_command_args(
+        shell: &'a Shell<SE>,
+        command_name: impl Into<Cow<'a, str>>,
+        args: &'a [CommandArg],
+    ) -> Self {
+        Self {
+            shell,
+            command_name: command_name.into(),
+            args: Cow::Borrowed(&[]), // Empty placeholder
+            raw_args: Some(args),
+        }
+    }
+
+    /// Returns the command name.
+    pub fn command_name(&self) -> &str {
+        &self.command_name
+    }
+
+    /// Returns the command arguments as strings.
+    ///
+    /// If this instance was created via [`from_command_args`](Self::from_command_args),
+    /// this returns an empty slice. Use [`args_to_strings`](Self::args_to_strings)
+    /// to get the actual arguments with lazy allocation.
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+
+    /// Converts command arguments to strings, allocating if necessary.
+    ///
+    /// If this instance was created via [`new`](Self::new) with pre-allocated args,
+    /// returns them directly. If created via [`from_command_args`](Self::from_command_args),
+    /// performs the string conversion now.
+    ///
+    /// For iteration, use `args_to_strings().iter()` on the returned `Cow`.
+    pub fn args_to_strings(&self) -> Cow<'_, [String]> {
+        if let Some(raw) = self.raw_args {
+            Cow::Owned(raw.iter().map(|a| a.to_string()).collect())
+        } else {
+            Cow::Borrowed(&self.args)
+        }
+    }
+}
+
+/// Parameters for external command execution filtering.
+///
+/// Provides access to the command being spawned and shell state.
+#[non_exhaustive]
+pub struct ExternalCmdParams<'a, SE: ShellExtensions> {
+    /// The shell executing the command.
+    pub shell: &'a Shell<SE>,
+    /// The external command builder (introspectable and modifiable).
+    pub command: ExternalCommand,
+}
+
+impl<'a, SE: ShellExtensions> ExternalCmdParams<'a, SE> {
+    /// Creates new external command parameters.
+    pub const fn new(shell: &'a Shell<SE>, command: ExternalCommand) -> Self {
+        Self { shell, command }
+    }
+}
+
+/// Parameters for script sourcing filtering.
+#[non_exhaustive]
+pub struct SourceScriptParams<'a, SE: ShellExtensions> {
+    /// The shell sourcing the script.
+    pub shell: &'a Shell<SE>,
+    /// The path to the script being sourced.
+    pub path: Cow<'a, Path>,
+    /// The arguments to pass to the script.
+    pub args: Cow<'a, [String]>,
+}
+
+impl<'a, SE: ShellExtensions> SourceScriptParams<'a, SE> {
+    /// Creates new source script parameters.
+    pub fn new(
+        shell: &'a Shell<SE>,
+        path: impl Into<Cow<'a, Path>>,
+        args: impl Into<Cow<'a, [String]>>,
+    ) -> Self {
+        Self {
+            shell,
+            path: path.into(),
+            args: args.into(),
+        }
+    }
+
+    /// Returns the script path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the script arguments.
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+}
+
+//
+// External command builder (introspectable)
+//
+
+/// An introspectable command builder for external process execution.
+///
+/// Unlike `std::process::Command`, this type allows inspection of all
+/// configured state, enabling filters to make decisions based on the
+/// full command configuration.
+///
+/// # Known Limitations
+///
+/// The following `std::process::Command` features are not yet supported:
+/// - stdin/stdout/stderr redirection configuration
+/// - Unix-specific options (uid, gid, process group)
+/// - Windows-specific options (creation flags)
+///
+/// These may be added in future versions as the filter system matures.
+#[derive(Debug, Clone)]
+pub struct ExternalCommand {
+    program: std::ffi::OsString,
+    args: Vec<std::ffi::OsString>,
+    envs: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+    current_dir: Option<std::path::PathBuf>,
+    env_clear: bool,
+}
+
+impl ExternalCommand {
+    /// Creates a new external command for the given program.
+    pub fn new(program: impl AsRef<std::ffi::OsStr>) -> Self {
+        Self {
+            program: program.as_ref().to_owned(),
+            args: Vec::new(),
+            envs: Vec::new(),
+            current_dir: None,
+            env_clear: false,
+        }
+    }
+
+    /// Returns the program path.
+    pub fn program(&self) -> &std::ffi::OsStr {
+        &self.program
+    }
+
+    /// Returns the arguments.
+    pub fn args(&self) -> &[std::ffi::OsString] {
+        &self.args
+    }
+
+    /// Returns the environment variables that will be set.
+    pub fn envs(&self) -> &[(std::ffi::OsString, std::ffi::OsString)] {
+        &self.envs
+    }
+
+    /// Returns the current directory, if set.
+    pub fn current_dir(&self) -> Option<&std::path::Path> {
+        self.current_dir.as_deref()
+    }
+
+    /// Returns whether the environment will be cleared.
+    pub const fn env_clear(&self) -> bool {
+        self.env_clear
+    }
+
+    /// Sets the program path.
+    pub fn set_program(&mut self, program: impl AsRef<std::ffi::OsStr>) -> &mut Self {
+        program.as_ref().clone_into(&mut self.program);
+        self
+    }
+
+    /// Adds an argument.
+    pub fn arg(&mut self, arg: impl AsRef<std::ffi::OsStr>) -> &mut Self {
+        self.args.push(arg.as_ref().to_owned());
+        self
+    }
+
+    /// Adds multiple arguments.
+    pub fn args_extend<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        self.args
+            .extend(args.into_iter().map(|s| s.as_ref().to_owned()));
+        self
+    }
+
+    /// Clears the environment.
+    pub const fn clear_env(&mut self) -> &mut Self {
+        self.env_clear = true;
+        self
+    }
+
+    /// Sets an environment variable.
+    pub fn env(
+        &mut self,
+        key: impl AsRef<std::ffi::OsStr>,
+        val: impl AsRef<std::ffi::OsStr>,
+    ) -> &mut Self {
+        self.envs
+            .push((key.as_ref().to_owned(), val.as_ref().to_owned()));
+        self
+    }
+
+    /// Sets the current directory.
+    pub fn set_current_dir(&mut self, dir: impl AsRef<std::path::Path>) -> &mut Self {
+        self.current_dir = Some(dir.as_ref().to_owned());
+        self
+    }
+
+    /// Converts this into a `std::process::Command`.
+    #[must_use]
+    pub fn into_std_command(self) -> std::process::Command {
+        let mut cmd = std::process::Command::new(&self.program);
+
+        if self.env_clear {
+            cmd.env_clear();
+        }
+
+        for (key, val) in &self.envs {
+            cmd.env(key, val);
+        }
+
+        cmd.args(&self.args);
+
+        if let Some(dir) = &self.current_dir {
+            cmd.current_dir(dir);
+        }
+
+        cmd
+    }
+}
+
+//
+// Filter traits
+//
+
+/// Filter for command execution operations.
+///
+/// Provides hooks for both simple commands (builtins, functions, externals)
+/// and external command spawning specifically.
+///
+/// # Hook Semantics
+///
+/// - `pre_simple_cmd` / `post_simple_cmd`: Called for ALL commands (builtins, functions,
+///   external). Use for observation, modification, or short-circuiting. When using the
+///   `$p =>` form of [`with_filter!`], returned params are captured and can be used.
+///
+/// - `pre_external_cmd` / `post_external_cmd`: Called only for external process spawning.
+///   The [`ExternalCommand`] in params can be modified and changes will be applied.
+///
+/// # Panic Safety
+///
+/// **Filter implementations must not panic.** Panics in filter methods will propagate
+/// through the shell and may terminate the process. There is no `catch_unwind` wrapper
+/// around filter invocations for performance reasons. If your filter interacts with
+/// fallible operations (locks, I/O, etc.), handle errors gracefully rather than
+/// panicking.
+pub trait CmdExecFilter: Clone + Default + Send + Sync + 'static {
+    /// Called before a simple command is executed.
+    ///
+    /// Can inspect and modify the command parameters, or short-circuit execution by returning
+    /// `PreFilterResult::Return`. This hook is called for ALL command types
+    /// (builtins, shell functions, external commands).
+    ///
+    /// When returning `Continue(params)` with the `$p =>` form of [`with_filter!`], the
+    /// returned params are captured and used. For external command modification specifically,
+    /// prefer `pre_external_cmd` which provides the introspectable [`ExternalCommand`] builder.
+    #[allow(unused_variables)]
+    fn pre_simple_cmd<'a, SE: ShellExtensions>(
+        &self,
+        params: SimpleCmdParams<'a, SE>,
+    ) -> impl std::future::Future<Output = PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput>>
+    + Send {
+        async { PreFilterResult::Continue(params) }
+    }
+
+    /// Called after a simple command is executed.
+    ///
+    /// Can inspect/modify the execution result.
+    #[allow(unused_variables)]
+    fn post_simple_cmd(
+        &self,
+        result: SimpleCmdOutput,
+    ) -> impl std::future::Future<Output = PostFilterResult<SimpleCmdOutput>> + Send {
+        async { PostFilterResult::Return(result) }
+    }
+
+    /// Called before an external command is spawned.
+    ///
+    /// Can inspect and **modify** the command configuration, or short-circuit
+    /// with an error. Unlike `pre_simple_cmd`, modifications to `ExternalCommand`
+    /// in the returned `Continue` params ARE applied to the spawned process.
+    #[allow(unused_variables)]
+    fn pre_external_cmd<'a, SE: ShellExtensions>(
+        &self,
+        params: ExternalCmdParams<'a, SE>,
+    ) -> impl std::future::Future<
+        Output = PreFilterResult<ExternalCmdParams<'a, SE>, ExternalCmdOutput>,
+    > + Send {
+        async { PreFilterResult::Continue(params) }
+    }
+
+    /// Called after an external command is spawned.
+    ///
+    /// Can inspect/modify the spawn result.
+    #[allow(unused_variables)]
+    fn post_external_cmd(
+        &self,
+        result: ExternalCmdOutput,
+    ) -> impl std::future::Future<Output = PostFilterResult<ExternalCmdOutput>> + Send {
+        async { PostFilterResult::Return(result) }
+    }
+}
+
+/// Filter for script sourcing operations.
+///
+/// Provides hooks for the `.` and `source` builtins that execute scripts
+/// in the current shell context.
+///
+/// # Panic Safety
+///
+/// **Filter implementations must not panic.** Panics in filter methods will propagate
+/// through the shell and may terminate the process. There is no `catch_unwind` wrapper
+/// around filter invocations for performance reasons.
+pub trait SourceFilter: Clone + Default + Send + Sync + 'static {
+    /// Called before a script is sourced.
+    ///
+    /// Can inspect/modify the source parameters or short-circuit.
+    #[allow(unused_variables)]
+    fn pre_source_script<'a, SE: ShellExtensions>(
+        &self,
+        params: SourceScriptParams<'a, SE>,
+    ) -> impl std::future::Future<
+        Output = PreFilterResult<SourceScriptParams<'a, SE>, SourceScriptOutput>,
+    > + Send {
+        async { PreFilterResult::Continue(params) }
+    }
+
+    /// Called after a script is sourced.
+    ///
+    /// Can inspect/modify the source result.
+    #[allow(unused_variables)]
+    fn post_source_script(
+        &self,
+        result: SourceScriptOutput,
+    ) -> impl std::future::Future<Output = PostFilterResult<SourceScriptOutput>> + Send {
+        async { PostFilterResult::Return(result) }
+    }
+}
+
+//
+// No-op filter implementations
+//
+
+/// No-op command execution filter.
+///
+/// Passes through all operations unchanged. This is the default filter
+/// and incurs zero runtime overhead due to monomorphization.
+#[derive(Clone, Default, Debug)]
+pub struct NoOpCmdExecFilter;
+
+impl CmdExecFilter for NoOpCmdExecFilter {}
+
+/// No-op source filter.
+///
+/// Passes through all operations unchanged.
+#[derive(Clone, Default, Debug)]
+pub struct NoOpSourceFilter;
+
+impl SourceFilter for NoOpSourceFilter {}
+
+//
+// Filter composition
+//
+
+/// Two filters composed in sequence.
+///
+/// When executing:
+/// - Pre-filters run in order: `first`, then `second`
+/// - Post-filters run in reverse order: `second`, then `first`
+///
+/// This follows standard middleware/interceptor semantics where the
+/// "outer" filter (first) wraps the "inner" filter (second).
+///
+/// # Example
+///
+/// ```ignore
+/// use brush_core::filter::{FilterStack, CmdExecFilterExt};
+///
+/// // Using FilterStack::new directly:
+/// let filter = FilterStack::new(LoggingFilter, SecurityFilter);
+///
+/// // Using the extension trait (equivalent):
+/// let filter = LoggingFilter.and_then(SecurityFilter);
+///
+/// // Execution order for a command:
+/// // 1. LoggingFilter::pre_simple_cmd (logs "starting")
+/// // 2. SecurityFilter::pre_simple_cmd (checks permissions)
+/// // 3. <actual command executes>
+/// // 4. SecurityFilter::post_simple_cmd (checks output)
+/// // 5. LoggingFilter::post_simple_cmd (logs "completed")
+/// ```
+#[derive(Debug)]
+pub struct FilterStack<First, Second> {
+    /// The first (outer) filter in the stack.
+    pub first: First,
+    /// The second (inner) filter in the stack.
+    pub second: Second,
+}
+
+impl<First, Second> FilterStack<First, Second> {
+    /// Creates a new filter stack with the given filters.
+    ///
+    /// Pre-filters run `first` then `second`; post-filters run `second` then `first`.
+    pub const fn new(first: First, second: Second) -> Self {
+        Self { first, second }
+    }
+}
+
+impl<First: Clone, Second: Clone> Clone for FilterStack<First, Second> {
+    fn clone(&self) -> Self {
+        Self {
+            first: self.first.clone(),
+            second: self.second.clone(),
+        }
+    }
+}
+
+impl<First: Default, Second: Default> Default for FilterStack<First, Second> {
+    fn default() -> Self {
+        Self {
+            first: First::default(),
+            second: Second::default(),
+        }
+    }
+}
+
+impl<First: CmdExecFilter, Second: CmdExecFilter> CmdExecFilter for FilterStack<First, Second> {
+    async fn pre_simple_cmd<'a, SE: ShellExtensions>(
+        &self,
+        params: SimpleCmdParams<'a, SE>,
+    ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+        // Run first filter, short-circuit if it returns
+        let params = match self.first.pre_simple_cmd(params).await {
+            PreFilterResult::Continue(p) => p,
+            PreFilterResult::Return(r) => return PreFilterResult::Return(r),
+        };
+        // Run second filter
+        self.second.pre_simple_cmd(params).await
+    }
+
+    async fn post_simple_cmd(&self, result: SimpleCmdOutput) -> PostFilterResult<SimpleCmdOutput> {
+        // Post-filters run in reverse order: second then first
+        let PostFilterResult::Return(result) = self.second.post_simple_cmd(result).await;
+        self.first.post_simple_cmd(result).await
+    }
+
+    async fn pre_external_cmd<'a, SE: ShellExtensions>(
+        &self,
+        params: ExternalCmdParams<'a, SE>,
+    ) -> PreFilterResult<ExternalCmdParams<'a, SE>, ExternalCmdOutput> {
+        let params = match self.first.pre_external_cmd(params).await {
+            PreFilterResult::Continue(p) => p,
+            PreFilterResult::Return(r) => return PreFilterResult::Return(r),
+        };
+        self.second.pre_external_cmd(params).await
+    }
+
+    async fn post_external_cmd(
+        &self,
+        result: ExternalCmdOutput,
+    ) -> PostFilterResult<ExternalCmdOutput> {
+        let PostFilterResult::Return(result) = self.second.post_external_cmd(result).await;
+        self.first.post_external_cmd(result).await
+    }
+}
+
+impl<First: SourceFilter, Second: SourceFilter> SourceFilter for FilterStack<First, Second> {
+    async fn pre_source_script<'a, SE: ShellExtensions>(
+        &self,
+        params: SourceScriptParams<'a, SE>,
+    ) -> PreFilterResult<SourceScriptParams<'a, SE>, SourceScriptOutput> {
+        let params = match self.first.pre_source_script(params).await {
+            PreFilterResult::Continue(p) => p,
+            PreFilterResult::Return(r) => return PreFilterResult::Return(r),
+        };
+        self.second.pre_source_script(params).await
+    }
+
+    async fn post_source_script(
+        &self,
+        result: SourceScriptOutput,
+    ) -> PostFilterResult<SourceScriptOutput> {
+        let PostFilterResult::Return(result) = self.second.post_source_script(result).await;
+        self.first.post_source_script(result).await
+    }
+}
+
+/// Extension trait for fluent command execution filter composition.
+///
+/// This trait is automatically implemented for all types that implement
+/// [`CmdExecFilter`], providing the [`and_then`](CmdExecFilterExt::and_then) method.
+pub trait CmdExecFilterExt: CmdExecFilter + Sized {
+    /// Composes this filter with another, creating a [`FilterStack`].
+    ///
+    /// The resulting filter runs `self`'s pre-filter first, then `next`'s.
+    /// Post-filters run in reverse order.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let filter = AuditingFilter::new()
+    ///     .and_then(RateLimitFilter::new(5))
+    ///     .and_then(SecurityFilter::new());
+    /// ```
+    fn and_then<F: CmdExecFilter>(self, next: F) -> FilterStack<Self, F> {
+        FilterStack::new(self, next)
+    }
+}
+
+impl<T: CmdExecFilter> CmdExecFilterExt for T {}
+
+/// Extension trait for fluent source filter composition.
+///
+/// This trait is automatically implemented for all types that implement
+/// [`SourceFilter`], providing the [`and_then`](SourceFilterExt::and_then) method.
+pub trait SourceFilterExt: SourceFilter + Sized {
+    /// Composes this filter with another, creating a [`FilterStack`].
+    ///
+    /// The resulting filter runs `self`'s pre-filter first, then `next`'s.
+    /// Post-filters run in reverse order.
+    fn and_then<F: SourceFilter>(self, next: F) -> FilterStack<Self, F> {
+        FilterStack::new(self, next)
+    }
+}
+
+impl<T: SourceFilter> SourceFilterExt for T {}
+
+//
+// Filter invocation macro
+//
+
+/// Macro for invoking a filter around an operation.
+///
+/// Handles the boilerplate of calling pre/post filter methods and
+/// matching on the results. When used with no-op filters, the compiler
+/// optimizes away all filter overhead.
+///
+/// # Variants
+///
+/// - Basic form: `with_filter!(shell, filter, pre, post, params, body)` - ignores returned params
+/// - With params: `with_filter!(shell, filter, pre, post, params, |p| body)` - captures returned params as `p`
+///
+/// # Arguments
+///
+/// * `$shell` - The shell instance
+/// * `$filter_accessor` - Method to get the filter from the shell
+/// * `$pre_method` - The pre-operation filter method name
+/// * `$post_method` - The post-operation filter method name
+/// * `$params` - Expression that constructs the filter parameters
+/// * `$body` - The operation body to execute if the filter allows
+///
+/// # Example
+///
+/// ```ignore
+/// // Basic form (returned params not captured):
+/// with_filter!(
+///     shell,
+///     cmd_exec_filter,
+///     pre_simple_cmd,
+///     post_simple_cmd,
+///     SimpleCmdParams::new(&shell, cmd_name, &args),
+///     execute_impl().await
+/// )
+///
+/// // With params capture (for hooks that modify):
+/// with_filter!(
+///     shell,
+///     source_filter,
+///     pre_source_script,
+///     post_source_script,
+///     SourceScriptParams::new(&shell, path, &args),
+///     p => run_script(p.path(), p.args()).await
+/// )
+///
+/// // With params capture and finally block (runs after post-filter):
+/// with_filter!(
+///     shell,
+///     cmd_exec_filter,
+///     pre_external_cmd,
+///     post_external_cmd,
+///     params,
+///     p => execute_command(p).await,
+///     finally { cleanup_after() }
+/// )
+/// ```
+#[macro_export]
+macro_rules! with_filter {
+    // Basic form: ignores returned params from Continue
+    ($shell:expr, $filter_accessor:ident, $pre_method:ident, $post_method:ident, $params:expr, $body:expr) => {{
+        let __filter = $shell.$filter_accessor().clone();
+        match __filter.$pre_method($params).await {
+            $crate::filter::PreFilterResult::Continue(_p) => {
+                let __result = $body;
+                let $crate::filter::PostFilterResult::Return(__r) =
+                    __filter.$post_method(__result).await;
+                __r
+            }
+            $crate::filter::PreFilterResult::Return(__r) => __r,
+        }
+    }};
+    // Form with params capture: "$p =>" syntax binds returned params to $p for use in $body
+    ($shell:expr, $filter_accessor:ident, $pre_method:ident, $post_method:ident, $params:expr, $p:ident => $body:expr) => {{
+        let __filter = $shell.$filter_accessor().clone();
+        match __filter.$pre_method($params).await {
+            $crate::filter::PreFilterResult::Continue($p) => {
+                let __result = $body;
+                let $crate::filter::PostFilterResult::Return(__r) =
+                    __filter.$post_method(__result).await;
+                __r
+            }
+            $crate::filter::PreFilterResult::Return(__r) => __r,
+        }
+    }};
+    // Form with params capture AND finally block: runs $finally after post-filter completes
+    ($shell:expr, $filter_accessor:ident, $pre_method:ident, $post_method:ident, $params:expr, $p:ident => $body:expr, finally $finally:block) => {{
+        let __filter = $shell.$filter_accessor().clone();
+        match __filter.$pre_method($params).await {
+            $crate::filter::PreFilterResult::Continue($p) => {
+                let __result = $body;
+                let $crate::filter::PostFilterResult::Return(__r) =
+                    __filter.$post_method(__result).await;
+                $finally
+                __r
+            }
+            $crate::filter::PreFilterResult::Return(__r) => __r,
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Shell;
+    use crate::extensions::DefaultShellExtensions;
+
+    /// Test that the basic form of `with_filter!` compiles and works correctly
+    /// with the no-op filter (zero-cost case).
+    #[tokio::test]
+    async fn test_with_filter_basic_form_noop() {
+        let shell: Shell<DefaultShellExtensions> = Shell::default();
+
+        // Construct params separately to help type inference
+        let args = ["echo".to_string(), "hello".to_string()];
+        let params = SimpleCmdParams::new(&shell, "echo", args.as_slice());
+
+        let result: SimpleCmdOutput = with_filter!(
+            shell,
+            cmd_exec_filter,
+            pre_simple_cmd,
+            post_simple_cmd,
+            params,
+            Ok(crate::ExecutionSpawnResult::Completed(
+                crate::ExecutionResult::success()
+            ))
+        );
+
+        assert!(result.is_ok());
+    }
+
+    /// Test that the params-capture form of `with_filter!` compiles and works correctly.
+    /// Note: This test uses the basic form since the `|p|` form requires context where SE is known.
+    /// The `|p|` form is tested implicitly via production code usage.
+    #[tokio::test]
+    async fn test_with_filter_params_capture_form_noop() {
+        let shell: Shell<DefaultShellExtensions> = Shell::default();
+
+        // Construct params separately to help type inference
+        let params = ExternalCmdParams::new(&shell, ExternalCommand::new("/bin/echo"));
+
+        // Use basic form (ignoring params) since |p| form requires more context for inference
+        let result: ExternalCmdOutput = with_filter!(
+            shell,
+            cmd_exec_filter,
+            pre_external_cmd,
+            post_external_cmd,
+            params,
+            Ok(crate::ExecutionSpawnResult::Completed(
+                crate::ExecutionResult::success(),
+            ))
+        );
+
+        assert!(result.is_ok());
+    }
+
+    /// Test `with_filter!` for source script operations.
+    #[tokio::test]
+    async fn test_with_filter_source_script_noop() {
+        let shell: Shell<DefaultShellExtensions> = Shell::default();
+
+        // Construct params separately to help type inference
+        let empty_args: [String; 0] = [];
+        let params =
+            SourceScriptParams::new(&shell, std::path::Path::new("/tmp/test.sh"), &empty_args);
+
+        // Use basic form (ignoring params) since |p| form requires more context for inference
+        let result: SourceScriptOutput = with_filter!(
+            shell,
+            source_filter,
+            pre_source_script,
+            post_source_script,
+            params,
+            Ok(crate::ExecutionResult::success())
+        );
+
+        assert!(result.is_ok());
+    }
+
+    /// Custom filter that tracks calls for testing.
+    #[derive(Clone, Default)]
+    struct TrackingCmdExecFilter {
+        pre_called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        post_called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl CmdExecFilter for TrackingCmdExecFilter {
+        async fn pre_simple_cmd<'a, SE: crate::extensions::ShellExtensions>(
+            &self,
+            params: SimpleCmdParams<'a, SE>,
+        ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+            self.pre_called
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            PreFilterResult::Continue(params)
+        }
+
+        async fn post_simple_cmd(
+            &self,
+            result: SimpleCmdOutput,
+        ) -> PostFilterResult<SimpleCmdOutput> {
+            self.post_called
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            PostFilterResult::Return(result)
+        }
+    }
+
+    /// Custom extensions type for testing with `TrackingCmdExecFilter`.
+    #[derive(Clone, Default)]
+    #[allow(dead_code)] // filter field used indirectly through ShellExtensions
+    struct TrackingExtensions {
+        filter: TrackingCmdExecFilter,
+    }
+
+    impl crate::extensions::ShellExtensions for TrackingExtensions {
+        type ErrorFormatter = crate::extensions::DefaultErrorFormatter;
+        type CmdExecFilter = TrackingCmdExecFilter;
+        type SourceFilter = NoOpSourceFilter;
+    }
+
+    /// Test that a custom filter's pre/post methods are actually called.
+    #[tokio::test]
+    async fn test_with_filter_custom_filter_called() {
+        let pre_called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let post_called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let filter = TrackingCmdExecFilter {
+            pre_called: pre_called.clone(),
+            post_called: post_called.clone(),
+        };
+
+        let shell: Shell<TrackingExtensions> = Shell::builder_with_extensions()
+            .cmd_exec_filter(filter)
+            .build()
+            .await
+            .unwrap();
+
+        // Construct params separately to help type inference
+        let args = ["test".to_string()];
+        let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+
+        let _result: SimpleCmdOutput = with_filter!(
+            shell,
+            cmd_exec_filter,
+            pre_simple_cmd,
+            post_simple_cmd,
+            params,
+            Ok(crate::ExecutionSpawnResult::Completed(
+                crate::ExecutionResult::success()
+            ))
+        );
+
+        assert!(
+            pre_called.load(std::sync::atomic::Ordering::SeqCst),
+            "pre_simple_cmd should have been called"
+        );
+        assert!(
+            post_called.load(std::sync::atomic::Ordering::SeqCst),
+            "post_simple_cmd should have been called"
+        );
+    }
+
+    /// Test that returning `PreFilterResult::Return` short-circuits execution.
+    #[derive(Clone, Default)]
+    struct ShortCircuitFilter;
+
+    impl CmdExecFilter for ShortCircuitFilter {
+        async fn pre_simple_cmd<'a, SE: crate::extensions::ShellExtensions>(
+            &self,
+            _params: SimpleCmdParams<'a, SE>,
+        ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+            PreFilterResult::Return(Ok(crate::ExecutionSpawnResult::Completed(
+                crate::ExecutionResult::new(42),
+            )))
+        }
+    }
+
+    /// Custom extensions type for testing with `ShortCircuitFilter`.
+    #[derive(Clone, Default)]
+    struct ShortCircuitExtensions;
+
+    impl crate::extensions::ShellExtensions for ShortCircuitExtensions {
+        type ErrorFormatter = crate::extensions::DefaultErrorFormatter;
+        type CmdExecFilter = ShortCircuitFilter;
+        type SourceFilter = NoOpSourceFilter;
+    }
+
+    /// Test short-circuit behavior.
+    #[tokio::test]
+    #[allow(clippy::panic_in_result_fn)]
+    async fn test_with_filter_short_circuit() -> Result<(), crate::Error> {
+        let shell: Shell<ShortCircuitExtensions> = Shell::builder_with_extensions()
+            .cmd_exec_filter(ShortCircuitFilter)
+            .build()
+            .await?;
+
+        let body_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let body_executed_clone = body_executed.clone();
+
+        // Construct params separately to help type inference
+        let args = ["test".to_string()];
+        let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+
+        let result: SimpleCmdOutput = with_filter!(
+            shell,
+            cmd_exec_filter,
+            pre_simple_cmd,
+            post_simple_cmd,
+            params,
+            {
+                body_executed_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(crate::ExecutionSpawnResult::Completed(
+                    crate::ExecutionResult::success(),
+                ))
+            }
+        );
+
+        assert!(
+            !body_executed.load(std::sync::atomic::Ordering::SeqCst),
+            "body should NOT have been executed due to short-circuit"
+        );
+
+        // Verify we got the short-circuit result
+        let result = result?;
+        let crate::ExecutionSpawnResult::Completed(exec_result) = result else {
+            unreachable!("expected Completed variant")
+        };
+        assert_eq!(u8::from(exec_result.exit_code), 42);
+        Ok(())
+    }
+
+    // ========================================================================
+    // FilterStack composition tests
+    // ========================================================================
+
+    /// A filter that records when its pre/post methods are called.
+    #[derive(Clone, Default)]
+    struct OrderTrackingFilter {
+        id: &'static str,
+        pre_order: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+        post_order: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    impl OrderTrackingFilter {
+        fn new(
+            id: &'static str,
+            pre_order: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+            post_order: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+        ) -> Self {
+            Self {
+                id,
+                pre_order,
+                post_order,
+            }
+        }
+    }
+
+    impl CmdExecFilter for OrderTrackingFilter {
+        async fn pre_simple_cmd<'a, SE: crate::extensions::ShellExtensions>(
+            &self,
+            params: SimpleCmdParams<'a, SE>,
+        ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+            if let Ok(mut order) = self.pre_order.lock() {
+                order.push(self.id);
+            }
+            PreFilterResult::Continue(params)
+        }
+
+        async fn post_simple_cmd(
+            &self,
+            result: SimpleCmdOutput,
+        ) -> PostFilterResult<SimpleCmdOutput> {
+            if let Ok(mut order) = self.post_order.lock() {
+                order.push(self.id);
+            }
+            PostFilterResult::Return(result)
+        }
+    }
+
+    /// Test that `FilterStack` runs pre-filters in order (first then second)
+    /// and post-filters in reverse order (second then first).
+    #[tokio::test]
+    #[allow(clippy::significant_drop_tightening)]
+    async fn test_filter_stack_ordering() {
+        let pre_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let post_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let filter_a = OrderTrackingFilter::new("A", pre_order.clone(), post_order.clone());
+        let filter_b = OrderTrackingFilter::new("B", pre_order.clone(), post_order.clone());
+
+        // Compose: A.and_then(B)
+        let composed = filter_a.and_then(filter_b);
+
+        // Create a mock shell for testing
+        let shell: Shell<DefaultShellExtensions> = Shell::default();
+        let args = ["test".to_string()];
+        let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+
+        // Run pre-filter
+        let result = composed.pre_simple_cmd(params).await;
+        assert!(matches!(result, PreFilterResult::Continue(_)));
+
+        // Run post-filter
+        let result = Ok(crate::ExecutionSpawnResult::Completed(
+            crate::ExecutionResult::success(),
+        ));
+        let _ = composed.post_simple_cmd(result).await;
+
+        // Verify ordering
+        let pre = pre_order.lock().unwrap();
+        let post = post_order.lock().unwrap();
+
+        assert_eq!(*pre, vec!["A", "B"], "pre-filters should run first→second");
+        assert_eq!(
+            *post,
+            vec!["B", "A"],
+            "post-filters should run second→first (reverse)"
+        );
+    }
+
+    /// A filter that short-circuits in `pre_simple_cmd`.
+    #[derive(Clone, Default)]
+    struct ShortCircuitAtPreFilter {
+        pre_order: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    impl CmdExecFilter for ShortCircuitAtPreFilter {
+        async fn pre_simple_cmd<'a, SE: crate::extensions::ShellExtensions>(
+            &self,
+            _params: SimpleCmdParams<'a, SE>,
+        ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+            if let Ok(mut order) = self.pre_order.lock() {
+                order.push("SHORT");
+            }
+            PreFilterResult::Return(Ok(crate::ExecutionSpawnResult::Completed(
+                crate::ExecutionResult::new(99),
+            )))
+        }
+    }
+
+    /// Test that short-circuiting in the first filter prevents the second filter from running.
+    #[tokio::test]
+    #[allow(clippy::significant_drop_tightening)]
+    async fn test_filter_stack_short_circuit_first() {
+        let pre_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let short_circuit = ShortCircuitAtPreFilter {
+            pre_order: pre_order.clone(),
+        };
+        let post_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tracking = OrderTrackingFilter::new("B", pre_order.clone(), post_order);
+
+        // Short-circuit filter is first
+        let composed = FilterStack::new(short_circuit, tracking);
+
+        let shell: Shell<DefaultShellExtensions> = Shell::default();
+        let args = ["test".to_string()];
+        let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+
+        let result = composed.pre_simple_cmd(params).await;
+
+        // Should have short-circuited
+        assert!(matches!(result, PreFilterResult::Return(_)));
+
+        // Only the short-circuit filter should have run
+        let pre = pre_order.lock().unwrap();
+        assert_eq!(
+            *pre,
+            vec!["SHORT"],
+            "second filter should not run when first short-circuits"
+        );
+    }
+
+    /// Test that `and_then` extension trait works correctly.
+    #[tokio::test]
+    async fn test_cmd_exec_filter_ext_and_then() {
+        let filter_a = NoOpCmdExecFilter;
+        let filter_b = NoOpCmdExecFilter;
+
+        // This should compile and create a FilterStack
+        let _composed: FilterStack<NoOpCmdExecFilter, NoOpCmdExecFilter> =
+            filter_a.and_then(filter_b);
+    }
+
+    /// Test that three filters can be composed.
+    #[tokio::test]
+    #[allow(clippy::significant_drop_tightening)]
+    async fn test_filter_stack_triple_composition() {
+        let pre_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let post_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let filter_a = OrderTrackingFilter::new("A", pre_order.clone(), post_order.clone());
+        let filter_b = OrderTrackingFilter::new("B", pre_order.clone(), post_order.clone());
+        let filter_c = OrderTrackingFilter::new("C", pre_order.clone(), post_order.clone());
+
+        // Compose: A.and_then(B).and_then(C)
+        let composed = filter_a.and_then(filter_b).and_then(filter_c);
+
+        let shell: Shell<DefaultShellExtensions> = Shell::default();
+        let args = ["test".to_string()];
+        let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+
+        let PreFilterResult::Continue(_) = composed.pre_simple_cmd(params).await else {
+            unreachable!("expected Continue")
+        };
+
+        let result = Ok(crate::ExecutionSpawnResult::Completed(
+            crate::ExecutionResult::success(),
+        ));
+        let _ = composed.post_simple_cmd(result).await;
+
+        let pre = pre_order.lock().unwrap();
+        let post = post_order.lock().unwrap();
+
+        assert_eq!(*pre, vec!["A", "B", "C"], "pre-filters: A → B → C");
+        assert_eq!(*post, vec!["C", "B", "A"], "post-filters: C → B → A");
+    }
+
+    // ========================================================================
+    // Error propagation tests
+    // ========================================================================
+
+    /// A filter that returns an error result in `pre_simple_cmd`.
+    #[derive(Clone, Default)]
+    struct ErrorReturningFilter;
+
+    impl CmdExecFilter for ErrorReturningFilter {
+        async fn pre_simple_cmd<'a, SE: crate::extensions::ShellExtensions>(
+            &self,
+            _params: SimpleCmdParams<'a, SE>,
+        ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+            PreFilterResult::Return(Err(crate::error::Error::from(
+                crate::error::ErrorKind::CommandNotFound("blocked by filter".to_string()),
+            )))
+        }
+    }
+
+    /// Custom extensions type for testing with `ErrorReturningFilter`.
+    #[derive(Clone, Default)]
+    struct ErrorExtensions;
+
+    impl crate::extensions::ShellExtensions for ErrorExtensions {
+        type ErrorFormatter = crate::extensions::DefaultErrorFormatter;
+        type CmdExecFilter = ErrorReturningFilter;
+        type SourceFilter = NoOpSourceFilter;
+    }
+
+    /// Test that errors returned from filters propagate correctly.
+    #[tokio::test]
+    #[allow(clippy::panic_in_result_fn, clippy::panic)]
+    async fn test_filter_error_propagation() -> Result<(), crate::Error> {
+        let shell: Shell<ErrorExtensions> = Shell::builder_with_extensions()
+            .cmd_exec_filter(ErrorReturningFilter)
+            .build()
+            .await?;
+
+        let args = ["test".to_string()];
+        let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+
+        let result: SimpleCmdOutput = with_filter!(
+            shell,
+            cmd_exec_filter,
+            pre_simple_cmd,
+            post_simple_cmd,
+            params,
+            Ok(crate::ExecutionSpawnResult::Completed(
+                crate::ExecutionResult::success()
+            ))
+        );
+
+        // Should have received the error from the filter
+        let Err(err) = result else {
+            panic!("expected error result from filter");
+        };
+        assert!(
+            matches!(err.kind(), crate::error::ErrorKind::CommandNotFound(_)),
+            "expected CommandNotFound error, got: {err:?}"
+        );
+        Ok(())
+    }
+
+    /// A filter that uses Arc<Mutex<_>> for state, demonstrating safe shared state patterns.
+    #[derive(Clone, Default)]
+    struct StatefulFilter {
+        call_count: std::sync::Arc<std::sync::Mutex<u32>>,
+    }
+
+    impl CmdExecFilter for StatefulFilter {
+        async fn pre_simple_cmd<'a, SE: crate::extensions::ShellExtensions>(
+            &self,
+            params: SimpleCmdParams<'a, SE>,
+        ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+            // Demonstrate safe mutex handling - don't unwrap, handle poisoning gracefully
+            if let Ok(mut count) = self.call_count.lock() {
+                *count += 1;
+            }
+            PreFilterResult::Continue(params)
+        }
+    }
+
+    /// Custom extensions type for testing with `StatefulFilter`.
+    #[derive(Clone, Default)]
+    struct StatefulExtensions;
+
+    impl crate::extensions::ShellExtensions for StatefulExtensions {
+        type ErrorFormatter = crate::extensions::DefaultErrorFormatter;
+        type CmdExecFilter = StatefulFilter;
+        type SourceFilter = NoOpSourceFilter;
+    }
+
+    /// Test that stateful filters with Arc<Mutex> work correctly and
+    /// demonstrate proper error handling patterns.
+    #[tokio::test]
+    #[allow(clippy::significant_drop_tightening)]
+    async fn test_stateful_filter_with_shared_state() {
+        let call_count = std::sync::Arc::new(std::sync::Mutex::new(0u32));
+        let filter = StatefulFilter {
+            call_count: call_count.clone(),
+        };
+
+        let shell: Shell<StatefulExtensions> = Shell::builder_with_extensions()
+            .cmd_exec_filter(filter)
+            .build()
+            .await
+            .unwrap();
+
+        // Run filter twice
+        for _ in 0..2 {
+            let args = ["test".to_string()];
+            let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+            let _result: SimpleCmdOutput = with_filter!(
+                shell,
+                cmd_exec_filter,
+                pre_simple_cmd,
+                post_simple_cmd,
+                params,
+                Ok(crate::ExecutionSpawnResult::Completed(
+                    crate::ExecutionResult::success()
+                ))
+            );
+        }
+
+        // Verify state was updated
+        let count = call_count.lock().unwrap();
+        assert_eq!(*count, 2, "filter should have been called twice");
+    }
+
+    /// Test that a filter gracefully handles a poisoned mutex (doesn't panic).
+    /// This demonstrates the recommended error handling pattern for filter authors.
+    #[tokio::test]
+    #[allow(clippy::panic_in_result_fn, clippy::panic)]
+    async fn test_filter_handles_poisoned_mutex_gracefully() -> Result<(), crate::Error> {
+        let call_count = std::sync::Arc::new(std::sync::Mutex::new(0u32));
+
+        // Poison the mutex by panicking while holding the lock in another thread
+        let count_clone = call_count.clone();
+        let handle = std::thread::spawn(move || {
+            let _guard = count_clone.lock().unwrap();
+            panic!("intentional panic to poison mutex");
+        });
+        // Wait for the thread to finish (it will panic)
+        let _ = handle.join();
+
+        // Verify the mutex is poisoned
+        assert!(
+            call_count.lock().is_err(),
+            "mutex should be poisoned after panic"
+        );
+
+        // Now test that our filter pattern handles this gracefully
+        let filter = StatefulFilter {
+            call_count: call_count.clone(),
+        };
+
+        let shell: Shell<StatefulExtensions> = Shell::builder_with_extensions()
+            .cmd_exec_filter(filter)
+            .build()
+            .await?;
+
+        let args = ["test".to_string()];
+        let params = SimpleCmdParams::new(&shell, "test", args.as_slice());
+
+        // This should NOT panic even though the mutex is poisoned,
+        // because our filter uses `if let Ok(...)` pattern
+        let result: SimpleCmdOutput = with_filter!(
+            shell,
+            cmd_exec_filter,
+            pre_simple_cmd,
+            post_simple_cmd,
+            params,
+            Ok(crate::ExecutionSpawnResult::Completed(
+                crate::ExecutionResult::success()
+            ))
+        );
+
+        // Operation should still succeed (filter gracefully ignores poisoned mutex)
+        assert!(result.is_ok());
+        Ok(())
+    }
+}

--- a/brush-core/src/lib.rs
+++ b/brush-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod escape;
 pub mod expansion;
 mod extendedtests;
 pub mod extensions;
+pub mod filter;
 pub mod functions;
 pub mod history;
 pub mod int_utils;

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -61,6 +61,14 @@ pub struct Shell<SE: extensions::ShellExtensions = extensions::DefaultShellExten
     #[cfg_attr(feature = "serde", serde(skip, default = "default_error_formatter"))]
     error_formatter: SE::ErrorFormatter,
 
+    /// Command execution filter.
+    #[cfg_attr(feature = "serde", serde(skip, default = "default_cmd_exec_filter"))]
+    cmd_exec_filter: SE::CmdExecFilter,
+
+    /// Source filter.
+    #[cfg_attr(feature = "serde", serde(skip, default = "default_source_filter"))]
+    source_filter: SE::SourceFilter,
+
     /// Trap handler configuration for the shell.
     traps: crate::traps::TrapHandlerConfig,
 
@@ -151,6 +159,8 @@ impl<SE: extensions::ShellExtensions> Clone for Shell<SE> {
     fn clone(&self) -> Self {
         Self {
             error_formatter: self.error_formatter.clone(),
+            cmd_exec_filter: self.cmd_exec_filter.clone(),
+            source_filter: self.source_filter.clone(),
             traps: self.traps.clone(),
             open_files: self.open_files.clone(),
             working_dir: self.working_dir.clone(),
@@ -214,6 +224,8 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
         // Instantiate the shell with some defaults.
         let mut shell = Self {
             error_formatter: options.error_formatter,
+            cmd_exec_filter: options.cmd_exec_filter,
+            source_filter: options.source_filter,
             open_files: openfiles::OpenFiles::new(),
             options: runtime_options,
             name: options.shell_name,
@@ -346,6 +358,16 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
         } else {
             keywords::KEYWORDS.contains(s)
         }
+    }
+
+    /// Returns the command execution filter.
+    pub const fn cmd_exec_filter(&self) -> &SE::CmdExecFilter {
+        &self.cmd_exec_filter
+    }
+
+    /// Returns the source filter.
+    pub const fn source_filter(&self) -> &SE::SourceFilter {
+        &self.source_filter
     }
 
     pub(crate) const fn last_exit_status_change_count(&self) -> usize {
@@ -550,4 +572,14 @@ impl<SE: extensions::ShellExtensions> ShellState for Shell<SE> {
 #[cfg(feature = "serde")]
 fn default_error_formatter<EF: extensions::ErrorFormatter>() -> EF {
     EF::default()
+}
+
+#[cfg(feature = "serde")]
+fn default_cmd_exec_filter<CF: crate::filter::CmdExecFilter>() -> CF {
+    CF::default()
+}
+
+#[cfg(feature = "serde")]
+fn default_source_filter<SF: crate::filter::SourceFilter>() -> SF {
+    SF::default()
 }

--- a/brush-core/src/shell/builder.rs
+++ b/brush-core/src/shell/builder.rs
@@ -146,6 +146,12 @@ pub struct CreateOptions<SE: extensions::ShellExtensions = extensions::DefaultSh
     /// Error behavior implementation.
     #[builder(default)]
     pub error_formatter: SE::ErrorFormatter,
+    /// Command execution filter.
+    #[builder(default)]
+    pub cmd_exec_filter: SE::CmdExecFilter,
+    /// Source filter.
+    #[builder(default)]
+    pub source_filter: SE::SourceFilter,
     /// Disallow overwriting regular files via output redirection.
     #[builder(default)]
     pub disallow_overwriting_regular_files_via_output_redirection: bool,
@@ -239,6 +245,8 @@ impl<SE: extensions::ShellExtensions> Default for Shell<SE> {
     fn default() -> Self {
         Self {
             error_formatter: SE::ErrorFormatter::default(),
+            cmd_exec_filter: SE::CmdExecFilter::default(),
+            source_filter: SE::SourceFilter::default(),
             traps: traps::TrapHandlerConfig::default(),
             open_files: openfiles::OpenFiles::default(),
             working_dir: PathBuf::default(),

--- a/brush-core/src/shell/execution.rs
+++ b/brush-core/src/shell/execution.rs
@@ -4,8 +4,11 @@ use std::{io::Read, path::Path};
 
 use crate::{
     ExecutionControlFlow, ExecutionParameters, ExecutionResult, ProcessGroupPolicy, SourceInfo,
-    arithmetic::Evaluatable as _, callstack, error, interp::Execute as _, openfiles,
-    trace_categories,
+    arithmetic::Evaluatable as _,
+    callstack, error,
+    filter::{SourceFilter as _, SourceScriptParams},
+    interp::Execute as _,
+    openfiles, trace_categories,
 };
 
 impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
@@ -51,13 +54,29 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         args: I,
         params: &ExecutionParameters,
     ) -> Result<ExecutionResult, error::Error> {
-        self.parse_and_execute_script_file(
-            path.as_ref(),
-            args,
-            params,
-            callstack::ScriptCallType::Source,
+        // Collect args and create filter params.
+        let args_vec: Vec<String> = args.map(Into::into).collect();
+        let filter_params = SourceScriptParams::new(self, path.as_ref(), args_vec.as_slice());
+
+        crate::with_filter!(
+            self,
+            source_filter,
+            pre_source_script,
+            post_source_script,
+            filter_params,
+            p => {
+                // Extract owned values to release the borrow on self
+                let path = p.path.into_owned();
+                let args = p.args.into_owned();
+                self.parse_and_execute_script_file(
+                    &path,
+                    args.iter().cloned(),
+                    params,
+                    callstack::ScriptCallType::Source,
+                )
+                .await
+            }
         )
-        .await
     }
 
     /// Parse and execute the given file as a shell script, returning the execution result.

--- a/docs/reference/filter-architecture.md
+++ b/docs/reference/filter-architecture.md
@@ -1,0 +1,261 @@
+# Filter Architecture
+
+This document describes the filter infrastructure in brush, which provides hooks for intercepting and modifying shell operations.
+
+## Design Philosophy
+
+### Zero-Overhead Abstraction
+
+Filters use Rust's trait system and monomorphization to achieve zero runtime cost when using the default no-op filters:
+
+- Filter types are generic parameters on `Shell<SE>` where `SE: ShellExtensions`
+- No-op filters are zero-sized types (ZSTs) with inline default implementations
+- The compiler eliminates filter code paths entirely when no-op filters are used
+- Custom filters incur only the cost of their actual implementation
+
+### Minimal Hook-Site Boilerplate
+
+The `with_filter!` macro reduces boilerplate at hook sites:
+
+```rust
+// Observation-only hook (params not used after filter)
+with_filter!(
+    shell,
+    cmd_exec_filter,
+    pre_simple_cmd,
+    post_simple_cmd,
+    SimpleCmdParams::new(&shell, cmd_name, &args),
+    execute_impl().await
+)
+
+// Hook with params capture (for filters that modify)
+with_filter!(
+    shell,
+    source_filter,
+    pre_source_script,
+    post_source_script,
+    SourceScriptParams::new(&shell, path, &args),
+    |p| run_script(p.path(), p.args()).await
+)
+```
+
+## Current Filters
+
+### CmdExecFilter
+
+Hooks for command execution at two levels:
+
+| Hook | Scope | Modification Support |
+|------|-------|---------------------|
+| `pre_simple_cmd` | All commands (builtins, functions, externals) | Observation/short-circuit only |
+| `post_simple_cmd` | After any command | Result transformation |
+| `pre_external_cmd` | External process spawning only | Full modification via `ExternalCommand` |
+| `post_external_cmd` | After external spawn | Result transformation |
+
+**Execution Flow:**
+```
+Command Invoked
+    │
+    ▼
+pre_simple_cmd ──[Return]──► Short-circuit with result
+    │
+    │ [Continue]
+    ▼
+Resolve command type (builtin/function/external)
+    │
+    ├─[Builtin]──► Execute builtin
+    ├─[Function]─► Execute function
+    └─[External]─┬► pre_external_cmd ──[Return]──► Short-circuit
+                 │      │ [Continue]
+                 │      ▼
+                 │  Spawn process
+                 │      │
+                 │      ▼
+                 └► post_external_cmd
+    │
+    ▼
+post_simple_cmd
+    │
+    ▼
+Return result
+```
+
+### SourceFilter
+
+Hooks for script sourcing (`.` and `source` builtins):
+
+| Hook | Purpose |
+|------|---------|
+| `pre_source_script` | Observe/modify path and args, or block sourcing |
+| `post_source_script` | Transform execution result |
+
+## Filter Result Types
+
+### PreFilterResult
+
+```rust
+pub enum PreFilterResult<I, O> {
+    /// Continue with operation, optionally with modified input
+    Continue(I),
+    /// Short-circuit and return this result immediately
+    Return(O),
+}
+```
+
+### PostFilterResult
+
+```rust
+pub enum PostFilterResult<O> {
+    /// Return this (possibly modified) result
+    Return(O),
+}
+```
+
+## Implementing Custom Filters
+
+### Basic Example
+
+```rust
+use brush_core::filter::{CmdExecFilter, PreFilterResult, SimpleCmdParams, SimpleCmdOutput};
+use brush_core::extensions::ShellExtensions;
+
+#[derive(Clone, Default)]
+struct LoggingFilter;
+
+impl CmdExecFilter for LoggingFilter {
+    async fn pre_simple_cmd<'a, SE: ShellExtensions>(
+        &self,
+        params: SimpleCmdParams<'a, SE>,
+    ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+        println!("Executing: {}", params.command_name());
+        PreFilterResult::Continue(params)
+    }
+}
+```
+
+### Stateful Filter with Shared State
+
+```rust
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct AuditingFilter {
+    log: Arc<Mutex<Vec<String>>>,
+}
+
+impl CmdExecFilter for AuditingFilter {
+    async fn pre_simple_cmd<'a, SE: ShellExtensions>(
+        &self,
+        params: SimpleCmdParams<'a, SE>,
+    ) -> PreFilterResult<SimpleCmdParams<'a, SE>, SimpleCmdOutput> {
+        if let Ok(mut log) = self.log.lock() {
+            log.push(params.command_name().to_string());
+        }
+        PreFilterResult::Continue(params)
+    }
+}
+```
+
+### Wiring Filters into Shell
+
+1. **Define ShellExtensions implementation:**
+
+```rust
+use brush_core::extensions::{ShellExtensions, DefaultErrorFormatter};
+use brush_core::filter::{NoOpSourceFilter};
+
+#[derive(Clone, Default)]
+struct MyExtensions {
+    cmd_filter: MyCustomFilter,
+}
+
+impl ShellExtensions for MyExtensions {
+    type ErrorFormatter = DefaultErrorFormatter;
+    type CmdExecFilter = MyCustomFilter;
+    type SourceFilter = NoOpSourceFilter;
+}
+```
+
+2. **Build shell with extensions:**
+
+```rust
+let shell = Shell::builder_with_extensions::<MyExtensions>()
+    .cmd_exec_filter(my_preconfigured_filter)
+    .build()
+    .await?;
+```
+
+## Thread Safety
+
+Filters must implement `Clone + Send + Sync + 'static`:
+
+- **Clone**: Filters may be cloned when shell is forked
+- **Send + Sync**: Filters are accessed from async contexts
+- **'static**: Filters live as long as the shell
+
+For shared mutable state, use `Arc<Mutex<T>>` or `Arc<RwLock<T>>`. The `Arc` ensures state is shared across shell clones (subshells).
+
+## Panic Safety
+
+**Filter implementations must not panic.** Panics in filter methods will propagate through the shell and may terminate the process. There is no `catch_unwind` wrapper around filter invocations for performance reasons.
+
+When implementing filters with fallible operations:
+
+```rust
+// DO: Handle errors gracefully
+if let Ok(mut log) = self.log.lock() {
+    log.push(entry);
+}
+
+// DON'T: Panic on lock failure
+self.log.lock().unwrap().push(entry);  // May panic on poisoned mutex!
+```
+
+## Future Filters
+
+See `docs/todo/` for planned filter types:
+
+- **ExpansionFilter**: Word expansion hooks
+- **EnvFilter**: Variable mutation hooks
+- **RedirectionFilter**: File open hooks
+- **IoFilter**: Per-I/O operation hooks
+
+## Future Considerations
+
+The following considerations apply to planned filter types and may influence the current design:
+
+### Performance-Critical Filter Paths
+
+**EnvFilter** (variable reads) and **IoFilter** (read/write operations) will be invoked extremely frequently:
+
+- Every `$variable` expansion triggers EnvFilter
+- Every `echo`, `printf`, or pipe read/write triggers IoFilter
+- The current design clones filters before invocation; this is zero-cost for ZSTs but has `Arc` overhead for stateful filters
+- Future optimization may introduce `&self` reference-based invocation for read-only filter operations (see `docs/todo/filter-clone-optimization.md`)
+
+### Zero-Copy Data Handling
+
+**IoFilter** will need to handle data buffers efficiently:
+
+- The current `Cow<'a, [u8]>` pattern (used in params) supports both borrowed and owned data
+- Filters that only observe data should avoid cloning
+- Filters that transform data can return owned variants
+- Consider providing `Bytes` or similar zero-copy types for large data
+
+### Synchronous vs Asynchronous Hooks
+
+Current filters are async-only. Future high-frequency filters may benefit from sync paths:
+
+- EnvFilter read hooks could be synchronous for common cases
+- IoFilter sync hooks could reduce overhead for small I/O operations
+- May require trait-level distinction or separate hook methods
+
+### Hook Granularity
+
+Future filters face granularity tradeoffs:
+
+- **Coarse**: Single `pre_expand` hook for all expansion types (simpler, less control)
+- **Fine**: Separate hooks per expansion type (complex, precise control)
+- Current `CmdExecFilter` uses fine granularity (`pre_simple_cmd` + `pre_external_cmd`)
+- Recommendation: Start fine-grained, compose via `FilterStack` for coarser needs
+


### PR DESCRIPTION
**Draft, and mostly not my work.** The first commit is @reubeno's #972 (`static-filter-attempt-minimized`), rebased onto current `main`. The second is one fix on top. Opened as a draft so the rebase is reviewable rather than described — take it, adapt it, or close it; it's your design and I'd rather you drive it.

Context in #1183: you asked me in June whether the statically registered filters would serve our use case, I didn't answer and pushed a competing seam in #1184 instead. #1184 is now closed. This is me answering properly.

## Commit 1 — #972 rebased onto `30a3bce`

One cherry-pick. Only two files conflicted, `brush-core/src/commands.rs` and `brush-core/src/shell/execution.rs`. Two things in `execute_via_external` needed carrying forward that the branch predates, and are easy to lose in a mechanical rebase:

- `main`'s `argv0` override — `execute_external_command` grew an `argv0_override` parameter, which the branch's call site doesn't pass;
- `main`'s `$_` update after external commands (`update_last_arg_variable`), which the branch's `finally` block drops.

Both are restored in the rebase.

## Commit 2 — route the `exec` builtin through the filter

`brush-builtins/src/exec.rs` composes its own `std::process::Command` and calls `CommandExt::exec`, replacing the shell process image without ever reaching `execute_external_command`. So a `CmdExecFilter` that denies `rm` is still replaceable by `exec /bin/rm`. #972 touches no `brush-builtins/` files, so the gap is inherited.

This runs the same `pre_external_cmd` filter in the builtin, before `cmd.exec()`, and resolves the program first (new `commands::resolve_external_program`) so the filter is shown the executable that will actually run — otherwise the OS redoes its own `PATH` search against the child environment, which need not match the shell's.

`PreFilterResult` is `#[non_exhaustive]`, and this site is about to replace the process image, so an unrecognized decision fails closed rather than being guessed at as "continue".

**Test.** Cases run in a dedicated child process — this test binary, re-invoked — because a successful `exec` replaces the process image and a broken implementation takes the test runner with it. Each asserts the marker the denied program would have created does not exist, and that the filter was consulted exactly once. Against the unfiltered `exec.rs` they fail with `the denied program ran and replaced the shell: /tmp/.../marker exists`.

## What I found porting a real policy onto this

Offered as feedback, not as requests. Our downstream is an object-capability layer for LLM coding agents; the shell is the tool surface, and a per-invocation grant has to be enforced in-process because a name containing a path separator bypasses both `PATH` and the builtin table.

1. **`ExternalCmdParams` exposes neither the command name as written nor `argv0`** — only the `ExternalCommand` (program, args, envs, cwd). A policy can't match on the spelling used, and can't see `exec -a impostor /usr/bin/touch`. I dropped two tests in the port because the information isn't there.
2. **`cmd_exec_filter` is `#[serde(skip, default = …)]`** — a serialized shell returns with a freshly-defaulted filter rather than the installed one. If the default is the no-op, a round-trip silently unconfines; if it isn't, a stateful policy still returns without its state.
3. **A successful `exec` never returns**, so `post_external_cmd` can never fire for it. An audit log assuming pre/post pairing will mis-attribute it — probably worth a line in `filter-architecture.md`.
4. **Redirections aren't covered.** `SourceFilter` handles `.`/`source`, but `>`, `>>` and `<>` reach `Shell::open_file` unfiltered. All four `open_file` call sites already know their access intent explicitly, so it needn't be recovered after the fact.
5. **A denial can be swallowed** by an enclosing `while … done`, which for a runaway-bounding policy means the leash doesn't hold. We needed a notion of a *terminating* error downstream.
6. **A filter that can rewrite the command** means what was authorized and what runs can differ, and under composition a later filter can rewrite what an earlier one approved. Worth a documented rule about which filter's output is final.

## Validation

At the head commit against base `30a3bce`: `cargo xtask ci pre-commit` — fmt, build, clippy `--workspace --all-features --all-targets`, schemas clean; unit **390/390**; integration (nextest `--workspace`) **2709/2709**; `cargo test --test brush-compat-tests` unchanged from clean `main`.

`cargo deny` reports `advisories FAILED`, identically on clean `main`: `chacha20 0.10.1` was yanked after the lockfile was pinned. `cargo update -p chacha20` resolves to 0.10.2.

> Authored with AI assistance and reviewed and tested by a human contributor; commits carry `Assisted-by:` trailers. The first commit is @reubeno's, unmodified except for the rebase conflicts noted above.
