### PR TITLE
fix(builtins): resolve command -v/-V the way the shell resolves a name

### DIFF
--- a/brush-builtins/src/alias.rs
+++ b/brush-builtins/src/alias.rs
@@ -2,7 +2,9 @@ use clap::Parser;
 use itertools::Itertools;
 use std::io::Write;
 
-use brush_core::{ExecutionResult, builtins, escape};
+use brush_core::{ExecutionResult, builtins};
+
+use crate::write_alias_definition;
 
 /// Manage aliases within the shell.
 #[derive(Parser)]
@@ -28,11 +30,7 @@ impl builtins::Command for AliasCommand {
         if self.print || self.aliases.is_empty() {
             // Aliases are stored unordered; bash lists them sorted by name.
             for (name, value) in context.shell.aliases().iter().sorted() {
-                writeln!(
-                    context.stdout(),
-                    "alias {name}={}",
-                    escape::single_quote(value)
-                )?;
+                write_alias_definition(context.stdout(), name, value)?;
             }
         } else {
             for alias in &self.aliases {
@@ -44,11 +42,7 @@ impl builtins::Command for AliasCommand {
                         .aliases_mut()
                         .insert(name.to_owned(), unexpanded_value.to_owned());
                 } else if let Some(value) = context.shell.aliases().get(alias) {
-                    writeln!(
-                        context.stdout(),
-                        "alias {alias}={}",
-                        escape::single_quote(value)
-                    )?;
+                    write_alias_definition(context.stdout(), alias, value)?;
                 } else {
                     writeln!(
                         context.stderr(),

--- a/brush-builtins/src/command.rs
+++ b/brush-builtins/src/command.rs
@@ -1,10 +1,11 @@
 use clap::Parser;
-use std::{fmt::Display, io::Write, path::Path};
+use std::io::Write;
+use std::path::PathBuf;
 
-use brush_core::{
-    ExecutionResult, builtins, commands, pathsearch,
-    sys::{self, fs::PathExt},
-};
+use brush_core::{ExecutionResult, builtins, commands, sys};
+
+use crate::lookup::{self, Resolved};
+use crate::write_alias_definition;
 
 /// Directly invokes an external command, without going through typical search order.
 #[derive(Default, Parser)]
@@ -14,11 +15,11 @@ pub(crate) struct CommandCommand {
     pub use_default_path: bool,
 
     /// Display a short description of the command.
-    #[arg(short = 'v')]
+    #[arg(short = 'v', overrides_with = "print_verbose_description")]
     pub print_description: bool,
 
     /// Display a more verbose description of the command.
-    #[arg(short = 'V')]
+    #[arg(short = 'V', overrides_with = "print_description")]
     pub print_verbose_description: bool,
 
     /// Command and arguments.
@@ -30,6 +31,105 @@ impl CommandCommand {
     fn command(&self) -> Option<&str> {
         self.command_and_args.first().map(|s| s.as_str())
     }
+
+    fn path_dirs(&self) -> Option<Vec<PathBuf>> {
+        self.use_default_path
+            .then(sys::fs::get_default_standard_utils_paths)
+    }
+
+    /// Describes every name given, as `-v`/`-V` do; succeeds if any name was found.
+    fn describe_names<SE: brush_core::ShellExtensions>(
+        &self,
+        context: &brush_core::ExecutionContext<'_, SE>,
+    ) -> Result<ExecutionResult, brush_core::Error> {
+        // With no names to look up there is nothing to fail to find, so this still succeeds.
+        if self.command_and_args.is_empty() {
+            return Ok(ExecutionResult::success());
+        }
+
+        let options = lookup::Options {
+            path_dirs: self.path_dirs(),
+            ..Default::default()
+        };
+
+        let mut any_found = false;
+        for name in &self.command_and_args {
+            let Some(mut found) = lookup::resolve(context.shell, name, &options)
+                .into_iter()
+                .next()
+            else {
+                if self.print_verbose_description {
+                    writeln!(context.stderr(), "command: {name}: not found")?;
+                }
+                continue;
+            };
+
+            any_found = true;
+            if self.print_description {
+                // Display in a form that could be reused as shell input.
+                match &found {
+                    Resolved::Alias(target) => {
+                        write_alias_definition(context.stdout(), name, target)?;
+                    }
+                    Resolved::Keyword | Resolved::Function(_) | Resolved::Builtin => {
+                        writeln!(context.stdout(), "{name}")?;
+                    }
+                    Resolved::File { path, .. } => {
+                        writeln!(context.stdout(), "{}", path.to_string_lossy())?;
+                    }
+                }
+            } else {
+                // A command found by searching PATH is reported with an absolute path, even
+                // when the PATH entry it came from was relative. Explicit paths and hashed
+                // entries are reported exactly as they were given. Like bash, this only
+                // prefixes the working directory; it doesn't otherwise normalize the path,
+                // except to drop the leading `./` a `.` entry in PATH contributes.
+                if let Resolved::File {
+                    path,
+                    hashed: false,
+                } = &mut found
+                    && !sys::fs::contains_path_separator(name)
+                {
+                    let relative = path.strip_prefix(".").unwrap_or(&*path);
+                    *path = context.shell.absolute_path(relative);
+                }
+
+                lookup::describe(context.stdout(), name, &found)?;
+            }
+        }
+
+        if any_found {
+            Ok(ExecutionResult::success())
+        } else {
+            Ok(ExecutionResult::general_error())
+        }
+    }
+
+    async fn execute_command(
+        &self,
+        mut context: brush_core::ExecutionContext<'_, impl brush_core::ShellExtensions>,
+        command_name: &str,
+    ) -> Result<ExecutionResult, brush_core::Error> {
+        command_name.clone_into(&mut context.command_name);
+        let command_and_args = self
+            .command_and_args
+            .iter()
+            .map(brush_core::CommandArg::from);
+
+        let mut cmd = commands::SimpleCommand::new(
+            commands::ShellForCommand::ParentShell(context.shell),
+            context.params,
+            context.command_name,
+            command_and_args,
+        );
+        cmd.use_functions = false;
+        cmd.path_dirs = self.path_dirs();
+
+        let spawn_result = cmd.execute().await?;
+        let wait_result = spawn_result.wait().await?;
+
+        Ok(wait_result.into())
+    }
 }
 
 impl builtins::Command for CommandCommand {
@@ -40,132 +140,14 @@ impl builtins::Command for CommandCommand {
         context: brush_core::ExecutionContext<'_, SE>,
     ) -> Result<ExecutionResult, Self::Error> {
         if self.print_description || self.print_verbose_description {
-            // bash iterates over every operand, printing one line per name that
-            // resolves; operands that do not resolve are skipped (with `-V`, each
-            // miss is reported on stderr). The exit status is successful if any
-            // operand resolved, and unsuccessful only when none did.
-            let mut any_found = false;
-            for command_name in &self.command_and_args {
-                let Some(found_cmd) = Self::try_find_command(
-                    context.shell,
-                    command_name.as_str(),
-                    self.use_default_path,
-                ) else {
-                    if self.print_verbose_description {
-                        writeln!(context.stderr(), "command: {command_name}: not found")?;
-                    }
-                    continue;
-                };
-                any_found = true;
-                if self.print_description {
-                    writeln!(context.stdout(), "{found_cmd}")?;
-                } else {
-                    match found_cmd {
-                        FoundCommand::Builtin(_name) => {
-                            writeln!(context.stdout(), "{command_name} is a shell builtin")?;
-                        }
-                        FoundCommand::External(path) => {
-                            writeln!(context.stdout(), "{command_name} is {path}")?;
-                        }
-                    }
-                }
-            }
-            if any_found || self.command_and_args.is_empty() {
-                Ok(ExecutionResult::success())
-            } else {
-                Ok(ExecutionResult::general_error())
-            }
-        } else if let Some(command_name) = self.command() {
-            self.execute_command(context, command_name, self.use_default_path)
-                .await
-        } else {
-            // Silently exit if no command was provided.
-            Ok(ExecutionResult::success())
+            return self.describe_names(&context);
         }
-    }
-}
 
-enum FoundCommand {
-    Builtin(String),
-    External(String),
-}
-
-impl Display for FoundCommand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Builtin(name) => write!(f, "{name}"),
-            Self::External(path) => write!(f, "{path}"),
-        }
-    }
-}
-
-impl CommandCommand {
-    fn try_find_command(
-        shell: &mut brush_core::Shell<impl brush_core::ShellExtensions>,
-        command_name: &str,
-        use_default_path: bool,
-    ) -> Option<FoundCommand> {
-        // Look in path.
-        if sys::fs::contains_path_separator(command_name) {
-            let candidate_path = shell.absolute_path(Path::new(command_name));
-            if candidate_path.executable() {
-                Some(FoundCommand::External(
-                    candidate_path.to_string_lossy().to_string(),
-                ))
-            } else {
-                None
-            }
-        } else {
-            if let Some(builtin_cmd) = shell.builtins().get(command_name)
-                && !builtin_cmd.disabled
-            {
-                return Some(FoundCommand::Builtin(command_name.to_owned()));
-            }
-
-            if use_default_path {
-                let dirs = sys::fs::get_default_standard_utils_paths();
-
-                pathsearch::search_for_executable(dirs.iter(), command_name)
-                    .next()
-                    .map(|path| FoundCommand::External(path.to_string_lossy().to_string()))
-            } else {
-                shell
-                    .find_first_executable_in_path_using_cache(command_name)
-                    .map(|path| FoundCommand::External(path.to_string_lossy().to_string()))
-            }
-        }
-    }
-
-    async fn execute_command(
-        &self,
-        mut context: brush_core::ExecutionContext<'_, impl brush_core::ShellExtensions>,
-        command_name: &str,
-        use_default_path: bool,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        command_name.clone_into(&mut context.command_name);
-        let command_and_args = self
-            .command_and_args
-            .iter()
-            .map(brush_core::CommandArg::from);
-
-        let path_dirs = if use_default_path {
-            Some(sys::fs::get_default_standard_utils_paths())
-        } else {
-            None
+        // Silently exit if no command was provided.
+        let Some(command_name) = self.command() else {
+            return Ok(ExecutionResult::success());
         };
 
-        let mut cmd = commands::SimpleCommand::new(
-            commands::ShellForCommand::ParentShell(context.shell),
-            context.params,
-            context.command_name,
-            command_and_args,
-        );
-        cmd.use_functions = false;
-        cmd.path_dirs = path_dirs;
-
-        let spawn_result = cmd.execute().await?;
-        let wait_result = spawn_result.wait().await?;
-
-        Ok(wait_result.into())
+        self.execute_command(context, command_name).await
     }
 }

--- a/brush-builtins/src/lib.rs
+++ b/brush-builtins/src/lib.rs
@@ -118,12 +118,26 @@ mod wait;
 
 mod builder;
 mod factory;
-#[cfg(feature = "builtin.type")]
+#[cfg(any(feature = "builtin.command", feature = "builtin.type"))]
 mod lookup;
 mod unimp;
 
 pub use builder::ShellBuilderExt;
 pub use factory::{BuiltinSet, default_builtins};
+
+/// Writes an alias definition in the reusable form printed by `alias` and `command -v`.
+#[cfg(any(feature = "builtin.alias", feature = "builtin.command"))]
+fn write_alias_definition(
+    mut writer: impl std::io::Write,
+    name: &str,
+    value: &str,
+) -> std::io::Result<()> {
+    writeln!(
+        writer,
+        "alias {name}={}",
+        brush_core::escape::single_quote(value)
+    )
+}
 
 /// Macro to define a struct that represents a shell built-in flag argument that can be
 /// enabled or disabled by specifying an option with a leading '+' or '-' character.

--- a/brush-builtins/src/lookup.rs
+++ b/brush-builtins/src/lookup.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use brush_core::{
     Shell, ShellExtensions,
     parser::ast,
+    pathsearch,
     sys::{self, fs::PathExt},
 };
 
@@ -32,6 +33,9 @@ pub(crate) struct Options {
     pub suppress_func_lookup: bool,
     /// Report every location the name resolves to, not just the first.
     pub all_locations: bool,
+    /// Directories to search for executables, in lieu of the shell's `PATH`. The shell's
+    /// hash-based path cache is still consulted first.
+    pub path_dirs: Option<Vec<PathBuf>>,
 }
 
 /// Resolves the given name, returning the ways it resolved (in lookup order). Unless
@@ -117,10 +121,15 @@ fn resolve_in_filesystem<SE: ShellExtensions>(
         }
     }
 
-    if options.all_locations {
-        resolved.extend(shell.find_executables_in_path(name).map(to_file));
-    } else {
-        resolved.extend(shell.resolve_command_in_path(name).map(to_file));
+    match (&options.path_dirs, options.all_locations) {
+        (Some(dirs), true) => {
+            resolved.extend(pathsearch::search_for_executable(dirs.iter(), name).map(to_file));
+        }
+        (Some(dirs), false) => {
+            resolved.extend(pathsearch::resolve_command(dirs.iter(), name).map(to_file));
+        }
+        (None, true) => resolved.extend(shell.find_executables_in_path(name).map(to_file)),
+        (None, false) => resolved.extend(shell.resolve_command_in_path(name).map(to_file)),
     }
 }
 

--- a/brush-builtins/src/type_.rs
+++ b/brush-builtins/src/type_.rs
@@ -46,6 +46,7 @@ impl builtins::Command for TypeCommand {
             force_path_search: self.force_path_search,
             suppress_func_lookup: self.suppress_func_lookup,
             all_locations: self.all_locations,
+            path_dirs: None,
         };
 
         for name in &self.names {

--- a/brush-shell/tests/cases/compat/builtins/command.yaml
+++ b/brush-shell/tests/cases/compat/builtins/command.yaml
@@ -178,3 +178,218 @@ cases:
       command() { echo "shadow command: [$*] count=$#"; }
       command echo hi
       unset -f command
+
+  - name: "command -v finds aliases, keywords, and functions"
+    stdin: |
+      shopt -s expand_aliases
+      alias al="echo hi"
+      f() { :; }
+
+      command -v al; echo "rc=$?"
+      command -v if; echo "rc=$?"
+      command -v f; echo "rc=$?"
+      command -v echo; echo "rc=$?"
+
+  - name: "command -V describes aliases, keywords, and functions"
+    stdin: |
+      shopt -s expand_aliases
+      alias al="echo hi"
+      f() { :; }
+
+      command -V al; echo "rc=$?"
+      command -V if; echo "rc=$?"
+      command -V f; echo "rc=$?"
+      command -V echo; echo "rc=$?"
+
+  - name: "command -v/-V with multiple names"
+    stdin: |
+      # Normalize away the leading "shell: line N:" that the oracle prefixes onto diagnostics.
+      strip() { sed 's/^.*command:/command:/'; }
+
+      shopt -s expand_aliases
+      alias al="echo hi"
+      f() { :; }
+
+      echo "[all found]"
+      command -v al f if echo; echo "rc=$?"
+      command -V al f if echo; echo "rc=$?"
+
+      echo "[some found]"
+      command -v nonexistent f 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      command -v f nonexistent 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      command -V f nonexistent 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+      echo "[none found]"
+      command -v nope1 nope2 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      command -V nope1 nope2 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+  - name: "command -v/-V output is reusable/quoted for odd alias values"
+    stdin: |
+      shopt -s expand_aliases
+      alias q="echo 'it'\''s"
+      alias q2='a "b" $c'
+      alias q3="'"
+      alias q4="a''b"
+
+      command -v q
+      command -v q2
+      command -v q3
+      command -v q4
+      command -V q
+
+  - name: "command -v/-V honors expand_aliases"
+    stdin: |
+      strip() { sed 's/^.*command:/command:/'; }
+      alias za="ls"
+
+      shopt -u expand_aliases
+      command -v za; echo "rc=$?"
+      command -V za 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+      shopt -s expand_aliases
+      command -v za; echo "rc=$?"
+
+  - name: "command -v/-V: last of -v/-V wins"
+    stdin: |
+      command -v -V echo
+      command -V -v echo
+      command -vV echo
+      command -Vv echo
+      command -V -v nonexistent; echo "rc=$?"
+
+  - name: "command -V reports hashed commands"
+    stdin: |
+      # Normalize away the temporary directory the test runs in.
+      scrub() { sed -E "s|$PWD|<TMPDIR>|g"; }
+
+      mkdir -p bin
+      printf '#!/bin/sh\n:\n' > bin/mytool
+      chmod +x bin/mytool
+      PATH="$PWD/bin:$PATH"
+
+      hash mytool
+      command -v mytool | scrub
+      command -V mytool | scrub
+
+  - name: "command -v/-V report path names as given"
+    stdin: |
+      printf '#!/bin/sh\necho hi\n' > prog
+      chmod +x prog
+
+      command -v ./prog; echo "rc=$?"
+      command -V ./prog; echo "rc=$?"
+
+  - name: "command -v with non-executable and non-file path names"
+    stdin: |
+      strip() { sed 's/^.*command:/command:/'; }
+      mkdir subdir
+      touch plainfile
+
+      command -v ./subdir; echo "rc=$?"
+      command -V ./subdir 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+      command -v ./plainfile; echo "rc=$?"
+
+  - name: "command -v with empty name"
+    stdin: |
+      strip() { sed 's/^.*command:/command:/'; }
+
+      command -v ""; echo "rc=$?"
+      command -V "" 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+  - name: "command -p searches the default path"
+    # See "command -v -p" above: on NixOS the oracle's default utility path finds no
+    # standard utilities at all, so the `sh` lookup below can't be reconciled there.
+    incompatible_os: ["nixos"]
+    stdin: |
+      strip() { sed 's/^.*command:/command:/'; }
+
+      echo "[builtins are still found]"
+      command -p -v echo; echo "rc=$?"
+      command -p -V echo; echo "rc=$?"
+
+      echo "[externals come from the default path]"
+      # bash's default path is compiled in and brush asks the C library for it, so the two
+      # can name different directories on the same host; only the basename is comparable.
+      dirless() { sed 's#/[^ ]*/#<dir>/#'; }
+      command -p -v sh | dirless; echo "rc=${PIPESTATUS[0]}"
+      command -p -V sh | dirless; echo "rc=${PIPESTATUS[0]}"
+
+      echo "[PATH is ignored]"
+      mkdir -p bin
+      printf '#!/bin/sh\n:\n' > bin/mytool
+      chmod +x bin/mytool
+      PATH="$PWD/bin:$PATH"
+      command -v mytool > /dev/null; echo "rc=$?"
+      command -p -v mytool; echo "rc=$?"
+
+      echo "[missing name]"
+      command -p -V definitely-not-a-real-command 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+  - name: "command -V reports a PATH-found command with an absolute path"
+    stdin: |
+      # Normalize away the temporary directory the test runs in.
+      scrub() { sed -E "s|$PWD|<TMPDIR>|g"; }
+
+      mkdir -p d1
+      printf '#!/bin/sh\n:\n' > d1/ex
+      chmod +x d1/ex
+      touch d1/only
+      PATH="d1:$PATH"
+
+      echo "[a non-executable in PATH is still reported]"
+      command -v only; echo "rc=$?"
+      command -V only | scrub; echo "rc=${PIPESTATUS[0]}"
+
+      command -v ex; echo "rc=$?"
+      command -V ex | scrub; echo "rc=${PIPESTATUS[0]}"
+
+      echo "[a \".\" entry contributes no \"./\" to the absolute path]"
+      printf '#!/bin/sh\n:\n' > here; chmod +x here
+      PATH=".:$PATH" command -v here; echo "rc=$?"
+      PATH=".:$PATH" command -V here | scrub; echo "rc=${PIPESTATUS[0]}"
+
+      echo "[...but explicit and hashed paths are left alone]"
+      printf '#!/bin/sh\n:\n' > prog; chmod +x prog
+      command -V ./prog; echo "rc=$?"
+      hash -p rel/path hp
+      command -V hp; echo "rc=$?"
+
+  - name: "command -v/-V with no operands"
+    stdin: |
+      command -v; echo "rc=$?"
+      command -V; echo "rc=$?"
+
+  - name: "command -v/-V skips a disabled builtin"
+    stdin: |
+      # Normalize away the temporary directory the test runs in.
+      scrub() { sed -E "s|$PWD|<TMPDIR>|g"; }
+
+      mkdir -p bin
+      printf '#!/bin/sh\n:\n' > bin/echo
+      chmod +x bin/echo
+      PATH="$PWD/bin:$PATH"
+
+      # `echo` is disabled for the rest of this block, so report through printf.
+      enable -n echo
+      command -v echo | scrub; disabled_v=${PIPESTATUS[0]}
+      command -V echo | scrub; disabled_V=${PIPESTATUS[0]}
+      enable echo
+      printf 'rc=%s rc=%s\n' "$disabled_v" "$disabled_V"
+
+      command -v echo; echo "rc=$?"
+
+  - name: "command -v/-V reports an alias ahead of a same-named function"
+    stdin: |
+      f() { :; }
+      shopt -s expand_aliases
+      alias f='echo A'
+
+      command -v f; echo "rc=$?"
+      command -V f; echo "rc=$?"
+
+  - name: "command -p -v/-V still honors the hash table"
+    stdin: |
+      hash -p /nonexistent/cat cat
+      command -v cat; echo "rc=$?"
+      command -p -v cat; echo "rc=$?"
+      command -p -V cat; echo "rc=$?"

--- a/brush-shell/tests/cases/compat/builtins/hash.yaml
+++ b/brush-shell/tests/cases/compat/builtins/hash.yaml
@@ -104,3 +104,46 @@ cases:
       mkdir -p d1; touch d1/only
       PATH="d1:$PATH"
       hash only 2>&1 | strip; echo "rc=${PIPESTATUS[0]}"
+
+  #
+  # `hash` with no names lists the table. brush prints nothing for any such listing,
+  # whether the table is empty or populated, so these are marked `known_failure`. Hit
+  # counts get their own case: they can only be observed through the listing, but they
+  # are a separate gap and a fix for one need not be a fix for the other.
+  #
+  - name: "Display the whole table"
+    known_failure: true # TODO(hash): `hash` with no names should list the table
+    stdin: |
+      echo "[empty]"
+      hash; echo "rc=$?"
+
+      echo "[populated, in insertion order]"
+      hash -p /some/path sc1
+      hash -p /other/path sc2
+      hash; echo "rc=$?"
+
+      echo "[emptied again]"
+      hash -r
+      hash; echo "rc=$?"
+
+  - name: "Display the whole table in reusable form"
+    known_failure: true # TODO(hash): `hash -l` with no names should list the table
+    stdin: |
+      hash -p /some/path sc1
+      hash -p "/some/spaces path" sc2
+
+      hash -l; echo "rc=$?"
+
+  - name: "Count hits per hashed command"
+    known_failure: true # TODO(hash): hit counts are not tracked
+    stdin: |
+      # Normalize away the temporary directory the test runs in.
+      scrub() { sed -E "s|$PWD|<TMPDIR>|g"; }
+
+      printf '#!/bin/sh\n:\n' > prog
+      chmod +x prog
+      PATH="$PWD:$PATH"
+
+      prog
+      prog
+      hash | scrub; echo "rc=${PIPESTATUS[0]}"

--- a/brush-shell/tests/cases/compat/path_search.yaml
+++ b/brush-shell/tests/cases/compat/path_search.yaml
@@ -1,0 +1,81 @@
+name: "PATH search"
+
+#
+# An empty entry in PATH names the working directory, so a command found through one is
+# reported with a leading "./". brush finds the command but reports the bare name; the
+# `known_failure` cases below cover each surface that exposes the difference. They share
+# one root cause in the path search, so they should be retired together.
+#
+cases:
+  - name: "empty PATH entry is reported as the working directory"
+    known_failure: true # TODO(path): an empty PATH entry should resolve as "."
+    stdin: |
+      printf '#!/bin/sh\necho ran\n' > prog
+      chmod +x prog
+      PATH=":$PATH"
+
+      echo "[type]"
+      type prog; echo "rc=$?"
+      echo "[type -p]"
+      type -p prog; echo "rc=$?"
+      echo "[type -P]"
+      type -P prog; echo "rc=$?"
+      echo "[type -a]"
+      type -a prog; echo "rc=$?"
+      echo "[command -v]"
+      command -v prog; echo "rc=$?"
+
+  - name: "empty PATH entry is reported the same wherever it appears"
+    known_failure: true # TODO(path): an empty PATH entry should resolve as "."
+    stdin: |
+      printf '#!/bin/sh\necho ran\n' > prog
+      chmod +x prog
+      original=$PATH
+
+      # Each of these keeps the rest of PATH reachable, so only the empty entry can
+      # account for finding `prog`, which exists solely in the working directory.
+      echo "[leading]"
+      PATH=":$original"; hash -r
+      command -v prog; echo "rc=$?"
+
+      echo "[trailing]"
+      PATH="$original:"; hash -r
+      command -v prog; echo "rc=$?"
+
+      echo "[middle]"
+      PATH="/nonexistent::$original"; hash -r
+      command -v prog; echo "rc=$?"
+
+  - name: "empty PATH entry is hashed as the working directory"
+    known_failure: true # TODO(path): an empty PATH entry should resolve as "."
+    stdin: |
+      printf '#!/bin/sh\necho ran\n' > prog
+      chmod +x prog
+      PATH=":$PATH"
+
+      hash -r
+      hash prog; echo "rc=$?"
+      hash -t prog; echo "rc=$?"
+
+  #
+  # These two surfaces already agree with the oracle; they guard the parts of the
+  # behavior that work, so that a fix for the cases above doesn't regress them.
+  #
+  - name: "a command found through an empty PATH entry is runnable"
+    stdin: |
+      printf '#!/bin/sh\necho ran\n' > prog
+      chmod +x prog
+      PATH=":$PATH"
+
+      prog; echo "rc=$?"
+
+  - name: "command -V absolutizes a command found through an empty PATH entry"
+    stdin: |
+      # Normalize away the temporary directory the test runs in.
+      scrub() { sed -E "s|$PWD|<TMPDIR>|g"; }
+
+      printf '#!/bin/sh\necho ran\n' > prog
+      chmod +x prog
+      PATH=":$PATH"
+
+      command -V prog | scrub; echo "rc=${PIPESTATUS[0]}"


### PR DESCRIPTION
Makes `command -v` / `command -V` resolve a name the way the shell actually resolves it, and adds known-failure coverage for two pre-existing gaps found while testing it.

## `command -v`/`-V` resolve through the shared `lookup` module

`command -v` only ever looked for builtins and files, so it reported an alias, keyword, or function as *not found* — the names it is most often asked about. It now resolves through the same `lookup` module `type` uses, which answers all of those at once:

```console
$ shopt -s expand_aliases; alias al='echo hi'; f() { :; }
$ command -v al; command -v if; command -v f     # before: nothing, rc=1 for each
alias al='echo hi'
if
f
```

Also in this commit:

- **`-v`/`-V` take the last one given**, not the first (`overrides_with`), so `command -Vv x` behaves as `-v`.
- **Aliases render as `alias NAME='VALUE'`**, sharing one helper with the `alias` builtin. The old path went through `force_quote`, which reaches for ANSI-C quoting bash never uses here.
- **`command -V` reports a PATH search result with an absolute path**, as bash does, even when the PATH entry was relative — `command -V ex` gives `<cwd>/d1/ex` where `command -v ex` and `type ex` both give `d1/ex`. Like bash this only prefixes the working directory: a `.` entry in PATH contributes no `./`, and nothing else is normalized. Explicit paths and hashed entries are reported exactly as given.
- **`command -p` now consults the hash table** ahead of the default-utility-path search, as bash does. The old `-p` lookup skipped it, so `hash -p /nonexistent/cat cat; command -p -V cat` reported a fresh search result instead of `cat is hashed (/nonexistent/cat)`.

## Testing

24 new compat cases.

Assisted-by: Claude Opus 5