### PR TITLE
fix(builtins): apply attribute flags with declare -f

### DIFF
--- a/brush-builtins/src/declare.rs
+++ b/brush-builtins/src/declare.rs
@@ -232,6 +232,33 @@ impl DeclareCommand {
         }
     }
 
+    /// `declare -f` with attribute flags applies them to the named function rather than
+    /// displaying it (e.g. `declare -ft name`, `declare -fx name`).
+    fn apply_function_attributes(
+        &self,
+        context: &mut brush_core::ExecutionContext<'_, impl brush_core::ShellExtensions>,
+        declaration: &brush_core::CommandArg,
+    ) -> bool {
+        let func = match declaration {
+            brush_core::CommandArg::String(name) => context.shell.func_mut(name),
+            brush_core::CommandArg::Assignment(_) => None,
+        };
+
+        // As with display, bash reports failure without printing an error message here.
+        let Some(func) = func else {
+            return false;
+        };
+
+        match self.make_exported.to_bool() {
+            Some(true) => func.export(),
+            Some(false) => func.unexport(),
+            None => (),
+        }
+
+        // TODO(declare): function tracing (-t) isn't tracked; it's accepted silently.
+        true
+    }
+
     fn process_declaration(
         &self,
         context: &mut brush_core::ExecutionContext<'_, impl brush_core::ShellExtensions>,
@@ -242,6 +269,12 @@ impl DeclareCommand {
             || (matches!(verb, DeclareVerb::Declare)
                 && context.shell.in_function()
                 && !self.create_global);
+
+        if (self.function_names_or_defs_only || self.function_names_only)
+            && (self.make_traced.to_bool().is_some() || self.make_exported.to_bool().is_some())
+        {
+            return Ok(self.apply_function_attributes(context, declaration));
+        }
 
         if self.function_names_or_defs_only || self.function_names_only {
             return self.try_display_declaration(context, declaration, verb);

--- a/brush-shell/tests/cases/compat/builtins/declare.yaml
+++ b/brush-shell/tests/cases/compat/builtins/declare.yaml
@@ -1131,3 +1131,31 @@ cases:
       readonly 'bad-name3=1' 2>&1 | strip
       export -f nosuchfn 2>&1 | strip
       export 'e[0]=1' 2>&1 | strip
+
+  - name: "declare -fx exports a function"
+    stdin: |
+      f() { :; }
+      count_exported() { env | grep -c "^BASH_FUNC_f"; }
+      count_exported
+      declare -fx f; echo "rc=$?"
+      count_exported
+      declare +x -f f; echo "rc=$?"
+      count_exported
+
+  - name: "declare -f with attribute flags doesn't display the function"
+    stdin: |
+      f() { echo body; }
+      echo "[$(declare -ft f)]"; echo "rc=$?"
+      echo "[$(declare -fx f)]"; echo "rc=$?"
+
+  - name: "declare -f with attribute flags on a missing function"
+    stdin: |
+      declare -ft nosuchfn 2>&1; echo "rc=$?"
+      declare -fx nosuchfn 2>&1; echo "rc=$?"
+
+  - name: "declare -ft records the trace attribute"
+    known_failure: true # TODO(declare): brush accepts -t on functions but doesn't track it
+    stdin: |
+      f() { :; }
+      declare -ft f
+      declare -F


### PR DESCRIPTION
`declare -ft name` and `declare -fx name` set the trace/export attribute on a function; brush treated any -f as display-only and ignored the flags.

Notably, atuin uses `declare -f` this way during setup.

Assisted-By: Claude Opus 4.8