### PR TITLE
refactor(core)!: return the full result from `Shell::invoke_function`

### DIFF
--- a/brush-core/examples/call-func.rs
+++ b/brush-core/examples/call-func.rs
@@ -38,7 +38,10 @@ async fn run_func(shell: &mut brush_core::Shell, suppress_stdout: bool) -> Resul
         .invoke_function("hello", std::iter::once("arg"), params)
         .await?;
 
-    eprintln!("[Function invocation result: {result}]");
+    eprintln!(
+        "[Function invocation result: {}]",
+        u8::from(result.exit_code)
+    );
 
     Ok(())
 }

--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -785,7 +785,8 @@ impl Spec {
         let params = shell.default_exec_params();
         let invoke_result = shell
             .invoke_function(function_name, args.iter(), params)
-            .await;
+            .await
+            .map(|result| u8::from(result.exit_code));
 
         tracing::debug!(target: trace_categories::COMPLETION, "[completion function '{function_name}' returned: {invoke_result:?}]");
 

--- a/brush-core/src/results.rs
+++ b/brush-core/src/results.rs
@@ -88,6 +88,11 @@ impl ExecutionResult {
             ExecutionControlFlow::ReturnFromFunctionOrScript | ExecutionControlFlow::ExitShell
         )
     }
+
+    /// Returns whether the execution result indicates an exit from the shell.
+    pub const fn is_exit(&self) -> bool {
+        matches!(self.next_control_flow, ExecutionControlFlow::ExitShell)
+    }
 }
 
 impl From<ExecutionExitCode> for ExecutionResult {

--- a/brush-core/src/shell/funcs.rs
+++ b/brush-core/src/shell/funcs.rs
@@ -1,7 +1,8 @@
 //! Function support for shells.
 
 use crate::{
-    ExecutionParameters, commands, error, extensions, functions, results::ExecutionWaitResult,
+    ExecutionParameters, ExecutionResult, commands, error, extensions, functions,
+    results::ExecutionWaitResult,
 };
 
 impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
@@ -83,7 +84,7 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
         Ok(())
     }
 
-    /// Invokes a function defined in this shell, returning the resulting exit status.
+    /// Invokes a function defined in this shell, returning its execution result.
     ///
     /// # Arguments
     ///
@@ -95,7 +96,7 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
         name: N,
         args: I,
         params: ExecutionParameters,
-    ) -> Result<u8, error::Error> {
+    ) -> Result<ExecutionResult, error::Error> {
         let name = name.as_ref();
         let command_name = String::from(name);
 
@@ -120,7 +121,7 @@ impl<SE: extensions::ShellExtensions> crate::Shell<SE> {
             commands::invoke_shell_function(func_registration, context, &command_args).await?;
 
         match result.wait().await? {
-            ExecutionWaitResult::Completed(result) => Ok(result.exit_code.into()),
+            ExecutionWaitResult::Completed(result) => Ok(result),
             ExecutionWaitResult::Stopped(..) => {
                 error::unimp("stopped child from function invocation")
             }


### PR DESCRIPTION
An embedder invoking a shell function got back only a `u8`, which throws away the control flow the function requested. A function that calls `exit` is indistinguishable from one that returns the same status, so a caller that runs functions on the shell's behalf -- prompt hooks, completion -- cannot honor the exit.

Return the `ExecutionResult` instead, and give it `is_exit()` so a caller can ask. Completion, the only in-tree caller, narrows to the exit code at the call and is otherwise unchanged.

BREAKING CHANGE: `Shell::invoke_function` returns `ExecutionResult` rather than `u8`. Callers that want the old value can use `u8::from(result.exit_code)`.

Assisted-By: Claude Opus 5