### PR TITLE
Targeted alias fixes

### DIFF
--- a/brush-builtins/src/alias.rs
+++ b/brush-builtins/src/alias.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use itertools::Itertools;
 use std::io::Write;
 
 use brush_core::{ExecutionResult, builtins};
@@ -25,7 +26,8 @@ impl builtins::Command for AliasCommand {
         let mut exit_code = ExecutionResult::success();
 
         if self.print || self.aliases.is_empty() {
-            for (name, value) in context.shell.aliases() {
+            // Aliases are stored unordered; bash lists them sorted by name.
+            for (name, value) in context.shell.aliases().iter().sorted() {
                 writeln!(context.stdout(), "alias {name}='{value}'")?;
             }
         } else {

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -1,6 +1,7 @@
 //! Implements programmable command completion support.
 
 use clap::ValueEnum;
+use itertools::Itertools;
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -466,7 +467,8 @@ impl Spec {
         for action in &self.actions {
             match action {
                 CompleteAction::Alias => {
-                    for name in shell.aliases().keys() {
+                    // Aliases are stored unordered; bash enumerates them sorted by name.
+                    for name in shell.aliases().keys().sorted() {
                         if name.starts_with(token) {
                             candidates.push(name.clone());
                         }
@@ -508,7 +510,8 @@ impl Spec {
                             candidates.push(keyword.to_string());
                         }
                     }
-                    for (name, _) in shell.funcs().iter() {
+                    // Functions are stored unordered; bash enumerates them sorted by name.
+                    for (name, _) in shell.funcs().iter().sorted_by_key(|v| v.0) {
                         candidates.push(name.to_owned());
                     }
                 }
@@ -544,7 +547,8 @@ impl Spec {
                     candidates.append(&mut file_completions);
                 }
                 CompleteAction::Function => {
-                    for (name, _) in shell.funcs().iter() {
+                    // Functions are stored unordered; bash enumerates them sorted by name.
+                    for (name, _) in shell.funcs().iter().sorted_by_key(|v| v.0) {
                         candidates.push(name.to_owned());
                     }
                 }

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -512,7 +512,9 @@ impl Spec {
                     }
                     // Functions are stored unordered; bash enumerates them sorted by name.
                     for (name, _) in shell.funcs().iter().sorted_by_key(|v| v.0) {
-                        candidates.push(name.to_owned());
+                        if name.starts_with(token) {
+                            candidates.push(name.to_owned());
+                        }
                     }
                 }
                 CompleteAction::Directory => {

--- a/brush-core/src/interp.rs
+++ b/brush-core/src/interp.rs
@@ -799,17 +799,12 @@ impl Execute for ast::ForClauseCommand {
 
         // If we were given explicit words to iterate over, then expand them all, with splitting
         // enabled.
-        let mut expanded_values = vec![];
-        if let Some(unexpanded_values) = &self.values {
-            for value in unexpanded_values {
-                let mut expanded =
-                    expansion::full_expand_and_split_word(shell, params, value).await?;
-                expanded_values.append(&mut expanded);
-            }
+        let expanded_values = if let Some(unexpanded_values) = &self.values {
+            expand_words(shell, params, unexpanded_values).await?
         } else {
             // Otherwise, we use the current positional parameters.
-            expanded_values.extend_from_slice(shell.current_shell_args());
-        }
+            shell.current_shell_args().to_vec()
+        };
 
         for value in expanded_values {
             if shell.options().print_commands_and_arguments {
@@ -1226,17 +1221,21 @@ impl<SE: extensions::ShellExtensions> ExecuteInPipeline<SE> for ast::SimpleComma
 
                     if args.is_empty() {
                         if let Some(cmd_name) = next_args.first() {
-                            if let Some(alias_value) =
-                                context.shell.aliases().get(cmd_name.as_str())
+                            // Aliases are only expanded when `expand_aliases` is enabled; it's
+                            // enabled by default for interactive shells.
+                            if context.shell.options().expand_aliases
+                                && let Some(alias_value) =
+                                    context.shell.aliases().get(cmd_name.as_str())
                             {
                                 //
                                 // TODO(#57): This is a total hack; aliases are supposed to be
                                 // handled much earlier in the process.
                                 //
-                                let mut alias_pieces: Vec<_> = alias_value
-                                    .split_ascii_whitespace()
-                                    .map(|i| i.to_owned())
-                                    .collect();
+                                // N.B. Tokenizing first releases our borrow of the shell's aliases,
+                                // so we can take a mutable borrow of the shell to expand the words.
+                                let alias_words = tokenize_alias_body(&context.shell, alias_value);
+                                let mut alias_pieces =
+                                    expand_words(&mut context.shell, &params, alias_words).await?;
 
                                 next_args.remove(0);
                                 alias_pieces.append(&mut next_args);
@@ -1244,15 +1243,15 @@ impl<SE: extensions::ShellExtensions> ExecuteInPipeline<SE> for ast::SimpleComma
                                 next_args = alias_pieces;
                             }
 
-                            let first_arg = next_args[0].as_str();
-
                             // Check if we're going to be invoking a special declaration builtin.
-                            // That will change how we parse and process args.
-                            if context
-                                .shell
-                                .builtins()
-                                .get(first_arg)
-                                .is_some_and(|r| !r.disabled && r.declaration_builtin)
+                            // That will change how we parse and process args. (An alias with an
+                            // empty body leaves us with no words at all.)
+                            if let Some(first_arg) = next_args.first()
+                                && context
+                                    .shell
+                                    .builtins()
+                                    .get(first_arg.as_str())
+                                    .is_some_and(|r| !r.disabled && r.declaration_builtin)
                             {
                                 command_takes_assignments = true;
                             }
@@ -1386,6 +1385,45 @@ async fn execute_command<T: Into<String>>(
     // Execute
     // TODO(jobs): do we need to move self back to foreground on error here?
     cmd.execute().await
+}
+
+/// Tokenizes the body of an alias into the unexpanded words that should replace the aliased command
+/// name.
+///
+/// This only handles alias bodies that amount to a simple sequence of words; bodies containing
+/// operators (pipes, redirections, `&&`, ...) and recursive expansion of chained aliases require
+/// alias substitution to happen in the tokenizer instead (see issue #57).
+fn tokenize_alias_body(
+    shell: &Shell<impl extensions::ShellExtensions>,
+    alias_value: &str,
+) -> Vec<String> {
+    // Tokenize the body the same way the shell would tokenize any other input it's given.
+    let options = shell.parser_options().tokenizer_options();
+
+    // If we can't tokenize the body, fall back to naively splitting it on whitespace.
+    brush_parser::tokenize_str_with_options(alias_value, &options).map_or_else(
+        |_| {
+            alias_value
+                .split_ascii_whitespace()
+                .map(str::to_owned)
+                .collect()
+        },
+        |tokens| tokens.iter().map(|t| t.to_str().to_owned()).collect(),
+    )
+}
+
+/// Expands the given words, with splitting enabled, yielding the fields they expand to.
+async fn expand_words(
+    shell: &mut Shell<impl extensions::ShellExtensions>,
+    params: &ExecutionParameters,
+    words: impl IntoIterator<Item = impl AsRef<str>>,
+) -> Result<Vec<String>, error::Error> {
+    // N.B. Expansion needs `&mut shell`, so the words have to be expanded in sequence.
+    let mut fields = vec![];
+    for word in words {
+        fields.extend(expansion::full_expand_and_split_word(shell, params, word).await?);
+    }
+    Ok(fields)
 }
 
 async fn expand_assignment(

--- a/brush-shell/tests/cases/compat/builtins/alias.yaml
+++ b/brush-shell/tests/cases/compat/builtins/alias.yaml
@@ -1,11 +1,234 @@
 name: "Builtins: alias"
 cases:
+  #
+  # Defining, listing, and removing aliases.
+  #
+
   - name: "Basic alias usage"
     stdin: |
       shopt -s expand_aliases
       alias myalias=echo
       alias
       myalias 'hello'
+
+  - name: "Alias listing"
+    stdin: |
+      alias a=echo
+      alias b='ls -l'
+      alias
+      echo "---"
+      alias -p
+      echo "---"
+      alias a
+      echo "exit=$?"
+
+  - name: "Alias listing is sorted by name"
+    stdin: |
+      alias e=5
+      alias c=3
+      alias a=1
+      alias f=6
+      alias d=4
+      alias b=2
+      alias
+
+  - name: "Redefining an alias"
+    stdin: |
+      shopt -s expand_aliases
+      alias r='echo one'
+      r
+      alias r='echo two'
+      r
+
+  - name: "Unalias"
+    stdin: |
+      shopt -s expand_aliases
+      alias x='echo aliased'
+      x
+      unalias x
+      x 2>/dev/null || echo "gone: $?"
+
+  - name: "Unalias all"
+    stdin: |
+      alias a=echo
+      alias b=echo
+      unalias -a
+      alias
+      echo "exit=$?"
+
+  - name: "Unalias non-existent alias"
+    ignore_stderr: true # brush doesn't prefix errors with script name and line
+    stdin: |
+      unalias nosuchalias
+      echo "exit=$?"
+
+  #
+  # Expansion of the alias body: quoting and word expansions.
+  #
+
+  - name: "Alias body with quoted args"
+    stdin: |
+      shopt -s expand_aliases
+      alias fmt='printf "[%s]\n" -a --format "table {{.Names}}\t{{.State}}"'
+      fmt
+
+  - name: "Alias body with single-quoted args"
+    stdin: |
+      shopt -s expand_aliases
+      alias q="printf '[%s]\n' 'a b' c"
+      q
+
+  - name: "Alias body with escaped chars"
+    stdin: |
+      shopt -s expand_aliases
+      alias esc='printf "[%s]\n" a\ b c'
+      esc
+
+  - name: "Alias body with ANSI-C quoting"
+    stdin: |
+      shopt -s expand_aliases
+      alias d='printf "[%s]\n" $'"'"'a\tb'"'"''
+      d
+
+  - name: "Alias body with variable expansion"
+    stdin: |
+      shopt -s expand_aliases
+      export MYVAR="a b"
+      alias e='printf "[%s]\n" $MYVAR "$MYVAR"'
+      e
+
+  - name: "Alias body with tilde expansion"
+    stdin: |
+      shopt -s expand_aliases
+      alias t='echo ~/sub'
+      [ "$(t)" = "$HOME/sub" ] && echo "tilde expanded"
+
+  - name: "Alias body with command substitution"
+    stdin: |
+      shopt -s expand_aliases
+      alias c='echo $(echo inner)'
+      c
+
+  - name: "Alias body with pathname expansion"
+    stdin: |
+      shopt -s expand_aliases
+      touch aa.txt ab.txt
+      alias g='printf "[%s]\n" *.txt'
+      g
+
+  - name: "Alias body is expanded at use time"
+    stdin: |
+      shopt -s expand_aliases
+      alias e='echo $MYVAR'
+      MYVAR=first
+      e
+      MYVAR=second
+      e
+
+  - name: "Alias with empty body"
+    stdin: |
+      shopt -s expand_aliases
+      alias empty=''
+      empty
+      echo "exit=$?"
+
+  - name: "Args are appended after the alias body"
+    stdin: |
+      shopt -s expand_aliases
+      alias p='printf "[%s]\n" first'
+      p second "third fourth"
+
+  #
+  # Where alias expansion applies.
+  #
+
+  - name: "Alias takes precedence over function"
+    stdin: |
+      shopt -s expand_aliases
+      myfunc() { echo function-version; }
+      alias myfunc='echo alias-version'
+      myfunc
+      unalias myfunc
+      myfunc
+
+  - name: "Alias for a command name is not recursively re-expanded"
+    stdin: |
+      shopt -s expand_aliases
+      alias echo='echo prefix'
+      echo hello
+
+  - name: "Aliases are not expanded when expand_aliases is unset"
+    stdin: |
+      alias x='echo aliased'
+      x 2>/dev/null || echo "not-expanded"
+
+  - name: "Alias used in a pipeline"
+    stdin: |
+      shopt -s expand_aliases
+      alias u='tr a-z A-Z'
+      echo hello | u
+
+  - name: "Alias used after && and ||"
+    stdin: |
+      shopt -s expand_aliases
+      alias e='echo ran'
+      true && e
+      false || e
+
+  - name: "Alias used in a function body"
+    stdin: |
+      shopt -s expand_aliases
+      alias body='echo from-alias'
+      f() { body; }
+      f
+
+  - name: "Alias used in a for loop body"
+    stdin: |
+      shopt -s expand_aliases
+      alias pr='echo item'
+      for i in 1 2; do pr $i; done
+
+  #
+  # Cases the current (execution-time) alias implementation does not handle.
+  # These need alias substitution to move into the tokenizer; see issue #57.
+  #
+
+  - name: "Quoting the command name suppresses alias expansion"
+    known_failure: true # Issue #57
+    stdin: |
+      shopt -s expand_aliases
+      alias e='echo aliased'
+      e
+      \e 2>/dev/null || echo "backslash-suppressed"
+      "e" 2>/dev/null || echo "quote-suppressed"
+
+  - name: "Alias body containing a pipeline"
+    known_failure: true # Issue #57
+    stdin: |
+      shopt -s expand_aliases
+      alias pl='echo hello | tr a-z A-Z'
+      pl
+
+  - name: "Alias body containing a redirection"
+    known_failure: true # Issue #57
+    stdin: |
+      shopt -s expand_aliases
+      alias w='echo written > out.txt'
+      w
+      cat out.txt
+
+  - name: "Alias body containing a command separator"
+    known_failure: true # Issue #57
+    stdin: |
+      shopt -s expand_aliases
+      alias two='echo one; echo two'
+      two
+
+  - name: "Alias defined and used on the same line"
+    known_failure: true # Issue #57
+    stdin: |
+      shopt -s expand_aliases
+      alias sl='echo same-line'; sl
 
   - name: "Alias with trailing space"
     known_failure: true # Issue #57

--- a/brush-shell/tests/cases/compat/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/compat/builtins/compgen.yaml
@@ -86,6 +86,14 @@ cases:
 
       compgen -A command zzf
 
+  - name: "compgen -A command only returns functions matching the prefix"
+    stdin: |
+      zzfa() { :; }
+      zzfb() { :; }
+      totally_unrelated() { :; }
+
+      compgen -A command zzf
+
   - name: "compgen -A keyword"
     stdin: |
       compgen -A keyword esa | sort

--- a/brush-shell/tests/cases/compat/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/compat/builtins/compgen.yaml
@@ -5,7 +5,18 @@ cases:
       alias myalias="ls"
       alias myalias2="echo hi"
 
-      compgen -A alias myalias | sort
+      compgen -A alias myalias
+
+  - name: "compgen -A alias is sorted by name"
+    stdin: |
+      alias e=5
+      alias c=3
+      alias a=1
+      alias f=6
+      alias d=4
+      alias b=2
+
+      compgen -A alias
 
   - name: "compgen -A binding"
     stdin: |
@@ -54,7 +65,26 @@ cases:
         echo hello
       }
 
-      compgen -A function myfunc | sort
+      compgen -A function myfunc
+
+  - name: "compgen -A function is sorted by name"
+    stdin: |
+      e() { :; }
+      c() { :; }
+      a() { :; }
+      f() { :; }
+      d() { :; }
+      b() { :; }
+
+      compgen -A function
+
+  - name: "compgen -A command is sorted by name"
+    stdin: |
+      zzfe() { :; }
+      zzfc() { :; }
+      zzfa() { :; }
+
+      compgen -A command zzf
 
   - name: "compgen -A keyword"
     stdin: |


### PR DESCRIPTION
Improves alias support by more faithfully tokenizing alias bodies, handling expansion of those tokens. Gaps still remain that are tracked by #57.

Fixes: #1308