### PR TITLE
fix(interactive): handle Signal::HostCommand so bind -x keys don't kill the shell

### DIFF
--- a/brush-interactive/src/reedline/input_backend.rs
+++ b/brush-interactive/src/reedline/input_backend.rs
@@ -157,12 +157,21 @@ impl InputBackend for ReedlineInputBackend {
         if let Some(reedline) = &mut self.reedline {
             match reedline.read_line(&prompt) {
                 Ok(reedline::Signal::Success(s)) => {
+                    // reedline < 0.48 delivered `ExecuteHostCommand` payloads through
+                    // `Success` (hence the marker check); newer versions use the
+                    // dedicated `HostCommand` signal below. Keep both so the marker
+                    // round-trip stays correct regardless of which one we get.
                     if edit_mode::is_reedline_host_command(s.as_str()) {
                         Ok(ReadResult::BoundCommand(s))
                     } else {
                         Ok(ReadResult::Input(s))
                     }
                 }
+                // Since reedline 0.48 (nushell/reedline#1049), a key bound with
+                // `bind -x` comes back as `Signal::HostCommand` rather than
+                // `Signal::Success`. Without this arm it fell into the catch-all
+                // below and every bound key press terminated the interactive shell.
+                Ok(reedline::Signal::HostCommand(s)) => Ok(ReadResult::BoundCommand(s)),
                 Ok(reedline::Signal::CtrlC) => Ok(ReadResult::Interrupted),
                 Ok(reedline::Signal::CtrlD) => Ok(ReadResult::Eof),
                 Ok(reedline::Signal::ExternalBreak(_)) => Err(ShellError::UnexpectedInputFailure),

--- a/brush-shell/Cargo.toml
+++ b/brush-shell/Cargo.toml
@@ -44,11 +44,11 @@ path = "tests/interactive_tests.rs"
 name = "brush-completion-tests"
 path = "tests/completion_tests.rs"
 
-# N.B. tests/pty_startup_tests.rs is deliberately left auto-discovered (no
-# `brush-*-tests` name): the CI `brush_*_tests-*` artifact glob would otherwise
-# ship it to the os-tests jobs, which run prebuilt test binaries outside a cargo
-# target dir and so can't run pty-based tests (see the interactive/version test
-# skips there).
+# N.B. tests/pty_startup_tests.rs and tests/reedline_interactive_tests.rs are
+# deliberately left auto-discovered (no `brush-*-tests` name): the CI
+# `brush_*_tests-*` artifact glob would otherwise ship them to the os-tests
+# jobs, which run prebuilt test binaries outside a cargo target dir and so
+# can't run pty-based tests (see the interactive/version test skips there).
 
 [[bench]]
 name = "shell"

--- a/brush-shell/tests/reedline_interactive_tests.rs
+++ b/brush-shell/tests/reedline_interactive_tests.rs
@@ -78,7 +78,9 @@ fn expect_next_prompt(session: &mut ShellSession) -> anyhow::Result<()> {
         .expect(DSR_QUERY)
         .context("no cursor-position query before prompt")?;
     session.send(DSR_REPLY)?;
-    session.expect(PROMPT).context("no prompt after answered query")?;
+    session
+        .expect(PROMPT)
+        .context("no prompt after answered query")?;
     Ok(())
 }
 

--- a/brush-shell/tests/reedline_interactive_tests.rs
+++ b/brush-shell/tests/reedline_interactive_tests.rs
@@ -1,0 +1,109 @@
+//! Interactive behavior tests for the reedline input backend, run over a
+//! real pseudo-terminal.
+//!
+//! `pty_startup_tests.rs` covers *startup* on the default backend and
+//! `interactive_tests.rs` covers job control on the `basic` backend; this file
+//! is for behavior specific to reedline's line editing (key bindings, its
+//! interaction with the terminal).
+//!
+//! Unlike the basic backend, reedline queries the terminal for the cursor
+//! position (DSR, `ESC [ 6 n`) before it paints a prompt. A pty with nothing
+//! on the other end never answers, so these tests play the role of the
+//! terminal emulator and answer each query themselves.
+
+// Only compile this for platforms supported by expectrl's pty backend.
+#![cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+#![cfg(test)]
+#![allow(clippy::panic_in_result_fn)]
+
+use std::time::Duration;
+
+use anyhow::Context;
+use expectrl::{
+    Expect, Session,
+    process::unix::{PtyStream, UnixProcess},
+    stream::log::LogStream,
+};
+
+const PROMPT: &str = "brush> ";
+const DSR_QUERY: &str = "\x1b[6n";
+const DSR_REPLY: &str = "\x1b[1;1R";
+
+/// A key bound with `bind -x` must run its command and leave the shell
+/// alive. Regression test for reedline >= 0.48 delivering such keys as
+/// `Signal::HostCommand`, which previously fell through to a fatal
+/// "unexpected error occurred reading input".
+#[test]
+fn bound_key_runs_command_and_shell_survives() -> anyhow::Result<()> {
+    let mut session = start_reedline_session()?;
+    expect_next_prompt(&mut session)?;
+
+    // The bound command's output is split so the echoed keystrokes of the
+    // `bind` line itself can't satisfy the expectation below.
+    session.send_line(r#"bind -x '"\C-t": echo BOUND_""FIRED'"#)?;
+    expect_next_prompt(&mut session)?;
+
+    // Ctrl+T.
+    session.send("\x14")?;
+    session
+        .expect("BOUND_FIRED")
+        .context("bound command did not run")?;
+    expect_next_prompt(&mut session).context("no prompt after bound command")?;
+
+    // The shell must still be interactive afterwards.
+    session.send_line("echo STILL_$((40+2))")?;
+    session
+        .expect("STILL_42")
+        .context("shell did not survive the bound command")?;
+
+    Ok(())
+}
+
+//
+// Helpers
+//
+
+type ShellSession = Session<UnixProcess, LogStream<PtyStream, std::io::Stdout>>;
+
+/// Waits for the cursor-position query that precedes a prompt paint, answers
+/// it, and then waits for the prompt.
+fn expect_next_prompt(session: &mut ShellSession) -> anyhow::Result<()> {
+    session
+        .expect(DSR_QUERY)
+        .context("no cursor-position query before prompt")?;
+    session.send(DSR_REPLY)?;
+    session.expect(PROMPT).context("no prompt after answered query")?;
+    Ok(())
+}
+
+fn start_reedline_session() -> anyhow::Result<ShellSession> {
+    let shell_path = assert_cmd::cargo::cargo_bin!("brush");
+
+    let mut cmd = std::process::Command::new(shell_path);
+    cmd.args([
+        "--norc",
+        "--noprofile",
+        "--no-config",
+        "--disable-bracketed-paste",
+        "--disable-color",
+        "--input-backend=reedline",
+    ]);
+    cmd.env("PS1", PROMPT);
+    cmd.env("TERM", "xterm-256color");
+
+    let session = expectrl::session::Session::spawn(cmd)?;
+
+    // N.B. Replace with `session` directly to disable logging of the session.
+    let mut session = expectrl::session::log(session, std::io::stdout())?;
+
+    // The timeout test deliberately lets a ~2s crossterm timeout elapse.
+    session.set_expect_timeout(Some(Duration::from_secs(15)));
+
+    Ok(session)
+}


### PR DESCRIPTION
Fixes #1328.

reedline 0.48 (nushell/reedline#1049) made `ExecuteHostCommand` return `Signal::HostCommand` instead of smuggling the command through `Signal::Success`. `ReedlineInputBackend::read_line` only recognised the `Success` + `# bind-command` marker form, so since the reedline 0.49 bump in #1240 every `bind -x` key press fell into the `Ok(_)` catch-all and exited the shell. Most visible symptom: atuin's `Ctrl-R` kills brush on any build from `main`.

This adds the `HostCommand` arm, mapping it to `ReadResult::BoundCommand` exactly as the marker path does. The marker path stays so the `edit_mode` format/parse round-trip is untouched.

**Test:** new `brush-shell/tests/reedline_interactive_tests.rs` drives the reedline backend over a pty, answering reedline's cursor-position queries itself (same approach as `pty_startup_tests.rs`; left auto-discovered for the same CI-artifact reason, note in `Cargo.toml` extended). It binds `Ctrl-T` with `bind -x`, presses it, and requires the bound command's output and a still-interactive shell.

- on `main`: fails with EOF (shell exited)
- with this change: passes

Also verified by hand on x86_64 and aarch64: atuin `Ctrl-R` → search → accept → `READLINE_LINE` splice → re-run works end to end.
