### PR TITLE
fix(vars): give EPOCHREALTIME fixed six-digit microsecond precision

### DIFF
--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -245,7 +245,15 @@ pub(crate) fn init_well_known_vars(
                 let since_epoch = now
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default();
-                since_epoch.as_secs_f64().to_string().into()
+                // Match bash: seconds with exactly six fractional (microsecond) digits,
+                // zero-padded. Tools strip the dot and do integer math on the result
+                // (atuin computes command durations this way), so the width must be fixed.
+                std::format!(
+                    "{}.{:06}",
+                    since_epoch.as_secs(),
+                    since_epoch.subsec_micros()
+                )
+                .into()
             },
             setter: |_| (),
         }),

--- a/brush-shell/tests/cases/compat/well_known_vars.yaml
+++ b/brush-shell/tests/cases/compat/well_known_vars.yaml
@@ -256,3 +256,12 @@ cases:
       second=${SRANDOM}
 
       [[ $first != $second ]] && echo "Confirmed SRANDOM at least isn't static"
+
+  - name: "EPOCHREALTIME has fixed six-digit microsecond precision"
+    stdin: |
+      # Tools strip the dot and do integer math, so the fractional part must always be
+      # exactly six digits (like bash), regardless of trailing zeros.
+      for i in 1 2 3 4 5; do
+        [[ $EPOCHREALTIME =~ ^[0-9]+\.[0-9]{6}$ ]] || echo "bad format: $EPOCHREALTIME"
+      done
+      echo "done"


### PR DESCRIPTION
brush formatted EPOCHREALTIME via f64, yielding six or seven fractional digits depending on rounding. bash always emits exactly six (microseconds, zero-padded). Tools strip the dot and do integer math on the result, so a variable width breaks them.

Assisted-By: Claude Opus 4.8