### PR TITLE
fix(builtins): refuse to hash a directory

### DIFF
--- a/brush-builtins/src/hash.rs
+++ b/brush-builtins/src/hash.rs
@@ -37,13 +37,14 @@ impl builtins::Command for HashCommand {
         context: brush_core::ExecutionContext<'_, SE>,
     ) -> Result<brush_core::ExecutionResult, Self::Error> {
         let mut result = ExecutionResult::success();
+        let cmd = &context.command_name;
 
         if self.remove_all {
             context.shell.program_location_cache_mut().reset();
         } else if self.remove {
             for name in &self.names {
                 if !context.shell.program_location_cache_mut().unset(name) {
-                    writeln!(context.stderr(), "{name}: not found")?;
+                    writeln!(context.stderr(), "{cmd}: {name}: not found")?;
                     result = ExecutionResult::general_error();
                 }
             }
@@ -71,12 +72,26 @@ impl builtins::Command for HashCommand {
                         )?;
                     }
                 } else {
-                    writeln!(context.stderr(), "{name}: not found")?;
+                    writeln!(context.stderr(), "{cmd}: {name}: not found")?;
                     result = ExecutionResult::general_error();
                 }
             }
         } else if let Some(path) = &self.path_to_use {
+            // The shell's working directory is its own state, not the process's, so a
+            // relative path is resolved against it before it's inspected -- but reported as given.
+            let is_dir = context.shell.absolute_path(path).is_dir();
+
             for name in &self.names {
+                if is_dir {
+                    writeln!(
+                        context.stderr(),
+                        "{cmd}: {}: Is a directory",
+                        path.display()
+                    )?;
+                    result = ExecutionResult::general_error();
+                    continue;
+                }
+
                 context
                     .shell
                     .program_location_cache_mut()
@@ -98,7 +113,7 @@ impl builtins::Command for HashCommand {
                     .find_first_executable_in_path_using_cache(name)
                     .is_none()
                 {
-                    writeln!(context.stderr(), "{name}: not found")?;
+                    writeln!(context.stderr(), "{cmd}: {name}: not found")?;
                     result = ExecutionResult::general_error();
                 }
             }

--- a/brush-shell/tests/cases/compat/builtins/hash.yaml
+++ b/brush-shell/tests/cases/compat/builtins/hash.yaml
@@ -67,3 +67,40 @@ cases:
     stdin: |
       hash /dev/null && echo "1. Result: $?"
       hash /dev/nulll && echo "2. Result: $?"
+
+  - name: "hash -p refuses a directory"
+    stdin: |
+      # Normalize away the leading "shell: line N:" that the oracle prefixes onto diagnostics.
+      strip() { sed 's/^.*hash:/hash:/'; }
+
+      mkdir -p adir
+      touch afile
+
+      echo "[a directory is refused]"
+      hash -p adir z1 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      # The pipeline above ran in a subshell, so re-run it here to check the table itself.
+      hash -p adir z1 2>/dev/null; echo "rc=$?"
+      hash -t z1 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+      echo "[any other path is taken at face value]"
+      hash -p afile z2; echo "rc=$?"
+      hash -p /nonexistent/x z3; echo "rc=$?"
+      hash -t z2 z3; echo "rc=$?"
+
+      echo "[refused once per name]"
+      hash -p adir bad1 bad2 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+      echo "[a relative path resolves against the shell's working directory]"
+      mkdir -p sub/reldir sub2
+      cd sub
+      hash -p reldir z4 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      cd ../sub2
+      # ../sub/reldir exists, but 'reldir' does not from here, so this is just a path.
+      hash -p reldir z5 2>/dev/null; echo "rc=$?"
+      hash -t z5; echo "rc=$?"
+      cd ..
+
+      echo "[hash NAME stays strict about executables]"
+      mkdir -p d1; touch d1/only
+      PATH="d1:$PATH"
+      hash only 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"


### PR DESCRIPTION
bash rejects `hash -p DIR NAME` with "Is a directory" and leaves the table untouched, once per name given. Every other path is taken at face value, existing or not, so the check is just for a directory.

Also prefix the builtin's diagnostics with its own name, the way bash does and the way the other builtins here already do.

Assisted-By: Claude Opus 5