### PR TITLE
test(e2e): add ble.sh adapter running its upstream test suite

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -59,5 +59,4 @@ the tests write into.
 |-----|-------|
 | fzf | upstream `test/test_shell_integration.rb`, `TestBash` only; minitest + tmux, JUnit via `minitest-ci` |
 | atuin | our own suite in `atuin/tests/` (bats + tmux), written to be upstreamable |
-
-Planned: ble.sh.
+| blesh | upstream `ble.sh --test` (what its `make check` runs), one `lib/test-*.sh` file per run, each with a timeout (`BLESH_TEST_TIMEOUT`, default 180s; each file takes under 30s under bash); JUnit synthesized from the log, one testcase per upstream section. Args select files: `e2e/run.sh blesh util`. A hang logs the process tree; a hang or crash leaves ble.sh's per-test progress file in `progress/`, whose last `test` line is the test that was running |

--- a/e2e/blesh/Dockerfile
+++ b/e2e/blesh/Dockerfile
@@ -1,0 +1,13 @@
+# Environment for running ble.sh's own test suite (`ble.sh --test`, which is what upstream's
+# `make check` runs; see https://github.com/akinomyoga/ble.sh/blob/master/.github/workflows/test.yml,
+# BSD-3-Clause). Build needs git, GNU make and gawk (per upstream README). ble.sh is cloned and
+# built at image build time, pinned below. less: the pager test expects it; procps: ps for hang diagnostics.
+FROM ubuntu:24.04
+ARG BLESH_REF=63c23e99f1f7133ae57b79f87b16d1f68cd39884
+RUN apt-get update && apt-get install -y --no-install-recommends git make gawk less procps ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --filter=blob:none https://github.com/akinomyoga/ble.sh /blesh \
+    && git -C /blesh checkout -q "$BLESH_REF" && make -C /blesh && chmod -R a+rwX /blesh
+COPY blesh/entrypoint.sh blesh/skip-list.txt /e2e/
+ENV LANG=C.UTF-8
+ENTRYPOINT ["/e2e/entrypoint.sh"]

--- a/e2e/blesh/entrypoint.sh
+++ b/e2e/blesh/entrypoint.sh
@@ -5,15 +5,24 @@ set -uo pipefail
 # ble.sh --test runs under whatever shell invokes it, so no PATH shim is needed.
 shell=${SHELL_UNDER_TEST:-bash}
 timeout=${BLESH_TEST_TIMEOUT:-180}
+rm -rf /results/progress
+mkdir -p /results/junit /results/progress
+: > /results/log.txt
 case $timeout in
     ''|*[!0-9]*)
