### PR TITLE
build(deps): update chacha20 to 0.10.2 to clear a yanked-crate advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,9 +795,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
`chacha20 0.10.1` was yanked from crates.io after the lockfile was pinned, so `cargo deny check advisories` started failing on its own:

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
  chacha20 v0.10.1
```

This fails on `main`, and therefore on every open PR, at the **Deny check** step of all six `Source code checks` jobs. The open dependabot branch still carries 0.10.1, so it isn't already in flight.

`cargo update -p chacha20` resolves to **0.10.2**; nothing else moves — the diff is two lines of `Cargo.lock`.

Verified at `30a3bce`: `cargo deny --all-features check all` → `advisories ok, bans ok, licenses ok, sources ok` (it reported `advisories FAILED` before). `cargo xtask ci quick` — fmt, build, clippy clean; unit 378/378.

There is one unrelated leftover the same run warns about, not touched here: the `deny.toml` ignore for `RUSTSEC-2026-0253` no longer matches any crate. It's a warning, not a failure. Happy to drop it in a follow-up if you'd like.

> Authored with AI assistance and reviewed and tested by a human contributor; the commit carries an `Assisted-by:` trailer.