### PR TITLE
test(e2e): add containerized end-to-end harness with fzf adapter

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,59 @@
+# End-to-end tests against real applications
+
+Each subdirectory here runs a real application's *own* shell-integration test
+suite inside a container, with the shell under test swapped in for `bash`.
+This catches interactive-shell regressions (bindings, `bind -x`, `READLINE_*`,
+completion, history) that unit tests can't.
+
+```bash
+cargo build --release
+e2e/run.sh fzf                     # against target/release/brush (or debug)
+e2e/run.sh --shell bash fzf        # baseline: the same suite against real bash
+e2e/run.sh --shell /path/to/sh fzf # any other binary
+e2e/run.sh fzf -n /ctrl_r/         # extra args go to the app's test runner
+```
+
+Results land in `target/e2e/<app>/`: `log.txt` (full runner output) and
+`junit/*.xml` (JUnit, for CI upload). The exit status is the suite's.
+
+## Adapter contract
+
+An adapter is a directory `e2e/<app>/` containing a `Dockerfile` (build
+context is `e2e/`, so it can `COPY shim /e2e/bin`) whose entrypoint:
+
+1. **Receives the shell** via `$SHELL_UNDER_TEST`, an absolute path to a
+   binary bind-mounted into the container (`/shell/<name>`). It's built on
+   the host, so the image's glibc must be at least the host's. Most apps
+   hard-code `bash`, so the shared `shim/bash` exec's `$SHELL_UNDER_TEST`;
+   put `/e2e/bin` first on `PATH`. When the variable is unset the shim
+   runs the real `bash`, which gives the baseline run.
+2. **Writes results** to `/results`: `log.txt` plus JUnit XML under
+   `junit/`. Write whatever else helps debugging there too.
+3. **Exits non-zero** when any test fails. Known failures go in the adapter's
+   `skip-list.txt` (one test per line, with a comment saying why); the entrypoint
+   excludes them from the run.
+
+The container runs as the host user with `HOME=/tmp`, so `chmod` anything
+the tests write into.
+
+## Rules
+
+1. **Never copy upstream files into this tree.** Clone the application at
+   build time, pinned to a commit (not a branch).
+2. **The Dockerfile is our own environment recipe.** Deriving its package
+   list from upstream's Dockerfile or CI config is fine; say so in a comment,
+   with the source and license.
+3. **The entrypoint adapts upstream's runner to the results contract.** If the
+   runner can't emit JUnit itself, add a reporter there (fzf: `minitest-ci`).
+4. **Not every app has a suite to borrow.** When upstream only tests its own
+   code (atuin, say), the adapter brings its own tests: a small tmux-driven
+   script that installs the app's hooks into the shell under test and checks
+   the observable behavior. The contract is the same; only the author differs.
+
+## Adapters
+
+| app | notes |
+|-----|-------|
+| fzf | upstream `test/test_shell_integration.rb`, `TestBash` only; minitest + tmux, JUnit via `minitest-ci` |
+
+Planned: ble.sh, atuin.

--- a/e2e/fzf/Dockerfile
+++ b/e2e/fzf/Dockerfile
@@ -1,0 +1,17 @@
+# Environment for running fzf's bash shell-integration tests. Package list derived from
+# fzf's Dockerfile (https://github.com/junegunn/fzf/blob/master/Dockerfile, MIT license),
+# trimmed to what the bash tests need. fzf itself is cloned at build time, pinned below.
+FROM rubylang/ruby:3.4.1-noble
+ARG FZF_REF=52f4319a72c17e123396cc3a2e6abf2e96e9d753
+RUN apt-get update && apt-get install -y --no-install-recommends git make golang tmux ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY fzf/Gemfile /e2e/Gemfile
+RUN BUNDLE_GEMFILE=/e2e/Gemfile bundle install
+RUN git clone --filter=blob:none https://github.com/junegunn/fzf /fzf \
+    && git -C /fzf checkout -q "$FZF_REF" && cd /fzf && make install && chmod -R a+rwX /fzf
+# Do not set default PS1 (same as upstream)
+RUN rm -f /etc/bash.bashrc
+COPY shim /e2e/bin
+COPY fzf/entrypoint.sh fzf/skip-list.txt /e2e/
+ENV LANG=C.UTF-8 PATH=/e2e/bin:$PATH BUNDLE_GEMFILE=/e2e/Gemfile
+ENTRYPOINT ["/e2e/entrypoint.sh"]

