### PR TITLE
fix(shell): match bash when a PATH entry isn't a runnable executable

### DIFF
--- a/brush-core/src/commands.rs
+++ b/brush-core/src/commands.rs
@@ -391,14 +391,13 @@ impl<'a, SE: extensions::ShellExtensions> SimpleCommand<'a, SE> {
 
         // We still haven't found a command to invoke. We'll need to look for an external command.
         if !sys::fs::contains_path_separator(&self.command_name) {
-            // All else failed; if we were given path directories to search, try to look through
-            // them for a matching executable. Otherwise, use our default search logic.
+            // All else failed; if we were given path directories to search, look through them
+            // for a match. Otherwise, use our default search logic.
             let path = if let Some(path_dirs) = &self.path_dirs {
-                pathsearch::search_for_executable(path_dirs.iter(), self.command_name.as_str())
-                    .next()
+                pathsearch::resolve_command(path_dirs, self.command_name.as_str())
             } else {
                 self.shell
-                    .find_first_executable_in_path_using_cache(&self.command_name)
+                    .resolve_command_in_path_using_cache(&self.command_name)
             };
 
             if let Some(path) = path {

--- a/brush-core/src/pathsearch.rs
+++ b/brush-core/src/pathsearch.rs
@@ -24,18 +24,23 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(path) = self.paths.pop_front() {
             let path = PathBuf::from(path.as_ref()).join(self.filename.as_ref());
-            // Skip directories outright, then ask the platform to resolve
-            // the path to an actual executable file (which, on Windows, may
-            // involve appending a PATHEXT extension). The helper takes
-            // ownership so Unix — where no resolution is needed — can return
-            // the path unchanged without allocating.
-            if path.is_dir() {
-                continue;
-            }
-            if let Some(resolved) = sys::fs::resolve_executable(path) {
+
+            // Ask the platform to resolve the path to an actual executable file, which on
+            // Windows may involve appending a PATHEXT extension. The helper takes ownership
+            // so Unix — where no resolution is needed — can return the path unchanged
+            // without allocating.
+            //
+            // A directory carries the execute bit on Unix but is never a command. Filter
+            // the *resolved* path rather than the input: on Windows, resolution appends a
+            // PATHEXT extension, so a `prog` directory must not stop `prog.exe` in the
+            // same PATH entry from being found.
+            if let Some(resolved) = sys::fs::resolve_executable(path)
+                && !resolved.is_dir()
+            {
                 return Some(resolved);
             }
         }
+
         None
     }
 }
@@ -113,6 +118,43 @@ where
     }
 }
 
