### PR TITLE
test(e2e): add atuin adapter with a custom shell-integration suite

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -26,7 +26,10 @@ context is `e2e/`, so it can `COPY shim /e2e/bin`) whose entrypoint:
    the host, so the image's glibc must be at least the host's. Most apps
    hard-code `bash`, so the shared `shim/bash` exec's `$SHELL_UNDER_TEST`;
    put `/e2e/bin` first on `PATH`. When the variable is unset the shim
-   runs the real `bash`, which gives the baseline run.
+   runs the real `bash`, which gives the baseline run. If the suite has its
+   own knob for which shell to test (atuin's `ATUIN_TEST_BASH`), set that
+   instead and skip the shim; a shim on `PATH` also captures test tooling
+   written in bash (bats, say), which must not run under the shell under test.
 2. **Writes results** to `/results`: `log.txt` plus JUnit XML under
    `junit/`. Write whatever else helps debugging there too.
 3. **Exits non-zero** when any test fails. Known failures go in the adapter's
@@ -55,5 +58,6 @@ the tests write into.
 | app | notes |
 |-----|-------|
 | fzf | upstream `test/test_shell_integration.rb`, `TestBash` only; minitest + tmux, JUnit via `minitest-ci` |
+| atuin | our own suite in `atuin/tests/` (bats + tmux), written to be upstreamable |
 
-Planned: ble.sh, atuin.
+Planned: ble.sh.

--- a/e2e/atuin/Dockerfile
+++ b/e2e/atuin/Dockerfile
@@ -1,0 +1,12 @@
+# Environment for running atuin's bash shell-integration tests (see tests/). atuin itself is
+# a pinned release binary; the test suite is our own, written to be upstreamable.
+FROM ubuntu:24.04
+ARG ATUIN_VERSION=18.21.0
+RUN apt-get update && apt-get install -y --no-install-recommends bats tmux curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL "https://github.com/atuinsh/atuin/releases/download/v${ATUIN_VERSION}/atuin-x86_64-unknown-linux-gnu.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=1 atuin-x86_64-unknown-linux-gnu/atuin
+COPY atuin/entrypoint.sh atuin/skip-list.txt /e2e/
+COPY atuin/tests /e2e/tests
+ENV LANG=C.UTF-8
+ENTRYPOINT ["/e2e/entrypoint.sh"]

--- a/e2e/atuin/Dockerfile
+++ b/e2e/atuin/Dockerfile
@@ -4,8 +4,9 @@ FROM ubuntu:24.04
 ARG ATUIN_VERSION=18.21.0
 RUN apt-get update && apt-get install -y --no-install-recommends bats tmux curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL "https://github.com/atuinsh/atuin/releases/download/v${ATUIN_VERSION}/atuin-x86_64-unknown-linux-gnu.tar.gz" \
-    | tar -xz -C /usr/local/bin --strip-components=1 atuin-x86_64-unknown-linux-gnu/atuin
+RUN target="$(uname -m)-unknown-linux-gnu" \
+    && curl -fsSL "https://github.com/atuinsh/atuin/releases/download/v${ATUIN_VERSION}/atuin-${target}.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=1 "atuin-${target}/atuin"
 COPY atuin/entrypoint.sh atuin/skip-list.txt /e2e/
 COPY atuin/tests /e2e/tests
 ENV LANG=C.UTF-8

--- a/e2e/atuin/entrypoint.sh
+++ b/e2e/atuin/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Contract: $SHELL_UNDER_TEST names the shell binary; results go to /results
+# (junit XML + full log); exit status = test status.
+set -uo pipefail
+# The suite takes the bash to test directly, so no PATH shim is needed (and bats, which
+# is itself a bash script, must not run under the shell under test).
+export ATUIN_TEST_BASH=${SHELL_UNDER_TEST:-bash}
+mkdir -p /results/junit
+# The suite's setup() skips any test whose name is listed here (see tests/helpers/shell.bash).
+ATUIN_TEST_SKIP=$(grep -v '^\s*\(#\|$\)' /e2e/skip-list.txt)
+export ATUIN_TEST_SKIP
+bats --report-formatter junit --output /results/junit --print-output-on-failure --timing \
+    "$@" /e2e/tests 2>&1 | tee /results/log.txt
+exit $?

--- a/e2e/atuin/skip-list.txt
+++ b/e2e/atuin/skip-list.txt
@@ -1,0 +1,1 @@
+# Tests excluded from the run, one bats test name per line. Lines starting with # are comments.

--- a/e2e/atuin/tests/README.md
+++ b/e2e/atuin/tests/README.md
@@ -1,0 +1,20 @@
+# Shell integration tests
+
+End-to-end tests for `atuin init <shell>`, driven through a real terminal: each test
+starts an interactive shell inside tmux with the integration loaded, sends keystrokes,
+and checks the screen and the history database.
+
+```bash
+bats tests/                 # needs bats, tmux, atuin on PATH
+bats tests/bash.bats -f history
+```
+
+Environment:
+
+- `ATUIN_TEST_BASH` — bash binary to test (default: `bash` from `PATH`).
+- `ATUIN_TEST_TIMEOUT` — seconds to wait for a screen condition (default: 10).
+- `ATUIN_TEST_SKIP` — newline-separated test names to skip.
+
+Each test gets a fresh `HOME`, so atuin's config and database are isolated and no
+sync is configured. `tests/helpers/shell.bash` holds the tmux driver; per-shell test
+files (`bash.bats`) hold the scenarios.

--- a/e2e/atuin/tests/bash.bats
+++ b/e2e/atuin/tests/bash.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+# atuin shell integration: bash
+
+load helpers/shell
+
+@test "init binds ctrl-r and up arrow" {
+    start_shell bash
+    run_line "bind -s > $BATS_TEST_TMPDIR/macros"
+    wait_for_prompt
+    grep -qF '"\C-r"' "$BATS_TEST_TMPDIR/macros"
+    grep -qF '"\e[A"' "$BATS_TEST_TMPDIR/macros"
+}
+
+@test "commands are recorded with their exit status" {
+    start_shell bash
+    run_line 'echo recorded-one'
+    wait_for '^recorded-one$'
+    run_line 'false'
+    wait_for_prompt
+    flush_history
+    wait_for_history '^0 echo recorded-one$'
+    wait_for_history '^1 false$'
+}
+
+@test "ctrl-r search runs the selected command" {
+    start_shell bash
+    run_line 'echo needle-in-history'
+    wait_for '^needle-in-history$'
+    flush_history
+    wait_for_history '^0 echo needle-in-history$'
+    send_keys C-r
+    wait_for 'Atuin v'
+    send_keys -l 'needle-in'
+    wait_for '^\s*>.*echo needle-in-history'
+    send_keys Enter
+    wait_for_prompt
+    # The command was run again: two outputs on screen.
+    wait_for_screen_count '^needle-in-history$' 2
+}
+
+@test "escaping ctrl-r search keeps the current line" {
+    start_shell bash
+    send_keys -l 'echo keep-me'
+    send_keys C-r
+    wait_for 'Atuin v'
+    send_keys Escape
+    wait_for '^atuin-test> echo keep-me$'
+}
+
+@test "up arrow opens search" {
+    start_shell bash
+    run_line 'echo up-arrow-entry'
+    wait_for '^up-arrow-entry$'
+    send_keys Up
+    wait_for 'Atuin v'
+    send_keys Escape
+    wait_for_prompt
+}

--- a/e2e/atuin/tests/helpers/shell.bash
+++ b/e2e/atuin/tests/helpers/shell.bash
@@ -1,0 +1,129 @@
+# Helpers for driving an interactive shell with the atuin integration inside tmux.
+# Sourced by the per-shell .bats files via `load helpers/shell`.
+
+: "${ATUIN_TEST_BASH:=bash}"
+: "${ATUIN_TEST_TIMEOUT:=10}"
+
+# bats hooks -------------------------------------------------------------
+
+setup() {
+    if [[ -n ${ATUIN_TEST_SKIP-} ]] && grep -qxF -- "$BATS_TEST_DESCRIPTION" <<<"$ATUIN_TEST_SKIP"; then
+        skip "listed in ATUIN_TEST_SKIP"
+    fi
+
+    # Isolate atuin's config and database per test.
+    export HOME=$BATS_TEST_TMPDIR/home
+    mkdir -p "$HOME"
+    unset XDG_CONFIG_HOME XDG_DATA_HOME ATUIN_SESSION ATUIN_HISTORY_ID
+
+    # Create and migrate the database once, up front: atuin migrates on first use, and two
+    # atuin processes racing to migrate a fresh database trip a UNIQUE constraint. Our
+    # out-of-band history queries would otherwise race the shell's own atuin at startup.
+    ATUIN_SESSION=$(atuin uuid) atuin history list >/dev/null 2>&1 || true
+
+    export TMUX_SOCKET=$BATS_TEST_TMPDIR/tmux
+    export TMUX_TMPDIR=$BATS_TEST_TMPDIR
+    unset TMUX
+}
+
+teardown() {
+    tmux -S "$TMUX_SOCKET" kill-server 2>/dev/null || true
+}
+
+# Shell lifecycle --------------------------------------------------------
+
+# Starts an interactive shell with `atuin init <shell>` loaded. Waits for the prompt.
+start_shell() {
+    local shell=${1:-bash} rc=$BATS_TEST_TMPDIR/rc
+    case $shell in
+        bash)
+            printf 'PS1="atuin-test> "\nHISTFILE=\neval "$(atuin init bash)"\n' >"$rc"
+            tmux -S "$TMUX_SOCKET" new-session -d -x 100 -y 30 "$ATUIN_TEST_BASH --noprofile --rcfile $rc"
+            ;;
+        *) echo "unsupported shell: $shell" >&2; return 1 ;;
+    esac
+    wait_for_prompt
+}
+
+# Sends keys as tmux understands them (e.g. `Enter`, `C-r`, `Up`, or literal text).
+send_keys() {
+    tmux -S "$TMUX_SOCKET" send-keys "$@"
+}
+
+# Types a command line and runs it.
+run_line() {
+    send_keys -l "$1"
+    send_keys Enter
+}
+
+# Prints the screen, trailing blank lines removed.
+screen() {
+    tmux -S "$TMUX_SOCKET" capture-pane -p | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}'
+}
+
+# Waits until the screen matches the extended regex, or fails with the screen contents.
+wait_for() {
+    local pattern=$1 deadline=$((SECONDS + ATUIN_TEST_TIMEOUT))
+    until screen | grep -qE -- "$pattern"; do
+        if ((SECONDS >= deadline)); then
+            echo "timed out waiting for /$pattern/; screen:" >&2
+            screen >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+}
+
+# Waits for the shell to show a prompt as the last line.
+wait_for_prompt() {
+    local deadline=$((SECONDS + ATUIN_TEST_TIMEOUT))
+    until [[ $(screen | tail -n 1) == "atuin-test>" ]]; do
+        if ((SECONDS >= deadline)); then
+            echo "timed out waiting for prompt; screen:" >&2
+            screen >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+}
+
+# Waits until exactly N screen lines match the extended regex; shows the screen otherwise.
+wait_for_screen_count() {
+    local pattern=$1 expected=$2 deadline=$((SECONDS + ATUIN_TEST_TIMEOUT)) actual
+    while :; do
+        actual=$(screen | grep -cE -- "$pattern")
+        ((actual == expected)) && return 0
+        if ((SECONDS >= deadline || actual > expected)); then
+            echo "expected $expected line(s) matching /$pattern/, found $actual; screen:" >&2
+            screen >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+}
+
+# Runs an empty command so atuin's precmd fires `history end` for the previous command,
+# whose exit status it only records on the following prompt.
+flush_history() {
+    send_keys Enter
+    wait_for_prompt
+}
+
+# History assertions -----------------------------------------------------
+
+# Waits until `atuin history list` (run outside the shell, against the same database)
+# matches the extended regex. atuin records `history end` asynchronously, so this polls.
+wait_for_history() {
+    local pattern=$1 deadline=$((SECONDS + ATUIN_TEST_TIMEOUT)) listing
+    while :; do
+        # atuin insists on a session id even just to list.
+        listing=$(ATUIN_SESSION=${ATUIN_SESSION:-$(atuin uuid)} atuin history list --format '{exit} {command}' 2>/dev/null) || listing=""  # may race with db creation
+        grep -qE -- "$pattern" <<<"$listing" && return 0
+        if ((SECONDS >= deadline)); then
+            echo "timed out waiting for history /$pattern/; history:" >&2
+            echo "$listing" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+}

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -14,7 +14,8 @@ while [[ $# -gt 0 ]]; do
 done
 app=${1:?APP required}; shift
 [[ -f $here/$app/Dockerfile ]] || { echo "unknown app: $app" >&2; exit 2; }
-[[ -n $shell ]] || shell=$(ls "$here"/../target/{release,debug}/brush 2>/dev/null | head -1)
+for p in release debug; do [[ -n $shell || ! -x $here/../target/$p/brush ]] || shell=$here/../target/$p/brush; done
+[[ -n $shell ]] || { echo "no brush binary found; build first or pass --shell" >&2; exit 2; }
 results=${results:-$here/../target/e2e/$app}
 mkdir -p "$results"; results=$(cd "$results" && pwd)
 docker=${DOCKER:-docker}


### PR DESCRIPTION
atuin has no shell-integration tests of its own, so this brings its own: a bats + tmux suite (tests/) that loads `atuin init bash`, drives a real terminal, and checks history recording, Ctrl-R search, and the up-arrow binding. It is written to stand alone (ATUIN_TEST_BASH selects the shell) so it could be offered upstream. The adapter runs atuin as a pinned release binary and takes the shell under test directly, without the PATH shim (bats is itself bash and must not run under the shell being tested).

Also make run.sh prefer an existing release build over debug and fail clearly when neither is present.

Assisted-By: Claude Opus 4.8