### PR TITLE
fix(regex): anchor ^ and $ to the whole string in [[ =~ ]]

### DIFF
--- a/brush-core/src/regex.rs
+++ b/brush-core/src/regex.rs
@@ -66,9 +66,9 @@ impl Regex {
         self
     }
 
-    /// Enables (or disables) multiline support for this pattern.
-    /// This enables matching across lines as well as enables `.`
-    /// to match newline characters.
+    /// Enables (or disables) multiline support for this pattern: `.` then also matches
+    /// newline characters. `^` and `$` always anchor to the whole string, as in POSIX
+    /// regular expressions, which have no line anchors.
     ///
     /// # Arguments
     ///
@@ -128,7 +128,7 @@ pub(crate) fn compile_regex(
         // The fancy_regex crate internally seems to have flags that can be used
         // to enable multiline support, but they're not exposed via its
         // RegexBuilder. We instead just prefix with the right flags.
-        let updated_str = std::format!("(?ms){regex_str}");
+        let updated_str = std::format!("(?s){regex_str}");
         regex_str = updated_str.into();
     }
 

--- a/brush-shell/tests/cases/compat/extended_tests.yaml
+++ b/brush-shell/tests/cases/compat/extended_tests.yaml
@@ -546,3 +546,15 @@ cases:
     stdin: |
       [[ ( ! a
       ) ]] && echo should-not-print
+
+  # POSIX regexes have no line anchors: ^ and $ match only at the ends of the
+  # whole string, while . matches any character including newline.
+  - name: "Regex anchors match the whole string, not lines"
+    stdin: |
+      s=$'a\nb'
+      [[ $s =~ ^b ]] && echo "wrong 1" || echo "ok 1"
+      [[ $s =~ a$ ]] && echo "wrong 2" || echo "ok 2"
+      [[ $s =~ ^a.b$ ]] && echo "ok 3"
+      t=$' \t\nabc \t\n'
+      re=$'[ \t\n]+$'
+      [[ $t =~ $re ]] && printf '[%s]\n' "${t::${#t}-${#BASH_REMATCH}}"


### PR DESCRIPTION
POSIX regular expressions have no line anchors: `^` and `$` match only at the ends of the string, while `.` matches any character including newline. brush compiled `=~` patterns with the regex crate's multiline flag as well, so `$` matched before every newline and `^` after one; ble.sh's trimming helpers matched the wrong span. Keep only the dot-matches-newline flag.

Assisted-By: Claude Fable 5.1