### PR TITLE
fix(history): load HISTFILE after startup files and ignore an empty one

### DIFF
--- a/brush-core/src/history.rs
+++ b/brush-core/src/history.rs
@@ -224,6 +224,11 @@ impl History {
         Ok(Search::new(self, query))
     }
 
+    /// Returns whether the history contains no items.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
     /// Returns an iterator over the history items.
     pub fn iter(&self) -> impl Iterator<Item = &self::Item> {
         Search::all(self)

--- a/brush-core/src/shell.rs
+++ b/brush-core/src/shell.rs
@@ -249,12 +249,10 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
             shell.env.set_global(var_name, var_value)?;
         }
 
-        // Set up history, if relevant. Do NOT fail if we can't load history.
+        // Set up history, if relevant. The history file itself is loaded later, once startup
+        // files have run, since they may change HISTFILE.
         if shell.options.enable_command_history {
-            shell.history = shell
-                .load_history()
-                .unwrap_or_default()
-                .or_else(|| Some(crate::history::History::default()));
+            shell.history = Some(crate::history::History::default());
         }
 
         Ok(shell)

--- a/brush-core/src/shell/builder.rs
+++ b/brush-core/src/shell/builder.rs
@@ -23,7 +23,8 @@ impl<SE: extensions::ShellExtensions, S: shell_builder::IsComplete> ShellBuilder
         // Construct the shell.
         let mut shell = Shell::new(options)?;
 
-        // Load profiles/configuration, unless skipped.
+        // Load profiles/configuration (and then history), unless skipped. Callers that skip
+        // both are expected to call `load_config` themselves before needing history.
         if !profile.skip() || !rc.skip() {
             shell.load_config(&profile, &rc).await?;
         }

--- a/brush-core/src/shell/history.rs
+++ b/brush-core/src/shell/history.rs
@@ -42,6 +42,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
     /// Returns the path to the history file used by the shell, if one is set.
     pub fn history_file_path(&self) -> Option<PathBuf> {
         self.env_str("HISTFILE")
+            .filter(|s| !s.is_empty())
             .map(|s| PathBuf::from(s.into_owned()))
     }
 

--- a/brush-core/src/shell/history.rs
+++ b/brush-core/src/shell/history.rs
@@ -36,7 +36,21 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
             }
         }
 
-        Ok(Some(crate::history::History::import(history_file)?))
+        let mut history = crate::history::History::import(history_file)?;
+
+        // As bash does, stamp entries that carry no timestamp in the file with the load time.
+        let load_time = chrono::Utc::now();
+        let unstamped: Vec<_> = history
+            .iter()
+            .filter(|item| item.timestamp.is_none())
+            .map(|item| (item.id, item.clone()))
+            .collect();
+        for (id, mut item) in unstamped {
+            item.timestamp = Some(load_time);
+            history.update_by_id(id, item)?;
+        }
+
+        Ok(Some(history))
     }
 
     /// Returns the path to the history file used by the shell, if one is set.

