### PR TITLE
fix(builtins): iterate all operands for command -v/-V

### DIFF
--- a/brush-builtins/src/command.rs
+++ b/brush-builtins/src/command.rs
@@ -39,36 +39,47 @@ impl builtins::Command for CommandCommand {
         &self,
         context: brush_core::ExecutionContext<'_, SE>,
     ) -> Result<ExecutionResult, Self::Error> {
-        // Silently exit if no command was provided.
-        if let Some(command_name) = self.command() {
-            if self.print_description || self.print_verbose_description {
-                if let Some(found_cmd) =
-                    Self::try_find_command(context.shell, command_name, self.use_default_path)
-                {
-                    if self.print_description {
-                        writeln!(context.stdout(), "{found_cmd}")?;
-                    } else {
-                        match found_cmd {
-                            FoundCommand::Builtin(_name) => {
-                                writeln!(context.stdout(), "{command_name} is a shell builtin")?;
-                            }
-                            FoundCommand::External(path) => {
-                                writeln!(context.stdout(), "{command_name} is {path}")?;
-                            }
-                        }
-                    }
-                    Ok(ExecutionResult::success())
-                } else {
+        if self.print_description || self.print_verbose_description {
+            // bash iterates over every operand, printing one line per name that
+            // resolves; operands that do not resolve are skipped (with `-V`, each
+            // miss is reported on stderr). The exit status is successful if any
+            // operand resolved, and unsuccessful only when none did.
+            let mut any_found = false;
+            for command_name in &self.command_and_args {
+                let Some(found_cmd) = Self::try_find_command(
+                    context.shell,
+                    command_name.as_str(),
+                    self.use_default_path,
+                ) else {
                     if self.print_verbose_description {
                         writeln!(context.stderr(), "command: {command_name}: not found")?;
                     }
-                    Ok(ExecutionResult::general_error())
+                    continue;
+                };
+                any_found = true;
+                if self.print_description {
+                    writeln!(context.stdout(), "{found_cmd}")?;
+                } else {
+                    match found_cmd {
+                        FoundCommand::Builtin(_name) => {
+                            writeln!(context.stdout(), "{command_name} is a shell builtin")?;
+                        }
+                        FoundCommand::External(path) => {
+                            writeln!(context.stdout(), "{command_name} is {path}")?;
+                        }
+                    }
                 }
-            } else {
-                self.execute_command(context, command_name, self.use_default_path)
-                    .await
             }
+            if any_found || self.command_and_args.is_empty() {
+                Ok(ExecutionResult::success())
+            } else {
+                Ok(ExecutionResult::general_error())
+            }
+        } else if let Some(command_name) = self.command() {
+            self.execute_command(context, command_name, self.use_default_path)
+                .await
         } else {
+            // Silently exit if no command was provided.
             Ok(ExecutionResult::success())
         }
     }

--- a/brush-shell/tests/cases/compat/builtins/command.yaml
+++ b/brush-shell/tests/cases/compat/builtins/command.yaml
@@ -69,6 +69,28 @@ cases:
       echo "[\$(command -v cat)]"
       command -v $(command -v cat)
 
+  - name: "command -v with multiple operands"
+    stdin: |
+      echo "[resolved builtins]"
+      command -v echo true pwd
+      echo "rc=$?"
+
+      echo "[skipped miss]"
+      command -v echo non-existent pwd
+      echo "rc=$?"
+
+      echo "[all misses]"
+      command -v non-existent also-non-existent
+      echo "rc=$?"
+
+  - name: "command -V with multiple operands"
+    ignore_stderr: true # miss wording on stderr differs between brush and bash
+    stdin: |
+      command -V echo true
+      echo "rc=$?"
+
+      command -V non-existent || echo "not found"
+
   - name: "command -V"
     ignore_stderr: true
     stdin: |


### PR DESCRIPTION
Fixes #1338

## Problem

`command -v a b c` resolved only the first operand and silently ignored the rest. If the first operand did not resolve, later operands were never consulted — `command -v missing cat` produced no output and exited 1 even though `cat` exists.

bash (5.x) and zsh iterate over every operand: one line per resolved name, misses skipped (`-V` reports each miss on stderr), and a successful exit status when any operand resolves.

## Fix

`brush-builtins/src/command.rs`: in the `-v`/`-V` branch, iterate over all of `command_and_args` (clap already collects every operand via `trailing_var_arg = true`):

- one output line per resolved name (`-v`: path / bare builtin name; `-V`: description)
- `-V` reports misses on stderr; `-v` stays silent on misses (both unchanged from before)
- exit status: success if any operand resolves or no operands were given; failure only when operands were given and none resolve

The execution path (`command cmd args...`) is unchanged.

## Testing

Added compat cases `command -v with multiple operands` and `command -V with multiple operands` (oracle-compared against bash):

- with this fix: `2 test case(s) ran: 2 succeeded`
- without the fix (verified by stashing the source change while keeping the cases): both fail, oracle diff showing the dropped operands
- exit-status semantics verified against bash 5.3: `-v cat miss` → 0, `-v miss cat` → 0, `-v miss` → 1, `-v` (no operands) → 0

`cargo fmt` and `cargo clippy -p brush-builtins --all-targets` are clean.
