### PR TITLE
fix(builtins): match bash's type output for aliases, misses, and PATH

### DIFF
--- a/brush-builtins/src/lib.rs
+++ b/brush-builtins/src/lib.rs
@@ -118,6 +118,8 @@ mod wait;
 
 mod builder;
 mod factory;
+#[cfg(feature = "builtin.type")]
+mod lookup;
 mod unimp;
 
 pub use builder::ShellBuilderExt;

--- a/brush-builtins/src/lookup.rs
+++ b/brush-builtins/src/lookup.rs
@@ -1,0 +1,140 @@
+//! Shared command-name resolution, used by the `type` and `command` builtins.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use brush_core::{
+    Shell, ShellExtensions,
+    parser::ast,
+    sys::{self, fs::PathExt},
+};
+
+/// A way in which a name resolved, in the shell's lookup order.
+pub(crate) enum Resolved<'a> {
+    /// An alias, with its target.
+    Alias(String),
+    /// A shell keyword.
+    Keyword,
+    /// A shell function, with its definition.
+    Function(&'a ast::FunctionDefinition),
+    /// A built-in command.
+    Builtin,
+    /// An executable file; `hashed` indicates it came from the program location cache.
+    File { path: PathBuf, hashed: bool },
+}
+
+/// Options for [`resolve`]; the defaults match a plain `type NAME` lookup.
+#[derive(Default)]
+pub(crate) struct Options {
+    /// Only search the filesystem, even if the name is an alias, keyword, function, or builtin.
+    pub force_path_search: bool,
+    /// Don't consider functions when resolving the name.
+    pub suppress_func_lookup: bool,
+    /// Report every location the name resolves to, not just the first.
+    pub all_locations: bool,
+}
+
+/// Resolves the given name, returning the ways it resolved (in lookup order). Unless
+/// `all_locations` was requested, at most one way is returned.
+pub(crate) fn resolve<'a, SE: ShellExtensions>(
+    shell: &'a Shell<SE>,
+    name: &str,
+    options: &Options,
+) -> Vec<Resolved<'a>> {
+    let mut resolved = vec![];
+
+    // These are all hash lookups, so there's nothing to save by stopping at the first hit;
+    // any extras are trimmed off at the end.
+    if !options.force_path_search {
+        // Check for aliases.
+        if let Some(target) = shell.aliases().get(name) {
+            resolved.push(Resolved::Alias(target.clone()));
+        }
+
+        // Check for keywords.
+        if shell.is_keyword(name) {
+            resolved.push(Resolved::Keyword);
+        }
+
+        // Check for functions.
+        if !options.suppress_func_lookup
+            && let Some(registration) = shell.funcs().get(name)
+        {
+            resolved.push(Resolved::Function(registration.definition()));
+        }
+
+        // Check for builtins.
+        if shell.builtins().get(name).is_some_and(|b| !b.disabled) {
+            resolved.push(Resolved::Builtin);
+        }
+    }
+
+    // Searching the filesystem *does* cost something, so only do it if the results so far
+    // don't already answer the question.
+    if options.all_locations || resolved.is_empty() {
+        resolve_in_filesystem(shell, name, options, &mut resolved);
+    }
+
+    if !options.all_locations {
+        resolved.truncate(1);
+    }
+
+    resolved
+}
+
+/// Appends the files the given name resolves to.
+fn resolve_in_filesystem<SE: ShellExtensions>(
+    shell: &Shell<SE>,
+    name: &str,
+    options: &Options,
+    resolved: &mut Vec<Resolved<'_>>,
+) {
+    let to_file = |path| Resolved::File {
+        path,
+        hashed: false,
+    };
+
+    // A name with a separator in it is used as-is; it's never searched for.
+    if sys::fs::contains_path_separator(name) {
+        if shell.absolute_path(Path::new(name)).executable() {
+            resolved.push(to_file(PathBuf::from(name)));
+        }
+        return;
+    }
+
+    if let Some(path) = shell.program_location_cache().get(name) {
+        resolved.push(Resolved::File { path, hashed: true });
+        if !options.all_locations {
+            return;
+        }
+    }
+
+    resolved.extend(
+        shell
+            .find_executables_in_path(name)
+            .take(if options.all_locations { usize::MAX } else { 1 })
+            .map(to_file),
+    );
+}
+
+/// Writes the description shown by `type NAME` and `command -V NAME`, newline included.
+pub(crate) fn describe(
+    mut writer: impl Write,
+    name: &str,
+    resolved: &Resolved<'_>,
+) -> std::io::Result<()> {
+    match resolved {
+        Resolved::Alias(target) => writeln!(writer, "{name} is aliased to `{target}'"),
+        Resolved::Keyword => writeln!(writer, "{name} is a shell keyword"),
+        Resolved::Function(def) => writeln!(writer, "{name} is a function\n{def}"),
+        Resolved::Builtin => writeln!(writer, "{name} is a shell builtin"),
+        Resolved::File { path, hashed } => {
+            let path = path.to_string_lossy();
+            if *hashed {
+                writeln!(writer, "{name} is hashed ({path})")
+            } else {
+                writeln!(writer, "{name} is {path}")
+            }
+        }
+    }
+}