--- a/brush-core/src/shell/initscripts.rs
+++ b/brush-core/src/shell/initscripts.rs
@@ -41,13 +41,33 @@ impl RcLoadBehavior {
 }
 
 impl<SE: extensions::ShellExtensions> Shell<SE> {
-    /// Loads and executes standard shell configuration files (i.e., rc and profile).
+    /// Loads and executes standard shell configuration files (i.e., rc and profile), and then
+    /// loads the history file (if command history is enabled). History is loaded last since
+    /// the configuration files may change `HISTFILE`.
     ///
     /// # Arguments
     ///
     /// * `profile_behavior` - Behavior for loading profile files.
     /// * `rc_behavior` - Behavior for loading rc files.
     pub async fn load_config(
+        &mut self,
+        profile_behavior: &ProfileLoadBehavior,
+        rc_behavior: &RcLoadBehavior,
+    ) -> Result<(), error::Error> {
+        self.load_config_files(profile_behavior, rc_behavior)
+            .await?;
+
+        // Do NOT fail if we can't load history.
+        if self.options.enable_command_history
+            && let Ok(Some(history)) = self.load_history()
+        {
+            self.history = Some(history);
+        }
+
+        Ok(())
+    }
+
+    async fn load_config_files(
         &mut self,
         profile_behavior: &ProfileLoadBehavior,
         rc_behavior: &RcLoadBehavior,

--- a/brush-core/src/shell/initscripts.rs
+++ b/brush-core/src/shell/initscripts.rs
@@ -57,8 +57,13 @@ impl<SE: extensions::ShellExtensions> Shell<SE> {
         self.load_config_files(profile_behavior, rc_behavior)
             .await?;
 
-        // Do NOT fail if we can't load history.
+        // As bash does, skip the file if startup files already added entries (e.g. via
+        // `history -s`). Do NOT fail if we can't load history.
         if self.options.enable_command_history
+            && self
+                .history
+                .as_ref()
+                .is_none_or(crate::history::History::is_empty)
             && let Ok(Some(history)) = self.load_history()
         {
             self.history = Some(history);

--- a/brush-shell/tests/cases/compat/builtins/history.yaml
+++ b/brush-shell/tests/cases/compat/builtins/history.yaml
@@ -191,3 +191,88 @@ cases:
     stdin: |
       bash -c 'printf "\xff\xfe\xfd" >history-file.txt'
       HISTFILE=history-file.txt $0 -o history -c 'echo hi'
+
+  # NOTE: These cases run interactively with the harness's --norc removed so that ~/.bashrc is
+  # honored. The system rc file also runs on some distros and may set HISTTIMEFORMAT, so each
+  # .bashrc unsets it.
+  - name: "HISTFILE loaded from environment"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    removed_default_args: ["--norc"]
+    args: ["-i"]
+    home_dir: "."
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          a b c
+          1 2 3
+      - path: ".bashrc"
+        contents: |
+          unset HISTTIMEFORMAT
+    stdin: |
+      history
+
+  - name: "HISTFILE changed by .bashrc"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    removed_default_args: ["--norc"]
+    args: ["-i"]
+    home_dir: "."
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          a b c
+          1 2 3
+      - path: "other-history-file.txt"
+        contents: |
+          x y z
+      - path: ".bashrc"
+        contents: |
+          unset HISTTIMEFORMAT
+          HISTFILE=other-history-file.txt
+    stdin: |
+      history
+
+  - name: "HISTFILE emptied by .bashrc"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    removed_default_args: ["--norc"]
+    args: ["-i"]
+    home_dir: "."
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          a b c
+          1 2 3
+      - path: ".bashrc"
+        contents: |
+          unset HISTTIMEFORMAT
+          HISTFILE=
+    stdin: |
+      history
+
+  - name: "empty HISTFILE in environment"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    removed_default_args: ["--norc"]
+    args: ["-i"]
+    home_dir: "."
+    env:
+      HISTFILE: ""
+    test_files:
+      - path: ".bashrc"
+        contents: |
+          unset HISTTIMEFORMAT
+    stdin: |
+      history
+
+  - name: "history -w with empty HISTFILE"
+    min_oracle_version: "5.3" # bash 5.2 fails with status 1; 5.3 warns but succeeds
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    args: ["-i"]
+    env:
+      HISTFILE: ""
+    stdin: |
+      history -w; echo "status: $?"

--- a/brush-shell/tests/cases/compat/builtins/history.yaml
+++ b/brush-shell/tests/cases/compat/builtins/history.yaml
@@ -276,3 +276,19 @@ cases:
       HISTFILE: ""
     stdin: |
       history -w; echo "status: $?"
+
+  - name: "loaded history entries without timestamps are stamped with load time"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    args: ["-i"]
+    env:
+      HISTFILE: "history-file.txt"
+      HISTTIMEFORMAT: "[stamped] "
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          a b c
+          1 2 3
+    stdin: |
+      history
+      # Unset HISTFILE before exit so no wall-clock timestamp gets written to the file.
+      unset HISTFILE

--- a/brush-shell/tests/cases/compat/builtins/history.yaml
+++ b/brush-shell/tests/cases/compat/builtins/history.yaml
@@ -277,6 +277,65 @@ cases:
     stdin: |
       history -w; echo "status: $?"
 
+  - name: "history -s in .bashrc suppresses loading HISTFILE"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    removed_default_args: ["--norc"]
+    args: ["-i"]
+    home_dir: "."
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          a b c
+          1 2 3
+      - path: ".bashrc"
+        contents: |
+          unset HISTTIMEFORMAT
+          history -s marker
+    stdin: |
+      history
+
+  - name: "history -s then -c in .bashrc still loads HISTFILE"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    removed_default_args: ["--norc"]
+    args: ["-i"]
+    home_dir: "."
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          a b c
+          1 2 3
+      - path: ".bashrc"
+        contents: |
+          unset HISTTIMEFORMAT
+          history -s marker
+          history -c
+    stdin: |
+      history
+
+  - name: "history -s then -d in .bashrc still loads HISTFILE"
+    ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
+    removed_default_args: ["--norc"]
+    args: ["-i"]
+    home_dir: "."
+    env:
+      HISTFILE: "history-file.txt"
+    test_files:
+      - path: "history-file.txt"
+        contents: |
+          a b c
+          1 2 3
+      - path: ".bashrc"
+        contents: |
+          unset HISTTIMEFORMAT
+          history -s marker
+          history -d 1
+    stdin: |
+      history
+
   - name: "loaded history entries without timestamps are stamped with load time"
     ignore_stderr: true # Ignore job control warnings from interactive shell without a tty
     args: ["-i"]


### PR DESCRIPTION
History was read before rc files ran, so `HISTFILE=` (or any change to HISTFILE) in .bashrc had no effect on what was loaded, and an empty HISTFILE was treated as a path. Load it at the end of `load_config`, which covers both the builder and the brush binary (which loads config itself after building).

Assisted-By: Claude Fable 5.1