+/// Resolves a command name the way the shell does when it is about to run it.
+///
+/// Returns the first executable in search order, or -- if there is none -- the first entry
+/// that exists and is not a directory, which the shell reports as the command and then
+/// fails to run.
+///
+/// # Arguments
+///
+/// * `paths` - An iterator over the paths to search.
+/// * `filename` - The name of the command to resolve.
+pub fn resolve_command<P, PI, N>(paths: P, filename: N) -> Option<PathBuf>
+where
+    P: IntoIterator<Item = PI>,
+    PI: AsRef<Path>,
+    N: AsRef<Path>,
+{
+    let mut first_non_executable = None;
+
+    for dir in paths {
+        let path = dir.as_ref().join(filename.as_ref());
+
+        // Remember the first non-directory entry seen, in case no executable turns up.
+        if first_non_executable.is_none() && path.metadata().is_ok_and(|m| !m.is_dir()) {
+            first_non_executable = Some(path.clone());
+        }
+
+        // Resolve, then reject directories; see `ExecutablePathSearch::next`.
+        if let Some(resolved) = sys::fs::resolve_executable(path)
+            && !resolved.is_dir()
+        {
+            return Some(resolved);
+        }
+    }
+
+    first_non_executable
+}
+
 pub(crate) fn search_for_executable_with_prefix<P, PI>(
     paths: P,
     filename_prefix: &str,
@@ -133,5 +175,61 @@ where
         queued_items: VecDeque::new(),
         filename_prefix: stored_prefix,
         case_insensitive,
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic_in_result_fn)]
+mod tests {
+    use anyhow::Result;
+
+    use super::*;
+
+    /// A directory carries the execute bit on Unix, so it must not be mistaken for a
+    /// command; an executable later in the search order takes its place.
+    #[test]
+    fn directory_is_not_a_command() -> Result<()> {
+        let scratch = tempfile::tempdir()?;
+        let first = scratch.path().join("first");
+        let second = scratch.path().join("second");
+        std::fs::create_dir_all(first.join("prog"))?;
+        std::fs::create_dir_all(&second)?;
+        std::fs::write(second.join("prog"), "")?;
+
+        let paths = [first.as_path(), second.as_path()];
+
+        // The plain (non-executable) file wins over the directory, rather than the
+        // directory being reported as the command.
+        assert_eq!(resolve_command(paths, "prog"), Some(second.join("prog")));
+
+        // ...and a directory is never yielded as an executable at all.
+        assert_eq!(search_for_executable(paths.iter(), "prog").next(), None);
+
+        Ok(())
+    }
+
+    /// On Windows, `PATHEXT` resolution has to run before directories are rejected: a
+    /// `prog` directory must not keep `prog.bat` in the same PATH entry from being found.
+    #[cfg(windows)]
+    #[test]
+    fn same_named_directory_does_not_hide_a_pathext_match() -> Result<()> {
+        let scratch = tempfile::tempdir()?;
+        std::fs::create_dir_all(scratch.path().join("prog"))?;
+        std::fs::write(scratch.path().join("prog.bat"), "@echo off\r\n")?;
+
+        let paths = [scratch.path()];
+        for found in [
+            search_for_executable(paths.iter(), "prog").next(),
+            resolve_command(paths, "prog"),
+        ] {
+            assert!(
+                found.as_ref().is_some_and(|path| path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("bat"))),
+                "unexpected resolution: {found:?}"
+            );
+        }
+
+        Ok(())
     }
 }

--- a/brush-core/src/shell/fs.rs
+++ b/brush-core/src/shell/fs.rs
@@ -8,7 +8,7 @@ use crate::{
     ExecutionParameters, ShellFd,
     env::{EnvironmentLookup, EnvironmentScope},
     error, openfiles, pathsearch,
-    sys::{fs::PathExt as _, users},
+    sys::users,
     variables,
 };
 
@@ -81,11 +81,12 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         }
     }
 
-    /// Finds executables in the shell's current default PATH, matching the given glob pattern.
+    /// Finds executables with the given name in the shell's current PATH, yielding each match
+    /// in search order.
     ///
     /// # Arguments
     ///
-    /// * `required_glob_pattern` - The glob pattern to match against.
+    /// * `filename` - The name of the executable to look for.
     pub fn find_executables_in_path<'a>(
         &'a self,
         filename: &'a str,
@@ -123,14 +124,8 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         &self,
         candidate_name: S,
     ) -> Option<PathBuf> {
-        let path = self.env_str("PATH").unwrap_or_default();
-        for one_dir in crate::sys::fs::split_paths(path.as_ref()) {
-            let candidate_path = one_dir.join(candidate_name.as_ref());
-            if candidate_path.executable() {
-                return Some(candidate_path);
-            }
-        }
-        None
+        self.find_executables_in_path(candidate_name.as_ref())
+            .next()
     }
 
     /// Uses the shell's hash-based path cache to check whether the given filename is the name
@@ -156,6 +151,37 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         } else {
             None
         }
+    }
+
+    /// Resolves a command name against the shell's hash-based path cache, searching the
+    /// shell's current PATH on a miss and caching whatever the search turns up.
+    ///
+    /// Unlike [`Self::find_first_executable_in_path_using_cache`], a non-executable entry in
+    /// the PATH resolves as the command; the shell reports it as the command and then fails
+    /// to run it. See [`pathsearch::resolve_command`].
+    ///
+    /// # Arguments
+    ///
+    /// * `candidate_name` - The name of the command to resolve.
+    pub fn resolve_command_in_path_using_cache<S: AsRef<str>>(
+        &mut self,
+        candidate_name: S,
+    ) -> Option<PathBuf>
+    where
+        String: From<S>,
+    {
+        if let Some(cached_path) = self.program_location_cache.get(&candidate_name) {
+            return Some(cached_path);
+        }
+
+        let path_var = self.env.get_str("PATH", self).unwrap_or_default();
+        let paths = crate::sys::fs::split_paths(path_var.as_ref());
+        let found_path = pathsearch::resolve_command(paths, candidate_name.as_ref())?;
+
+        self.program_location_cache
+            .set(candidate_name, found_path.clone());
+
+        Some(found_path)
     }
 
     /// Gets the absolute form of the given path.