--- a/brush-builtins/src/lookup.rs
+++ b/brush-builtins/src/lookup.rs
@@ -46,8 +46,11 @@ pub(crate) fn resolve<'a, SE: ShellExtensions>(
     // These are all hash lookups, so there's nothing to save by stopping at the first hit;
     // any extras are trimmed off at the end.
     if !options.force_path_search {
-        // Check for aliases.
-        if let Some(target) = shell.aliases().get(name) {
+        // Check for aliases. They're only reported when alias expansion is enabled, since
+        // that's the only case in which the name would actually resolve to the alias.
+        if shell.options().expand_aliases
+            && let Some(target) = shell.aliases().get(name)
+        {
             resolved.push(Resolved::Alias(target.clone()));
         }
 
@@ -96,12 +99,17 @@ fn resolve_in_filesystem<SE: ShellExtensions>(
 
     // A name with a separator in it is used as-is; it's never searched for.
     if sys::fs::contains_path_separator(name) {
-        if shell.absolute_path(Path::new(name)).executable() {
+        // A directory is never a command, even though it carries the execute bit.
+        let candidate = shell.absolute_path(Path::new(name));
+        if !candidate.is_dir() && candidate.executable() {
             resolved.push(to_file(PathBuf::from(name)));
         }
         return;
     }
 
+    // Reporting every location is a strict search for executables; reporting just the one the
+    // name resolves to matches what the shell would actually try to run, which can be a
+    // non-executable file if the search turns up nothing better.
     if let Some(path) = shell.program_location_cache().get(name) {
         resolved.push(Resolved::File { path, hashed: true });
         if !options.all_locations {
@@ -109,12 +117,11 @@ fn resolve_in_filesystem<SE: ShellExtensions>(
         }
     }
 
-    resolved.extend(
-        shell
-            .find_executables_in_path(name)
-            .take(if options.all_locations { usize::MAX } else { 1 })
-            .map(to_file),
-    );
+    if options.all_locations {
+        resolved.extend(shell.find_executables_in_path(name).map(to_file));
+    } else {
+        resolved.extend(shell.resolve_command_in_path(name).map(to_file));
+    }
 }
 
 /// Writes the description shown by `type NAME` and `command -V NAME`, newline included.

--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
-use std::path::{Path, PathBuf};
 
 use clap::Parser;
 
-use brush_core::sys::{self, fs::PathExt};
-use brush_core::{ExecutionResult, Shell, builtins, parser::ast};
+use brush_core::{ExecutionResult, builtins};
+
+use crate::lookup::{self, Resolved};
 
 /// Inspect the type of a named shell item.
 #[derive(Parser)]
@@ -34,14 +34,6 @@ pub(crate) struct TypeCommand {
     names: Vec<String>,
 }
 
-enum ResolvedType<'a> {
-    Alias(String),
-    Keyword,
-    Function(&'a ast::FunctionDefinition),
-    Builtin,
-    File { path: PathBuf, hashed: bool },
-}
-
 impl builtins::Command for TypeCommand {
     type Error = brush_core::Error;
 
@@ -50,9 +42,14 @@ impl builtins::Command for TypeCommand {
         context: brush_core::ExecutionContext<'_, SE>,
     ) -> Result<brush_core::ExecutionResult, Self::Error> {
         let mut result = ExecutionResult::success();
+        let options = lookup::Options {
+            force_path_search: self.force_path_search,
+            suppress_func_lookup: self.suppress_func_lookup,
+            all_locations: self.all_locations,
+        };
 
         for name in &self.names {
-            let resolved_types = self.resolve_types(context.shell, name);
+            let resolved_types = lookup::resolve(context.shell, name, &options);
 
             if resolved_types.is_empty() {
                 if !self.type_only && !self.force_path_search && !self.show_path_only {
@@ -64,23 +61,23 @@ impl builtins::Command for TypeCommand {
             }
 
             for resolved_type in resolved_types {
-                if self.show_path_only && !matches!(resolved_type, ResolvedType::File { .. }) {
+                if self.show_path_only && !matches!(resolved_type, Resolved::File { .. }) {
                     // Do nothing.
                 } else if self.type_only {
-                    match resolved_type {
-                        ResolvedType::Alias(_) => {
+                    match &resolved_type {
+                        Resolved::Alias(_) => {
                             writeln!(context.stdout(), "alias")?;
                         }
-                        ResolvedType::Keyword => {
+                        Resolved::Keyword => {
                             writeln!(context.stdout(), "keyword")?;
                         }
-                        ResolvedType::Function(_) => {
+                        Resolved::Function(_) => {
                             writeln!(context.stdout(), "function")?;
                         }
-                        ResolvedType::Builtin => {
+                        Resolved::Builtin => {
                             writeln!(context.stdout(), "builtin")?;
                         }
-                        ResolvedType::File { path, .. } => {
+                        Resolved::File { path, .. } => {
                             if self.show_path_only || self.force_path_search {
                                 writeln!(context.stdout(), "{}", path.to_string_lossy())?;
                             } else {
@@ -89,42 +86,16 @@ impl builtins::Command for TypeCommand {
                         }
                     }
                 } else {
-                    match resolved_type {
-                        ResolvedType::Alias(target) => {
-                            writeln!(context.stdout(), "{name} is aliased to `{target}'")?;
+                    match &resolved_type {
+                        // When we're displaying all locations, we don't show hashed paths.
+                        Resolved::File { hashed: true, .. }
+                            if self.all_locations && !self.force_path_search => {}
+                        Resolved::File { path, .. }
+                            if self.show_path_only || self.force_path_search =>
+                        {
+                            writeln!(context.stdout(), "{}", path.to_string_lossy())?;
                         }
-                        ResolvedType::Keyword => {
-                            writeln!(context.stdout(), "{name} is a shell keyword")?;
-                        }
-                        ResolvedType::Function(def) => {
-                            writeln!(context.stdout(), "{name} is a function")?;
-                            writeln!(context.stdout(), "{def}")?;
-                        }
-                        ResolvedType::Builtin => {
-                            writeln!(context.stdout(), "{name} is a shell builtin")?;
-                        }
-                        ResolvedType::File { path, hashed } => {
-                            if hashed && self.all_locations && !self.force_path_search {
-                                // Do nothing. When we're displaying all locations, then
-                                // we don't show hashed paths.
-                            } else if self.show_path_only || self.force_path_search {
-                                writeln!(context.stdout(), "{}", path.to_string_lossy())?;
-                            } else if hashed {
-                                writeln!(
-                                    context.stdout(),
-                                    "{name} is hashed ({path})",
-                                    name = name,
-                                    path = path.to_string_lossy()
-                                )?;
-                            } else {
-                                writeln!(
-                                    context.stdout(),
-                                    "{name} is {path}",
-                                    name = name,
-                                    path = path.to_string_lossy()
-                                )?;
-                            }
-                        }
+                        _ => lookup::describe(context.stdout(), name, &resolved_type)?,
                     }
                 }
 
@@ -136,85 +107,5 @@ impl builtins::Command for TypeCommand {
         }
 
         Ok(result)
-    }
-}
-
-impl TypeCommand {
-    fn resolve_types<'a, SE: brush_core::ShellExtensions>(
-        &self,
-        shell: &'a Shell<SE>,
-        name: &str,
-    ) -> Vec<ResolvedType<'a>> {
-        let mut types = vec![];
-
-        if !self.force_path_search {
-            // Check for aliases.
-            if let Some(a) = shell.aliases().get(name) {
-                types.push(ResolvedType::Alias(a.clone()));
-                if !self.all_locations {
-                    return types;
-                }
-            }
-
-            // Check for keywords.
-            if shell.is_keyword(name) {
-                types.push(ResolvedType::Keyword);
-                if !self.all_locations {
-                    return types;
-                }
-            }
-
-            // Check for functions.
-            if !self.suppress_func_lookup {
-                if let Some(registration) = shell.funcs().get(name) {
-                    types.push(ResolvedType::Function(registration.definition()));
-                    if !self.all_locations {
-                        return types;
-                    }
-                }
-            }
-
-            // Check for builtins.
-            if shell.builtins().get(name).is_some_and(|b| !b.disabled) {
-                types.push(ResolvedType::Builtin);
-                if !self.all_locations {
-                    return types;
-                }
-            }
-        }
-
-        // Look in path.
-        if sys::fs::contains_path_separator(name) {
-            if shell.absolute_path(Path::new(name)).executable() {
-                types.push(ResolvedType::File {
-                    path: PathBuf::from(name),
-                    hashed: false,
-                });
-
-                if !self.all_locations {
-                    return types;
-                }
-            }
-        } else {
-            if let Some(path) = shell.program_location_cache().get(name) {
-                types.push(ResolvedType::File { path, hashed: true });
-                if !self.all_locations {
-                    return types;
-                }
-            }
-
-            for item in shell.find_executables_in_path(name) {
-                types.push(ResolvedType::File {
-                    path: item,
-                    hashed: false,
-                });
-
-                if !self.all_locations {
-                    return types;
-                }
-            }
-        }
-
-        types
     }
 }

--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -53,7 +53,7 @@ impl builtins::Command for TypeCommand {
 
             if resolved_types.is_empty() {
                 if !self.type_only && !self.force_path_search && !self.show_path_only {
-                    writeln!(context.stderr(), "type: {name} not found")?;
+                    writeln!(context.stderr(), "type: {name}: not found")?;
                 }
 
                 result = ExecutionResult::general_error();

--- a/brush-core/src/shell/fs.rs
+++ b/brush-core/src/shell/fs.rs
@@ -153,12 +153,23 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
         }
     }
 
-    /// Resolves a command name against the shell's hash-based path cache, searching the
-    /// shell's current PATH on a miss and caching whatever the search turns up.
+    /// Resolves a command name by searching the shell's current PATH.
     ///
-    /// Unlike [`Self::find_first_executable_in_path_using_cache`], a non-executable entry in
-    /// the PATH resolves as the command; the shell reports it as the command and then fails
-    /// to run it. See [`pathsearch::resolve_command`].
+    /// Unlike [`Self::find_first_executable_in_path`], a non-executable entry in the PATH
+    /// resolves as the command; the shell reports it as the command and then fails to run it.
+    /// See [`pathsearch::resolve_command`].
+    ///
+    /// # Arguments
+    ///
+    /// * `candidate_name` - The name of the command to resolve.
+    pub fn resolve_command_in_path<S: AsRef<str>>(&self, candidate_name: S) -> Option<PathBuf> {
+        let path_var = self.env.get_str("PATH", self).unwrap_or_default();
+        let paths = crate::sys::fs::split_paths(path_var.as_ref());
+        pathsearch::resolve_command(paths, candidate_name.as_ref())
+    }
+
+    /// Like [`Self::resolve_command_in_path`], but consults the shell's hash-based path cache
+    /// first and caches whatever a search turns up.
     ///
     /// # Arguments
     ///
@@ -174,10 +185,7 @@ impl<SE: crate::extensions::ShellExtensions> crate::Shell<SE> {
             return Some(cached_path);
         }
 
-        let path_var = self.env.get_str("PATH", self).unwrap_or_default();
-        let paths = crate::sys::fs::split_paths(path_var.as_ref());
-        let found_path = pathsearch::resolve_command(paths, candidate_name.as_ref())?;
-
+        let found_path = self.resolve_command_in_path(candidate_name.as_ref())?;
         self.program_location_cache
             .set(candidate_name, found_path.clone());
 

--- a/brush-shell/tests/cases/compat/builtins/type.yaml
+++ b/brush-shell/tests/cases/compat/builtins/type.yaml
@@ -84,3 +84,66 @@ cases:
     stdin: |
       hash -p /some/ls ls
       type -p -a ls
+
+  - name: Test type honors expand_aliases
+    ignore_stderr: true
+    stdin: |
+      alias za="ls"
+
+      shopt -u expand_aliases
+      type za; echo "rc=$?"
+      type -t za; echo "rc=$?"
+      type -a za; echo "rc=$?"
+
+      shopt -s expand_aliases
+      type za; echo "rc=$?"
+      type -t za; echo "rc=$?"
+
+  - name: Test type and execution skip a directory found in PATH
+    ignore_stderr: true # brush's diagnostics don't match bash's text.
+    stdin: |
+      mkdir -p pdir/prog
+      PATH="$PWD/pdir:$PATH"
+
+      type prog; echo "rc=$?"
+      type -a prog; echo "rc=$?"
+      prog; echo "rc=$?"
+
+  - name: Test type reports a missing name
+    stdin: |
+      # Normalize away the leading "shell: line N:" that the oracle prefixes onto diagnostics.
+      strip() { sed 's/^.*type:/type:/'; }
+
+      type nonexistent 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      type nonexistent echo 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+  - name: Test type reports a non-executable file found in PATH
+    stdin: |
+      # Normalize away the leading "shell: line N:" that the oracle prefixes onto diagnostics.
+      strip() { sed 's/^.*type:/type:/'; }
+
+      mkdir -p d1 d2
+      touch d1/nx
+      printf '#!/bin/sh\necho D2\n' > d2/nx
+      chmod +x d2/nx
+      touch d1/only
+      touch d2/only2
+      PATH="d1:d2:$PATH"
+
+      echo "[an executable later in PATH beats a non-executable earlier]"
+      type nx; echo "rc=$?"
+      type -a nx; echo "rc=$?"
+      nx; echo "run rc=$?"
+
+      echo "[only a non-executable exists]"
+      type only; echo "rc=$?"
+      type -t only; echo "rc=$?"
+      type -p only; echo "rc=$?"
+      type -P only; echo "rc=$?"
+      # -a is a strict search for executables, so it reports nothing.
+      type -a only 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      # ...and the shell tries to run the file, rather than reporting it as not found.
+      only 2>/dev/null; echo "run rc=$?"
+
+      echo "[the fallback keeps searching the rest of PATH]"
+      type only2; echo "rc=$?"


### PR DESCRIPTION
Fixes three ways `type` disagreed with bash, after first extracting its name resolution into a shared `lookup` module so `command -v`/`-V` can reuse it in a follow-up.

- **Aliases**: only reported when `expand_aliases` is on, matching bash (and what the name would actually resolve to).
- **Misses**: `type: NAME: not found`, with bash's punctuation.
- **PATH search**: `type NAME` now takes the same search execution does, so a directory is never reported as a command and a non-executable file is reported when it's what the shell would try to run. `type -a` stays a strict search for executables, as in bash.

Assisted-By: Claude Code