### PR TITLE
fix(completion): only fall back to -o dirnames when nothing matched

### DIFF
--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -410,14 +410,21 @@ impl Spec {
             no_trailing_space_at_end_of_line: options.no_space,
         };
 
-        if options.plus_dirs || options.dir_names {
-            // Also add dir name completion.
+        // plusdirs always adds directory names; dirnames only does so when nothing else matched.
+        if options.plus_dirs || (options.dir_names && candidates.is_empty()) {
             let mut dir_candidates = get_file_completions(
                 shell,
                 context.token_to_complete,
                 /* must_be_dir */ true,
             )
             .await;
+
+            // If directories are all we have, let them be marked as such.
+            if candidates.is_empty() && shell.completion_config().fallback_options.mark_directories
+            {
+                processing_options.treat_as_filenames = true;
+            }
+
             candidates.append(&mut dir_candidates);
         }
 

--- a/brush-shell/tests/cases/compat/builtins/compgen.yaml
+++ b/brush-shell/tests/cases/compat/builtins/compgen.yaml
@@ -243,6 +243,20 @@ cases:
       touch subfile
       compgen -W 'completion' -o dirnames -- s | sort
 
+      echo "[Take 3]"
+      mkdir cdir cdir2
+      touch cfile
+      compgen -W 'completion' -o dirnames -- c | sort
+
+      echo "[Take 4]"
+      compgen -W 'nomatch' -o dirnames -- c | sort
+
+      echo "[Take 5]"
+      compgen -o dirnames -- c | sort
+
+      echo "[Take 6]"
+      compgen -W 'completion' -o dirnames -o plusdirs -- c | sort
+
   - name: "compgen -o default"
     stdin: |
       echo "[Take 1]"


### PR DESCRIPTION
dirnames was applied unconditionally, like plusdirs, so a compspec's own results were buried under every directory. Also mark the resulting directories so they get their trailing slash.

Extends the `compgen -o dirnames` compat case to cover the regression: a compspec that matches alongside matching directories, the empty-match fallback, dirnames with no other generator, and dirnames + plusdirs.

Assisted-By: Claude Fable 5.1