--- a/brush-shell/tests/cases/compat/simple_commands.yaml
+++ b/brush-shell/tests/cases/compat/simple_commands.yaml
@@ -37,3 +37,56 @@ cases:
       cd test-dir
       rmdir $(pwd)
       ls
+
+  - name: "Command found in PATH is a directory"
+    ignore_stderr: true
+    stdin: |
+      mkdir -p pdir/prog
+      PATH="$PWD/pdir:$PATH"
+      prog
+      echo "Result: $?"
+
+  - name: "Command found in PATH is not executable"
+    ignore_stderr: true
+    stdin: |
+      mkdir -p pdir pdir2
+      touch pdir/only
+      PATH="$PWD/pdir:$PWD/pdir2:$PATH"
+
+      # The shell resolves the name to the file and fails to run it, rather than
+      # reporting the name as not found.
+      only
+      echo "Result: $?"
+
+      # An executable later in PATH still beats a non-executable earlier one.
+      touch pdir/both
+      printf '#!/bin/sh\necho HIT\n' > pdir2/both
+      chmod +x pdir2/both
+      both
+      echo "Result: $?"
+
+  - name: "Command found in PATH is a directory shadowing a later executable"
+    stdin: |
+      mkdir -p pdir/prog pdir2
+      printf '#!/bin/sh\necho HIT\n' > pdir2/prog
+      chmod +x pdir2/prog
+      PATH="$PWD/pdir:$PWD/pdir2:$PATH"
+
+      # The directory is skipped, not treated as a command that shadows the executable.
+      prog
+      echo "Result: $?"
+
+  - name: "Command found in PATH is not executable: search order and hashing"
+    ignore_stderr: true
+    stdin: |
+      mkdir -p d1 d2
+      touch d1/only d2/only
+      PATH="$PWD/d1:$PWD/d2:$PATH"
+
+      # The first non-executable file in PATH order is the one the name resolves to...
+      only
+      echo "Result: $?"
+
+      # ...and the shell remembers it, even though it could not be run.
+      hash -t only | sed "s|^$PWD/||"
+      echo "Result: ${PIPESTATUS[0]}"


### PR DESCRIPTION
Two related command-lookup fixes:

* A directory in PATH whose name matches the command was treated as an executable, because a directory carries the execute bit. Running `prog` with a `prog/` directory in PATH now reports "command not found" instead of failing to exec a directory.

* A non-executable file in PATH is now resolved as the command. Bash reports such a file as the command and then fails to run it (exit 126, "Permission denied") rather than reporting the name as not found; an executable found later in PATH still wins over a non-executable found earlier.

The directory check lives in `pathsearch`'s executable search, and `Shell::find_first_executable_in_path` now delegates to that search rather than repeating it with its own loop, so the fix applies everywhere an executable is looked up (and picks up PATHEXT resolution on Windows, which the open-coded loop skipped).

The non-executable fallback is a new `pathsearch::resolve_command`, plus `Shell::resolve_command_in_path_using_cache` for the cached form that command execution uses. Nothing else changes shape: `hash` and `command` keep calling `find_first_executable_in_path_using_cache` and stay strict, since bash won't hash a non-executable.

Public API: two additions, nothing removed, renamed, or re-signatured.

Known remaining divergence, deliberately left for a separate change: bash's `command -v` / `type` use the resolving rule too, so a lone non-executable in PATH is reported rather than treated as not found. brush is strict there today. That predates this PR and is orthogonal to running commands.

Assisted-By: Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjUcQLmWQpHouP2TSQVr9v
