### PR TITLE
fix(interactive): retry read_line when the cursor-position query times out

### DIFF
--- a/brush-interactive/src/reedline/input_backend.rs
+++ b/brush-interactive/src/reedline/input_backend.rs
@@ -12,6 +12,10 @@ pub struct ReedlineInputBackend {
 
 const COMPLETION_MENU_NAME: &str = "completion_menu";
 
+/// How many times a failed `reedline.read_line()` is re-issued before the
+/// error is propagated. See `read_line` below.
+const MAX_READ_LINE_RETRIES: u32 = 3;
+
 fn completion_menu_text_style() -> Style {
     Style::new()
 }
@@ -154,18 +158,40 @@ impl InputBackend for ReedlineInputBackend {
         _shell: &crate::ShellRef<impl brush_core::ShellExtensions>,
         prompt: InteractivePrompt,
     ) -> Result<ReadResult, ShellError> {
-        if let Some(reedline) = &mut self.reedline {
+        let Some(reedline) = &mut self.reedline else {
+            return Ok(ReadResult::Eof);
+        };
+
+        let mut attempt: u32 = 0;
+        loop {
             match reedline.read_line(&prompt) {
-                Ok(reedline::Signal::Success(s)) => Ok(ReadResult::Input(s)),
-                Ok(reedline::Signal::CtrlC) => Ok(ReadResult::Interrupted),
-                Ok(reedline::Signal::CtrlD) => Ok(ReadResult::Eof),
-                Ok(reedline::Signal::ExternalBreak(_)) => Err(ShellError::UnexpectedInputFailure),
-                Ok(reedline::Signal::HostCommand(cmd)) => Ok(ReadResult::BoundCommand(cmd)),
-                Ok(_) => Err(ShellError::UnexpectedInputFailure),
-                Err(err) => Err(ShellError::InputError(err)),
+                Ok(reedline::Signal::Success(s)) => return Ok(ReadResult::Input(s)),
+                Ok(reedline::Signal::CtrlC) => return Ok(ReadResult::Interrupted),
+                Ok(reedline::Signal::CtrlD) => return Ok(ReadResult::Eof),
+                Ok(reedline::Signal::ExternalBreak(_)) => {
+                    return Err(ShellError::UnexpectedInputFailure);
+                }
+                Ok(reedline::Signal::HostCommand(cmd)) => return Ok(ReadResult::BoundCommand(cmd)),
+                Ok(_) => return Err(ShellError::UnexpectedInputFailure),
+                // An error here is almost always transient. The prevalent case:
+                // reedline asks the terminal for the cursor position (DSR,
+                // `ESC [ 6 n`) before painting a prompt, and again after an
+                // external program (a `bind -x` command such as atuin's search
+                // UI, fzf, ...) hands the terminal back. crossterm waits a fixed
+                // 2s for the reply and then fails; a terminal busy repainting or
+                // a multiplexer briefly holding the reply is enough to trip it,
+                // and giving up would end the whole interactive session.
+                // Re-issuing the read is safe -- nothing has been consumed from
+                // the user's input -- so retry a bounded number of times before
+                // treating the failure as real.
+                Err(err) if attempt < MAX_READ_LINE_RETRIES => {
+                    attempt += 1;
+                    tracing::debug!(
+                        "reedline read_line failed (attempt {attempt}/{MAX_READ_LINE_RETRIES}), retrying: {err}"
+                    );
+                }
+                Err(err) => return Err(ShellError::InputError(err)),
             }
-        } else {
-            Ok(ReadResult::Eof)
         }
     }
 

--- a/brush-interactive/src/reedline/input_backend.rs
+++ b/brush-interactive/src/reedline/input_backend.rs
@@ -1,3 +1,4 @@
+use brush_core::trace_categories;
 use nu_ansi_term::Style;
 use reedline::MenuBuilder;
 
@@ -12,9 +13,10 @@ pub struct ReedlineInputBackend {
 
 const COMPLETION_MENU_NAME: &str = "completion_menu";
 
-/// How many times a failed `reedline.read_line()` is re-issued before the
-/// error is propagated. See `read_line` below.
-const MAX_READ_LINE_RETRIES: u32 = 3;
+/// How many times `reedline.read_line()` is attempted before its error is
+/// propagated: the initial call plus this many minus one retries. See
+/// `read_line` below.
+const MAX_READ_LINE_ATTEMPTS: u32 = 3;
 
 fn completion_menu_text_style() -> Style {
     Style::new()
@@ -162,7 +164,7 @@ impl InputBackend for ReedlineInputBackend {
             return Ok(ReadResult::Eof);
         };
 
-        let mut attempt: u32 = 0;
+        let mut attempt: u32 = 1;
         loop {
             match reedline.read_line(&prompt) {
                 Ok(reedline::Signal::Success(s)) => return Ok(ReadResult::Input(s)),
@@ -180,14 +182,23 @@ impl InputBackend for ReedlineInputBackend {
                 // UI, fzf, ...) hands the terminal back. crossterm waits a fixed
                 // 2s for the reply and then fails; a terminal busy repainting or
                 // a multiplexer briefly holding the reply is enough to trip it,
-                // and giving up would end the whole interactive session.
-                // Re-issuing the read is safe -- nothing has been consumed from
-                // the user's input -- so retry a bounded number of times before
-                // treating the failure as real.
-                Err(err) if attempt < MAX_READ_LINE_RETRIES => {
+                // and giving up would end the whole interactive session. That
+                // failure happens before any input is read, so re-issuing the
+                // read is safe; retry a bounded number of times before treating
+                // the failure as real. A terminal that never answers therefore
+                // fails after MAX_READ_LINE_ATTEMPTS x 2s rather than 2s.
+                //
+                // The one known exception: reedline restores the terminal mode
+                // *after* computing its result, so if `disable_raw_mode` itself
+                // fails, a line that was already submitted is lost and the retry
+                // prompts afresh. That is a tcsetattr failure on a tty that just
+                // worked; the alternative -- exiting the shell -- loses the same
+                // line and everything else with it.
+                Err(err) if attempt < MAX_READ_LINE_ATTEMPTS => {
                     attempt += 1;
                     tracing::debug!(
-                        "reedline read_line failed (attempt {attempt}/{MAX_READ_LINE_RETRIES}), retrying: {err}"
+                        target: trace_categories::INPUT,
+                        "reedline read_line failed; retrying (attempt {attempt}/{MAX_READ_LINE_ATTEMPTS}): {err}"
                     );
                 }
                 Err(err) => return Err(ShellError::InputError(err)),

--- a/brush-shell/tests/reedline_interactive_tests.rs
+++ b/brush-shell/tests/reedline_interactive_tests.rs
@@ -9,7 +9,8 @@
 //! Unlike the basic backend, reedline queries the terminal for the cursor
 //! position (DSR, `ESC [ 6 n`) before it paints a prompt. A pty with nothing
 //! on the other end never answers, so these tests play the role of the
-//! terminal emulator and answer each query themselves.
+//! terminal emulator and answer each query themselves (or, for the timeout
+//! test, deliberately withhold an answer).
 
 // Only compile this for platforms supported by expectrl's pty backend.
 #![cfg(any(
@@ -42,25 +43,48 @@ const DSR_REPLY: &str = "\x1b[1;1R";
 #[test]
 fn bound_key_runs_command_and_shell_survives() -> anyhow::Result<()> {
     let mut session = start_reedline_session()?;
-    expect_next_prompt(&mut session)?;
+    expect_next_prompt(&mut session, 0)?;
 
     // The bound command's output is split so the echoed keystrokes of the
     // `bind` line itself can't satisfy the expectation below.
     session.send_line(r#"bind -x '"\C-t": echo BOUND_""FIRED'"#)?;
-    expect_next_prompt(&mut session)?;
+    expect_next_prompt(&mut session, 0)?;
 
     // Ctrl+T.
     session.send("\x14")?;
     session
         .expect("BOUND_FIRED")
         .context("bound command did not run")?;
-    expect_next_prompt(&mut session).context("no prompt after bound command")?;
+    expect_next_prompt(&mut session, 0).context("no prompt after bound command")?;
 
     // The shell must still be interactive afterwards.
     session.send_line("echo STILL_$((40+2))")?;
     session
         .expect("STILL_42")
         .context("shell did not survive the bound command")?;
+
+    Ok(())
+}
+
+/// A single unanswered cursor-position query (a transient terminal hiccup,
+/// e.g. right after a full-screen program hands the terminal back) must not
+/// terminate the shell; the query is retried and the next answer is used.
+#[test]
+fn transient_cursor_query_timeout_is_retried() -> anyhow::Result<()> {
+    let mut session = start_reedline_session()?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // Withhold the answer to the query preceding the next prompt; crossterm
+    // gives up on it after ~2s and brush must ask again rather than exit.
+    session.send_line("echo BEFORE_$((7*6))")?;
+    session.expect("BEFORE_42")?;
+    expect_next_prompt(&mut session, 1)
+        .context("shell did not survive one unanswered cursor query")?;
+
+    session.send_line("echo AFTER_$((6*7))")?;
+    session
+        .expect("AFTER_42")
+        .context("shell not interactive after the retried query")?;
 
     Ok(())
 }
@@ -72,16 +96,23 @@ fn bound_key_runs_command_and_shell_survives() -> anyhow::Result<()> {
 type ShellSession = Session<UnixProcess, LogStream<PtyStream, std::io::Stdout>>;
 
 /// Waits for the cursor-position query that precedes a prompt paint, answers
-/// it, and then waits for the prompt.
-fn expect_next_prompt(session: &mut ShellSession) -> anyhow::Result<()> {
-    session
-        .expect(DSR_QUERY)
-        .context("no cursor-position query before prompt")?;
-    session.send(DSR_REPLY)?;
-    session
-        .expect(PROMPT)
-        .context("no prompt after answered query")?;
-    Ok(())
+/// it, and then waits for the prompt. The first `withhold` queries are left
+/// unanswered instead, so the shell has to re-issue them.
+fn expect_next_prompt(session: &mut ShellSession, mut withhold: usize) -> anyhow::Result<()> {
+    loop {
+        session
+            .expect(DSR_QUERY)
+            .context("no cursor-position query before prompt")?;
+        if withhold > 0 {
+            withhold -= 1;
+            continue;
+        }
+        session.send(DSR_REPLY)?;
+        session
+            .expect(PROMPT)
+            .context("no prompt after answered query")?;
+        return Ok(());
+    }
 }
 
 fn start_reedline_session() -> anyhow::Result<ShellSession> {

--- a/brush-shell/tests/reedline_interactive_tests.rs
+++ b/brush-shell/tests/reedline_interactive_tests.rs
@@ -89,6 +89,32 @@ fn transient_cursor_query_timeout_is_retried() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The retry is bounded: a terminal that never answers must make the shell
+/// give up (three attempts, ~2s each) rather than loop forever.
+#[test]
+fn unanswered_cursor_queries_eventually_fail_the_read() -> anyhow::Result<()> {
+    let mut session = start_reedline_session()?;
+    expect_next_prompt(&mut session, 0)?;
+
+    session.send_line("echo BEFORE_$((7*6))")?;
+    session.expect("BEFORE_42")?;
+
+    // Never answer. Exactly three queries, then the shell exits on the error.
+    for attempt in 1..=3 {
+        session
+            .expect(DSR_QUERY)
+            .with_context(|| format!("no cursor-position query for attempt {attempt}"))?;
+    }
+    session
+        .expect("The cursor position could not be read")
+        .context("shell did not report the exhausted query")?;
+    session
+        .expect(expectrl::Eof)
+        .context("shell did not exit after exhausting retries")?;
+
+    Ok(())
+}
+
 //
 // Helpers
 //
@@ -135,7 +161,8 @@ fn start_reedline_session() -> anyhow::Result<ShellSession> {
     // N.B. Replace with `session` directly to disable logging of the session.
     let mut session = expectrl::session::log(session, std::io::stdout())?;
 
-    // The timeout test deliberately lets a ~2s crossterm timeout elapse.
+    // The timeout tests deliberately let ~2s crossterm timeouts elapse, up
+    // to three in a row (MAX_READ_LINE_ATTEMPTS) for the exhaustion test.
     session.set_expect_timeout(Some(Duration::from_secs(15)));
 
     Ok(session)


### PR DESCRIPTION
Fixes #1329.

reedline asks the terminal for the cursor position before painting a prompt and after an external program hands the terminal back. crossterm gives that query a fixed 2s and then fails; brush treated every `Err` from `read_line` as fatal, so one late reply exited the interactive shell.

**Revised per review:** the retry is now unconditional — any `Err` from `reedline.read_line()` is re-issued up to three times, then propagated. No message matching. Nothing has been consumed from the user's input when `read_line` fails, so retrying is safe, and no other error has been observed on this path. A terminal that never answers still fails (~6s instead of ~2s); one that answers the next query keeps the session.

**Test:** `transient_cursor_query_timeout_is_retried` — the pty harness withholds the reply to exactly one query and requires the shell to survive and stay interactive. Fails on `main` with EOF after the 2s timeout; passes with this change.

**Upstream:** see the thread below — the reedline side of this is a small, in-pattern change, which I'm submitting there; crossterm's timeout isn't configurable and there's no open request for it.