-        echo "BLESH_TEST_TIMEOUT must be a non-negative integer number of seconds, got '$timeout'" >&2
+        echo "BLESH_TEST_TIMEOUT must be a non-negative integer number of seconds, got '$timeout'" | tee -a /results/log.txt >&2
+        cat > /results/junit/blesh.xml <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="blesh" tests="1" failures="1">
+  <testcase classname="configuration" name="BLESH_TEST_TIMEOUT">
+    <failure message="invalid BLESH_TEST_TIMEOUT">BLESH_TEST_TIMEOUT must be a non-negative integer number of seconds</failure>
+  </testcase>
+</testsuite>
+EOF
         exit 2
         ;;
 esac
 timeout=$((10#$timeout))
-rm -rf /results/progress
-mkdir -p /results/junit /results/progress
 # Diagnostics for crashes and hangs: ble.sh keeps a per-run progress file (one "test TITLE" line as
 # each test starts, then "pass"/"fail") in its runtime directory and deletes it on a clean exit. Put
 # that directory under /results so the file survives a panic or our SIGKILL; each run's leftovers are
@@ -30,7 +39,6 @@ if (($#)); then
 else
     mapfile -t files < <(printf '%s\n' "${all[@]}" | grep -vxFf <(grep -v '^\s*\(#\|$\)' /e2e/skip-list.txt))
 fi
-: > /results/log.txt
 log() { echo "$@" | tee -a /results/log.txt; }
 for f in "${files[@]}"; do
     log "==> test-$f"
@@ -42,17 +50,16 @@ for f in "${files[@]}"; do
     # process has already exited but a child is still writing to stdout/stderr.
     tee -a /results/log.txt <"$fifo" &
     tee_pid=$!
-    # setsid: own session, so the whole process tree can be listed (ps -s) and killed as a group.
+    # setsid: own session, so the whole process tree can be listed and killed.
     setsid "$shell" ble.sh --test "$f" </dev/null >"$fifo" 2>&1 &
     pid=$!
-    rm -f "$fifo"
     start=$SECONDS deadline=$((SECONDS + timeout))
     while { kill -0 "$pid" 2>/dev/null || kill -0 "$tee_pid" 2>/dev/null; } && ((SECONDS < deadline)); do sleep 1; done
     if { kill -0 "$pid" 2>/dev/null || kill -0 "$tee_pid" 2>/dev/null; }; then
         log "==> test-$f: timed out after ${timeout}s; process tree:"
         ps -s "$pid" -o pid,stat,etime,wchan:24,args --forest | tee -a /results/log.txt
         # SIGKILL, not TERM: ble.sh's exit trap would delete the progress file.
-        kill -KILL -- "-$pid" 2>/dev/null
+        pkill -KILL -s "$pid" 2>/dev/null
         kill -KILL "$tee_pid" 2>/dev/null || true
     fi
     wait "$pid" 2>/dev/null; exit=$?
@@ -60,6 +67,7 @@ for f in "${files[@]}"; do
         kill -TERM "$tee_pid" 2>/dev/null || true
         wait "$tee_pid" 2>/dev/null || true
     fi
+    rm -f "$fifo"
     for p in /results/run/blesh/*.test/*; do
         case ${p##*/} in *[!0-9]*|'') continue ;; esac  # the section file is named by BASHPID; skip diff temp files
         mkdir -p "/results/progress/test-$f" && cp "$p" "/results/progress/test-$f/"
@@ -86,7 +94,7 @@ function testcase(name, failed, msg,   body) {
 /^==> test-[^ ]+: timed out/ { timedout = 1 }
 /^==> test-[^ ]+ \([0-9]+s\) exit=/ {
     sub(/.*exit=/, "")
-    if (!seen || timedout || ($0 != 0 && !filefail)) testcase(file, 1, (timedout ? "timed out" : "crashed") " (exit " $0 ")")
+    if (!seen || timedout || ($0 != 0 && ($0 != 1 || !filefail))) testcase(file, 1, (timedout ? "timed out" : "crashed") " (exit " $0 ")")
     next
 }
 /\[section\] / && match($0, /([0-9]+)\/([0-9]+) \(([0-9]+) fail, ([0-9]+) crash, ([0-9]+) skip\)$/, m) {

--- a/e2e/blesh/entrypoint.sh
+++ b/e2e/blesh/entrypoint.sh
@@ -5,6 +5,7 @@ set -uo pipefail
 # ble.sh --test runs under whatever shell invokes it, so no PATH shim is needed.
 shell=${SHELL_UNDER_TEST:-bash}
 timeout=${BLESH_TEST_TIMEOUT:-180}
+rm -rf /results/progress
 mkdir -p /results/junit /results/progress
 # Diagnostics for crashes and hangs: ble.sh keeps a per-run progress file (one "test TITLE" line as
 # each test starts, then "pass"/"fail") in its runtime directory and deletes it on a clean exit. Put
@@ -51,7 +52,10 @@ done
 # logged above it); a file that ends without any summary, or exits non-zero without a failed
 # section, is reported as one crashed/timed-out testcase whose body is whatever it logged last.
 sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' /results/log.txt | gawk '
-function esc(s) { gsub(/&/, "\\&amp;", s); gsub(/</, "\\&lt;", s); gsub(/"/, "\\&quot;", s); return s }
+function esc(s) {
+    gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F]/, "", s)
+    gsub(/&/, "\\&amp;", s); gsub(/</, "\\&lt;", s); gsub(/"/, "\\&quot;", s); return s
+}
 function testcase(name, failed, msg,   body) {
     total++
     body = "  <testcase classname=\"" esc(file) "\" name=\"" esc(name) "\""
@@ -63,7 +67,7 @@ function testcase(name, failed, msg,   body) {
 /^==> test-[^ ]+: timed out/ { timedout = 1 }
 /^==> test-[^ ]+ \([0-9]+s\) exit=/ {
     sub(/.*exit=/, "")
-    if (!seen || ($0 != 0 && !filefail)) testcase(file, 1, (timedout ? "timed out" : "crashed") " (exit " $0 ")")
+    if (!seen || timedout || ($0 != 1 || !filefail)) testcase(file, 1, (timedout ? "timed out" : "crashed") " (exit " $0 ")")
     next
 }
 /\[section\] / && match($0, /([0-9]+)\/([0-9]+) \(([0-9]+) fail, ([0-9]+) crash, ([0-9]+) skip\)$/, m) {

--- a/e2e/blesh/entrypoint.sh
+++ b/e2e/blesh/entrypoint.sh
@@ -5,6 +5,13 @@ set -uo pipefail
 # ble.sh --test runs under whatever shell invokes it, so no PATH shim is needed.
 shell=${SHELL_UNDER_TEST:-bash}
 timeout=${BLESH_TEST_TIMEOUT:-180}
+case $timeout in
+    ''|*[!0-9]*)
+        echo "BLESH_TEST_TIMEOUT must be a non-negative integer number of seconds, got '$timeout'" >&2
+        exit 2
+        ;;
+esac
+timeout=$((10#$timeout))
 rm -rf /results/progress
 mkdir -p /results/junit /results/progress
 # Diagnostics for crashes and hangs: ble.sh keeps a per-run progress file (one "test TITLE" line as
@@ -28,19 +35,31 @@ log() { echo "$@" | tee -a /results/log.txt; }
 for f in "${files[@]}"; do
     log "==> test-$f"
     rm -rf /results/run/blesh/*.test
+    fifo=/results/run/test-$f.fifo
+    rm -f "$fifo"
+    mkfifo "$fifo"
+    # Keep a second handle for the log copier so it can be reaped even when the shell
+    # process has already exited but a child is still writing to stdout/stderr.
+    tee -a /results/log.txt <"$fifo" &
+    tee_pid=$!
     # setsid: own session, so the whole process tree can be listed (ps -s) and killed as a group.
-    setsid "$shell" ble.sh --test "$f" </dev/null > >(tee -a /results/log.txt) 2>&1 &
+    setsid "$shell" ble.sh --test "$f" </dev/null >"$fifo" 2>&1 &
     pid=$!
+    rm -f "$fifo"
     start=$SECONDS deadline=$((SECONDS + timeout))
-    while kill -0 "$pid" 2>/dev/null && ((SECONDS < deadline)); do sleep 1; done
-    if kill -0 "$pid" 2>/dev/null; then
+    while { kill -0 "$pid" 2>/dev/null || kill -0 "$tee_pid" 2>/dev/null; } && ((SECONDS < deadline)); do sleep 1; done
+    if { kill -0 "$pid" 2>/dev/null || kill -0 "$tee_pid" 2>/dev/null; }; then
         log "==> test-$f: timed out after ${timeout}s; process tree:"
         ps -s "$pid" -o pid,stat,etime,wchan:24,args --forest | tee -a /results/log.txt
         # SIGKILL, not TERM: ble.sh's exit trap would delete the progress file.
         kill -KILL -- "-$pid" 2>/dev/null
+        kill -KILL "$tee_pid" 2>/dev/null || true
     fi
-    wait "$pid"; exit=$?
-    wait  # drain the tee
+    wait "$pid" 2>/dev/null; exit=$?
+    if kill -0 "$tee_pid" 2>/dev/null; then
+        kill -TERM "$tee_pid" 2>/dev/null || true
+        wait "$tee_pid" 2>/dev/null || true
+    fi
     for p in /results/run/blesh/*.test/*; do
         case ${p##*/} in *[!0-9]*|'') continue ;; esac  # the section file is named by BASHPID; skip diff temp files
         mkdir -p "/results/progress/test-$f" && cp "$p" "/results/progress/test-$f/"

--- a/e2e/blesh/entrypoint.sh
+++ b/e2e/blesh/entrypoint.sh
@@ -86,7 +86,7 @@ function testcase(name, failed, msg,   body) {
 /^==> test-[^ ]+: timed out/ { timedout = 1 }
 /^==> test-[^ ]+ \([0-9]+s\) exit=/ {
     sub(/.*exit=/, "")
-    if (!seen || timedout || ($0 != 1 || !filefail)) testcase(file, 1, (timedout ? "timed out" : "crashed") " (exit " $0 ")")
+    if (!seen || timedout || ($0 != 0 && !filefail)) testcase(file, 1, (timedout ? "timed out" : "crashed") " (exit " $0 ")")
     next
 }
 /\[section\] / && match($0, /([0-9]+)\/([0-9]+) \(([0-9]+) fail, ([0-9]+) crash, ([0-9]+) skip\)$/, m) {

--- a/e2e/blesh/entrypoint.sh
+++ b/e2e/blesh/entrypoint.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Contract: $SHELL_UNDER_TEST names the shell binary; results go to /results
+# (junit XML + full log); exit status = test status.
+set -uo pipefail
+# ble.sh --test runs under whatever shell invokes it, so no PATH shim is needed.
+shell=${SHELL_UNDER_TEST:-bash}
+timeout=${BLESH_TEST_TIMEOUT:-180}
+mkdir -p /results/junit /results/progress
+# Diagnostics for crashes and hangs: ble.sh keeps a per-run progress file (one "test TITLE" line as
+# each test starts, then "pass"/"fail") in its runtime directory and deletes it on a clean exit. Put
+# that directory under /results so the file survives a panic or our SIGKILL; each run's leftovers are
+# copied to /results/progress/ below, where the last "test" line names the test that was running.
+mkdir -p -m 700 /results/run
+export XDG_RUNTIME_DIR=/results/run RUST_BACKTRACE=1
+cd /blesh/out
+# Upstream's `make check` is `bash out/ble.sh --test`, which sources every lib/test-*.sh in one
+# process. We run the files one at a time, each under a timeout, so a hang or crash in one is
+# reported as such and the rest still run. Arguments select files (default: all, minus skip-list.txt).
+all=(bash main util canvas decode edit syntax complete keymap.vi)
+if (($#)); then
+    files=("$@")
+else
+    mapfile -t files < <(printf '%s\n' "${all[@]}" | grep -vxFf <(grep -v '^\s*\(#\|$\)' /e2e/skip-list.txt))
+fi
+: > /results/log.txt
+log() { echo "$@" | tee -a /results/log.txt; }
+for f in "${files[@]}"; do
+    log "==> test-$f"
+    rm -rf /results/run/blesh/*.test
+    # setsid: own session, so the whole process tree can be listed (ps -s) and killed as a group.
+    setsid "$shell" ble.sh --test "$f" </dev/null > >(tee -a /results/log.txt) 2>&1 &
+    pid=$!
+    start=$SECONDS deadline=$((SECONDS + timeout))
+    while kill -0 "$pid" 2>/dev/null && ((SECONDS < deadline)); do sleep 1; done
+    if kill -0 "$pid" 2>/dev/null; then
+        log "==> test-$f: timed out after ${timeout}s; process tree:"
+        ps -s "$pid" -o pid,stat,etime,wchan:24,args --forest | tee -a /results/log.txt
+        # SIGKILL, not TERM: ble.sh's exit trap would delete the progress file.
+        kill -KILL -- "-$pid" 2>/dev/null
+    fi
+    wait "$pid"; exit=$?
+    wait  # drain the tee
+    for p in /results/run/blesh/*.test/*; do
+        case ${p##*/} in *[!0-9]*|'') continue ;; esac  # the section file is named by BASHPID; skip diff temp files
+        mkdir -p "/results/progress/test-$f" && cp "$p" "/results/progress/test-$f/"
+        log "==> test-$f: saved progress file $p (last started: $(grep '^test ' "$p" | tail -n1))"
+    done
+    log "==> test-$f ($((SECONDS - start))s) exit=$exit"
+done
+# JUnit: one testcase per upstream "[section]" summary line (its failure body is the diff output
+# logged above it); a file that ends without any summary, or exits non-zero without a failed
+# section, is reported as one crashed/timed-out testcase whose body is whatever it logged last.
+sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' /results/log.txt | gawk '
+function esc(s) { gsub(/&/, "\\&amp;", s); gsub(/</, "\\&lt;", s); gsub(/"/, "\\&quot;", s); return s }
+function testcase(name, failed, msg,   body) {
+    total++
+    body = "  <testcase classname=\"" esc(file) "\" name=\"" esc(name) "\""
+    if (!failed) { cases = cases body "/>\n"; return }
+    failures++; filefail = 1
+    cases = cases body ">\n    <failure message=\"" esc(msg) "\">" esc(buf) "</failure>\n  </testcase>\n"
+}
+/^==> test-[^ ]+$/ { file = $2; buf = ""; seen = 0; filefail = 0; timedout = 0; next }
+/^==> test-[^ ]+: timed out/ { timedout = 1 }
+/^==> test-[^ ]+ \([0-9]+s\) exit=/ {
+    sub(/.*exit=/, "")
+    if (!seen || ($0 != 0 && !filefail)) testcase(file, 1, (timedout ? "timed out" : "crashed") " (exit " $0 ")")
+    next
+}
+/\[section\] / && match($0, /([0-9]+)\/([0-9]+) \(([0-9]+) fail, ([0-9]+) crash, ([0-9]+) skip\)$/, m) {
+    name = $0; sub(/.*\[section\] /, "", name); sub(/: [0-9]+\/[0-9]+ \(.*/, "", name)
+    testcase(name, m[1] != m[2], m[3] " fail, " m[4] " crash")
+    seen = 1; buf = ""; next
+}
+{ buf = buf $0 "\n" }
+END {
+    print "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuite name=\"blesh\" tests=\"" total+0 "\" failures=\"" failures+0 "\">"
+    printf "%s", cases
+    print "</testsuite>"
+    exit failures > 0
+}' > /results/junit/blesh.xml

--- a/e2e/blesh/entrypoint.sh
+++ b/e2e/blesh/entrypoint.sh
@@ -39,7 +39,7 @@ if (($#)); then
 else
     mapfile -t files < <(printf '%s\n' "${all[@]}" | grep -vxFf <(grep -v '^\s*\(#\|$\)' /e2e/skip-list.txt))
 fi
-log() { echo "$@" | tee -a /results/log.txt; }
+log() { printf '\n%s\n' "$*" | tee -a /results/log.txt; }
 for f in "${files[@]}"; do
     log "==> test-$f"
     rm -rf /results/run/blesh/*.test
@@ -81,7 +81,7 @@ done
 sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' /results/log.txt | gawk '
 function esc(s) {
     gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F]/, "", s)
-    gsub(/&/, "\\&amp;", s); gsub(/</, "\\&lt;", s); gsub(/"/, "\\&quot;", s); return s
+    gsub(/&/, "\\&amp;", s); gsub(/</, "\\&lt;", s); gsub(/>/, "\\&gt;", s); gsub(/"/, "\\&quot;", s); return s
 }
 function testcase(name, failed, msg,   body) {
     total++

--- a/e2e/blesh/skip-list.txt
+++ b/e2e/blesh/skip-list.txt
@@ -1,0 +1,2 @@
+# Test files excluded from the run, one per line, named as in `ble.sh --test NAME` (bash, main,
+# util, canvas, decode, edit, syntax, complete, keymap.vi). Lines starting with # are comments.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -27,5 +27,8 @@ if [[ $shell != bash ]]; then
     mount=(-v "$shell:/shell/$(basename "$shell"):ro")
     env=(-e "SHELL_UNDER_TEST=/shell/$(basename "$shell")")
 fi
+if [[ -n ${BLESH_TEST_TIMEOUT:-} ]]; then
+    env+=(-e "BLESH_TEST_TIMEOUT=$BLESH_TEST_TIMEOUT")
+fi
 echo "==> $app against ${shell}; results in $results"
 $docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$results:/results" "${mount[@]}" "${env[@]}" "$image" "$@"


### PR DESCRIPTION
ble.sh ships a real test suite (`ble.sh --test`, what its `make check` runs), so this adapter borrows it: the image clones and builds ble.sh at a pinned commit, and the entrypoint runs each lib/test-*.sh file separately under a timeout so a hang or crash in one is reported and the rest still run. JUnit is synthesized from the log, one testcase per upstream section, plus a failing case for any file that times out, crashes, or ends without a summary (a file can exit 0 having run nothing).

Diagnostics for hangs and crashes: the process tree is logged before the run is SIGKILLed (not TERMed, so ble.sh's exit trap cannot delete evidence), ble.sh's runtime directory is placed under /results so its per-test progress file survives and is copied out with the last-started test named in the log, and RUST_BACKTRACE is enabled. Each file's elapsed time is logged; the default 180s cap is ~18x the slowest file under bash.

Assisted-By: Claude Fable 5.1