--- a/e2e/fzf/Gemfile
+++ b/e2e/fzf/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'minitest', '5.25.4'
+gem 'minitest-ci'

--- a/e2e/fzf/entrypoint.sh
+++ b/e2e/fzf/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Contract: $SHELL_UNDER_TEST names the shell binary (see ../shim/bash);
+# results go to /results (junit XML + full log); exit status = test status.
+set -uo pipefail
+mkdir -p /results
+cd /fzf
+tmux new-session -d
+# Turn skip-list.txt into a minitest --exclude regex.
+skips=$(grep -v '^\s*\(#\|$\)' /e2e/skip-list.txt | paste -sd'|')
+# Non-bash shells are excluded (rather than selected with -n) so callers can pass their own -n.
+exclude="^(TestZsh|TestFish|TestNushell)#"
+[[ -n $skips ]] && exclude="$exclude|^($skips)$"
+ruby -Itest test/test_shell_integration.rb --verbose --exclude "/$exclude/" \
+    --ci-report --ci-dir /results/junit "$@" 2>&1 | tee /results/log.txt
+exit $?

--- a/e2e/fzf/skip-list.txt
+++ b/e2e/fzf/skip-list.txt
@@ -1,0 +1,3 @@
+# Tests excluded from the run, one "Class#method" per line. Lines starting with # are comments.
+# Background jobs run as in-process tasks, so `cmd &` prints "<pid unknown>" and $! is empty.
+TestBash#test_process_completion

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Run a containerized end-to-end suite of a real application against a shell.
+# Usage: e2e/run.sh [--shell PATH|bash] [--results DIR] APP [test-runner args...]
+set -euo pipefail
+here=$(cd "$(dirname "$0")" && pwd)
+shell=""; results=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --shell) shell=$2; shift 2 ;;
+        --results) results=$2; shift 2 ;;
+        --help|-h) sed -n 2,3p "$0"; exit 0 ;;
+        *) break ;;
+    esac
+done
+app=${1:?APP required}; shift
+[[ -f $here/$app/Dockerfile ]] || { echo "unknown app: $app" >&2; exit 2; }
+[[ -n $shell ]] || shell=$(ls "$here"/../target/{release,debug}/brush 2>/dev/null | head -1)
+results=${results:-$here/../target/e2e/$app}
+mkdir -p "$results"; results=$(cd "$results" && pwd)
+docker=${DOCKER:-docker}
+image=brush-e2e-$app
+$docker build -q -t "$image" -f "$here/$app/Dockerfile" "$here"
+mount=(); env=()
+if [[ $shell != bash ]]; then
+    shell=$(realpath "$shell")
+    mount=(-v "$shell:/shell/$(basename "$shell"):ro")
+    env=(-e "SHELL_UNDER_TEST=/shell/$(basename "$shell")")
+fi
+echo "==> $app against ${shell}; results in $results"
+$docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$results:/results" "${mount[@]}" "${env[@]}" "$image" "$@"

--- a/e2e/shim/bash
+++ b/e2e/shim/bash
@@ -1,0 +1,5 @@
+#!/bin/sh
+# e2e shim: applications' test suites invoke "bash" by name; route that to the
+# shell under test. Falls back to the real bash so the same image can produce
+# a baseline run.
+exec "${SHELL_UNDER_TEST:-/bin/bash}" "$@"


### PR DESCRIPTION
Runs a real application's own shell-integration suite in a container with the shell under test swapped in for bash via a PATH shim. Results are written as JUnit XML plus a log. fzf is the first adapter.

skip-list.txt lists tests to exclude, with a comment saying why; the entrypoint turns it into minitest's --exclude. Non-bash test classes are excluded the same way so callers can pass their own -n filter.

Assisted-By: Claude Fable 5.1