### PR TITLE
fix(shell): treat `-s` with positional args as an interactive shell

### DIFF
--- a/brush-shell/src/args.rs
+++ b/brush-shell/src/args.rs
@@ -243,11 +243,29 @@ impl CommandLineArgs {
         reason = "parsing defaults should not panic"
     )]
     pub fn default_values() -> Self {
-        use clap::Parser;
         // Parse with just the program name to get all defaults.
         // This won't fail because all arguments have defaults or are optional.
         #[allow(clippy::expect_used)]
-        Self::try_parse_from(["brush"]).expect("parsing defaults should never fail")
+        Self::try_parse_from([String::from("brush")]).expect("parsing defaults should never fail")
+    }
+
+    /// Returns whether the shell will read its commands from standard input, as opposed to
+    /// running a command given with `-c` or a script named on the command line.
+    ///
+    /// This is the single source of truth for that question; it decides which shell mode
+    /// `entry::run_in_shell` enters, whether `$-` reports `s`, whether the shell can be
+    /// interactive, and which input backend gets selected.
+    pub const fn will_read_commands_from_stdin(&self) -> bool {
+        if self.command.is_some() {
+            // -c supplies the command.
+            false
+        } else if self.read_commands_from_stdin {
+            // -s makes any non-option arguments positional parameters, not a script to run.
+            true
+        } else {
+            // Otherwise the first non-option argument, if any, names a script to run.
+            self.script_args.is_empty()
+        }
     }
 
     /// Returns whether or not the arguments indicate that the shell should run in interactive mode.
@@ -258,8 +276,8 @@ impl CommandLineArgs {
             return true;
         }
 
-        // If -c or non-option arguments are provided, then we're not in interactive mode.
-        if self.command.is_some() || !self.script_args.is_empty() {
+        // Running a -c command or a named script is not interactive.
+        if !self.will_read_commands_from_stdin() {
             return false;
         }
 
@@ -299,5 +317,50 @@ mod tests {
         assert!(!args.login);
         assert!(args.command.is_none());
         assert!(args.script_args.is_empty());
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn test_will_read_commands_from_stdin() {
+        // (arguments, whether commands will be read from stdin)
+        let cases = [
+            (vec![], true),
+            (vec!["-i"], true),
+            (vec!["-c", "echo hi"], false),
+            (vec!["-c", "echo hi", "name"], false),
+            // `-i` forces an interactive shell, but `-c` still supplies the commands.
+            (vec!["-i", "-c", "echo hi"], false),
+            (vec!["script.sh"], false),
+            (vec!["-i", "script.sh"], false),
+            // `-s` claims the script slot, so trailing words are positional parameters.
+            (vec!["-s"], true),
+            (vec!["-s", "myarg"], true),
+            (vec!["-i", "-s", "myarg"], true),
+            (vec!["-si", "myarg"], true),
+            // N.B. `--` is presently kept as an ordinary positional rather than consumed
+            // as an end-of-options marker, so it lands in `script_args` -- a separate,
+            // pre-existing bug (bash runs `bash -- script.sh`; brush tries to source
+            // `--`). Classification comes out right either way, and pinning that here
+            // means fixing the parse can't silently change which branch these take.
+            (vec!["--", "script.sh"], false),
+            (vec!["-s", "--", "myarg"], true),
+        ];
+
+        for (args, expected) in cases {
+            // NOTE: This deliberately goes through the crate's own `try_parse_from` (which
+            // takes `String`s) and not `clap::Parser::try_parse_from`; only the former
+            // applies brush's `--` handling, so only the former sees what the shell sees.
+            let parsed = CommandLineArgs::try_parse_from(
+                std::iter::once("brush")
+                    .chain(args.iter().copied())
+                    .map(String::from),
+            )
+            .expect("arguments should parse");
+            assert_eq!(
+                parsed.will_read_commands_from_stdin(),
+                expected,
+                "for arguments: {args:?}"
+            );
+        }
     }
 }

--- a/brush-shell/src/config.rs
+++ b/brush-shell/src/config.rs
@@ -283,7 +283,6 @@ pub fn load_config(disabled: bool, explicit_path: Option<&Path>) -> ConfigLoadRe
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
 
     #[test]
     fn empty_config() {
@@ -414,11 +413,9 @@ mod tests {
 
         // Simulate CLI explicitly setting values different from defaults
         // by parsing with the flags enabled
-        let args = CommandLineArgs::try_parse_from([
-            "brush",
-            "--enable-highlighting",
-            "--enable-zsh-hooks",
-        ])
+        let args = CommandLineArgs::try_parse_from(
+            ["brush", "--enable-highlighting", "--enable-zsh-hooks"].map(String::from),
+        )
         .unwrap();
 
         // CLI explicitly enables highlighting and zsh-hooks (differs from default)
@@ -431,11 +428,9 @@ mod tests {
     #[test]
     fn to_ui_options_cli_only_settings() {
         let config = Config::default();
-        let args = CommandLineArgs::try_parse_from([
-            "brush",
-            "--disable-bracketed-paste",
-            "--disable-color",
-        ])
+        let args = CommandLineArgs::try_parse_from(
+            ["brush", "--disable-bracketed-paste", "--disable-color"].map(String::from),
+        )
         .unwrap();
 
         let ui = config.to_ui_options(&args);

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -32,7 +32,9 @@ impl CommandLineArgs {
     // TODO(cmdline): We can safely remove this `impl` after the issue is resolved
     // https://github.com/clap-rs/clap/issues/5055
     // This function takes precedence over [`clap::Parser::parse_from`]
-    fn try_parse_from(itr: impl IntoIterator<Item = String>) -> Result<Self, clap::Error> {
+    pub(crate) fn try_parse_from(
+        itr: impl IntoIterator<Item = String>,
+    ) -> Result<Self, clap::Error> {
         let mut args: Vec<String> = itr.into_iter().collect();
 
         // In bash, `-c` treats `--` as an option terminator and takes its
@@ -316,17 +318,6 @@ async fn run_async(
     Ok(exit_code)
 }
 
-/// Determines whether `run_in_shell` will run the shell interactively. Must be sync'd with it.
-const fn will_run_interactively(args: &CommandLineArgs) -> bool {
-    if args.command.is_some() {
-        false
-    } else if args.read_commands_from_stdin {
-        true
-    } else {
-        args.script_args.is_empty()
-    }
-}
-
 /// Runs the shell according to the provided command-line arguments.
 /// Also responsible for loading profiles and rc files as appropriate.
 ///
@@ -342,25 +333,25 @@ async fn run_in_shell(
     input_backend: &mut impl brush_interactive::InputBackend,
     ui_options: &brush_interactive::UIOptions,
 ) -> Result<u8, brush_interactive::ShellError> {
-    // First load profile and rc files as appropriate.
+    let read_commands_from_stdin = args.will_read_commands_from_stdin();
+    let interactive_options: brush_interactive::InteractiveOptions = ui_options.into();
+
+    // Load profile and rc files as appropriate.
     initialize_shell(shell_ref, &args).await?;
 
     // If a command was specified via -c, then run that command and then exit.
     if let Some(command) = args.command {
         shell_ref.lock().await.run_dash_c_command(command).await?;
 
-    // If -s was provided, then read commands from stdin. If there was a script (and optionally
-    // args) passed on the command line via positional arguments, then we copy over the
-    // parameters but do *not* execute it.
-    } else if args.read_commands_from_stdin {
-        let interactive_options = ui_options.into();
+    // Otherwise read commands interactively: -s was given (positional args become parameters;
+    // a script named among them is *not* run), or nothing to run was specified.
+    } else if read_commands_from_stdin {
         brush_interactive::InteractiveShell::new(shell_ref, input_backend, &interactive_options)?
             .run_interactively()
             .await?;
 
-    // If a script path was provided, then run the script.
-    } else if !args.script_args.is_empty() {
-        // The path to a script was provided on the command line; run the script.
+    // Otherwise a script path was given; run it.
+    } else {
         shell_ref
             .lock()
             .await
@@ -368,14 +359,6 @@ async fn run_in_shell(
                 Path::new(&args.script_args[0]),
                 args.script_args.iter().skip(1),
             )
-            .await?;
-
-    // If we got down here, then we don't have any commands to run. We'll be reading
-    // them in from stdin one way or the other.
-    } else {
-        let interactive_options = ui_options.into();
-        brush_interactive::InteractiveShell::new(shell_ref, input_backend, &interactive_options)?
-            .run_interactively()
             .await?;
     }
 
@@ -510,8 +493,7 @@ async fn instantiate_shell_from_args(
 
     // Commands are read from stdin if -s was provided, or if no command was specified (either via
     // -c or as a positional argument).
-    let read_commands_from_stdin = (args.read_commands_from_stdin && args.command.is_none())
-        || (args.script_args.is_empty() && args.command.is_none());
+    let read_commands_from_stdin = args.will_read_commands_from_stdin();
 
     let builtin_set = if args.sh_mode {
         brush_builtins::BuiltinSet::ShMode
@@ -628,7 +610,7 @@ fn get_default_input_backend_type(args: &CommandLineArgs) -> InputBackendType {
         // If stdin isn't a terminal, then `reedline` doesn't do the right thing
         // (reference: https://github.com/nushell/reedline/issues/509). Switch to
         // the minimal input backend instead for that scenario.
-        if std::io::stdin().is_terminal() && will_run_interactively(args) {
+        if std::io::stdin().is_terminal() && args.will_read_commands_from_stdin() {
             InputBackendType::Reedline
         } else {
             InputBackendType::Minimal

--- a/brush-shell/tests/cases/compat/arguments.yaml
+++ b/brush-shell/tests/cases/compat/arguments.yaml
@@ -3,6 +3,29 @@ common_test_files:
   - path: "script.sh"
     contents: |
       echo \"$0\" \"$1\" \"$2\" \"$@\"
+  # Announces that it ran, so cases can prove a script was *not* executed.
+  - path: "announce.sh"
+    contents: |
+      echo "RAN-SCRIPT count=[$#] one=[$1] two=[$2]"
+      case $- in *i*) echo "interactive";; *) echo "not-interactive";; esac
+      case $- in *s*) echo "stdin-flag";; *) echo "no-stdin-flag";; esac
+  # Consumes stdin, to prove leftover stdin reaches the script as data.
+  - path: "reader.sh"
+    contents: |
+      while IFS= read -r line; do echo "read=[$line]"; done
+  # Only sourced by an *interactive* shell, and only via `--rcfile`. Both effects it has
+  # -- the variable and the alias -- are things a non-interactive shell does not get.
+  - path: "testrc"
+    contents: |
+      # Re-assert the harness's prompt: cases that load this file drop `--norc`, which
+      # lets a system-wide /etc/bash.bashrc (Debian/Ubuntu) clobber the inherited PS1.
+      PS1='test$ '
+      RC_MARKER=loaded
+      alias aliascheck='echo ALIAS-EXPANDED'
+  # Reports whether the rc file reached it, from inside a named script.
+  - path: "rccheck.sh"
+    contents: |
+      echo "RC[$RC_MARKER]"
 
 cases:
   - name: "-c mode arguments without --"
@@ -120,3 +143,246 @@ cases:
     args:
       - "-o"
       - "--"
+
+  #
+  # Where the shell takes its commands from, and what the leftover words become.
+  #
+  # Three sources are possible -- a `-c` string, a named script, or standard input --
+  # and exactly one of `-c`/`-s`/a leading non-option word picks it. Getting that
+  # classification wrong silently changes both which commands run and what `$1`... are,
+  # so every combination below is pinned against bash.
+  #
+
+  - name: "no args reads commands from stdin"
+    stdin: |
+      echo "count=[$#] all=[$@]"
+      case $- in *i*) echo "interactive";; *) echo "not-interactive";; esac
+      case $- in *s*) echo "stdin-flag";; *) echo "no-stdin-flag";; esac
+
+  - name: "-s with no positional args"
+    args: ["-s"]
+    stdin: |
+      echo "count=[$#] all=[$@]"
+      case $- in *s*) echo "stdin-flag";; *) echo "no-stdin-flag";; esac
+
+  - name: "-s with one positional arg"
+    args: ["-s", "myarg"]
+    stdin: |
+      echo "count=[$#] one=[$1] all=[$@]"
+
+  - name: "-s with multiple positional args"
+    args: ["-s", "a", "b", "c"]
+    stdin: |
+      echo "count=[$#] one=[$1] two=[$2] three=[$3] all=[$@] star=[$*]"
+
+  - name: "-s with hyphen-leading positional args"
+    args: ["-s", "a", "-2", "c"]
+    stdin: |
+      echo "count=[$#] one=[$1] two=[$2] three=[$3] all=[$@]"
+
+  # `-s` claims the script slot, so a script named among the trailing words is a
+  # positional parameter and must NOT be executed.
+  - name: "-s does not run a script named among its positional args"
+    args: ["-s", "announce.sh"]
+    stdin: |
+      echo "count=[$#] one=[$1]"
+
+  # ...and $0 stays the shell's own name rather than being taken from the words.
+  - name: "-s leaves $0 alone rather than consuming the first positional"
+    args: ["-s", "myarg"]
+    stdin: |
+      case "$0" in myarg) echo "BAD: \$0 took the positional";; *) echo "OK: \$0 untouched";; esac
+      echo "one=[$1]"
+
+  - name: "-s reports the stdin flag in \\$-"
+    args: ["-s", "myarg"]
+    stdin: |
+      case $- in *s*) echo "stdin-flag";; *) echo "no-stdin-flag";; esac
+
+  # A shell reading commands from a pipe is not interactive, positional args or not.
+  - name: "-s with positional args on a non-terminal is not interactive"
+    args: ["-s", "myarg"]
+    stdin: |
+      case $- in *i*) echo "interactive";; *) echo "not-interactive";; esac
+      echo "one=[$1]"
+
+  # ...but -i forces it, and must not disturb the positional parameters.
+  - name: "-i -s with positional args is interactive"
+    ignore_stderr: true # bash echoes prompts and job-control warnings on a non-tty `-i` shell
+    args: ["-i", "-s", "myarg"]
+    stdin: |
+      case $- in *i*) echo "interactive";; *) echo "not-interactive";; esac
+      echo "count=[$#] one=[$1]"
+
+  - name: "-si with positional args"
+    ignore_stderr: true
+    args: ["-si", "myarg"]
+    stdin: |
+      case $- in *i*) echo "interactive";; *) echo "not-interactive";; esac
+      echo "count=[$#] one=[$1]"
+
+  - name: "-is with positional args"
+    ignore_stderr: true
+    args: ["-is", "myarg"]
+    stdin: |
+      case $- in *i*) echo "interactive";; *) echo "not-interactive";; esac
+      echo "count=[$#] one=[$1]"
+
+  #
+  # The tty-attached half of the matrix, and the one the piped cases above cannot reach:
+  # with `-s`, commands still come from stdin, so a terminal-attached shell is
+  # *interactive* -- trailing positional args notwithstanding. The `#expect:` directives
+  # are the assertion in these (stdout is too pty-dependent to diff).
+  #
+  # Being interactive is not cosmetic. It is what makes the shell source its rc file and
+  # expand aliases, so those are checked here too rather than taken on faith; the
+  # non-pty cases that follow pin the matching negatives.
+  #
+
+  - name: "-s with positional args is interactive on a terminal"
+    pty: true
+    incompatible_configs: ["sh"]
+    ignore_stdout: true # pty transcripts differ in echo and escape-sequence details
+    ignore_whitespace: true
+    args: ["-s", "myarg"]
+    # N.B. The markers must be *computed*, or the terminal's echo of the typed command
+    # line satisfies the expectation on its own and the case can never fail.
+    stdin: |
+      #expect-prompt
+      echo "FLAGS[${-//[!i]/}] ARG[$1]"
+      #send:Enter
+      #expect:FLAGS[i] ARG[myarg]
+      #expect-prompt
+      #send:Ctrl+D
+
+  - name: "-s with positional args loads the rc file on a terminal"
+    pty: true
+    incompatible_configs: ["sh"]
+    removed_default_args: ["--norc"] # `--norc` otherwise overrides `--rcfile`
+    ignore_stdout: true
+    ignore_whitespace: true
+    args: ["--rcfile", "testrc", "-s", "myarg"]
+    stdin: |
+      #expect-prompt
+      echo "RC[$RC_MARKER] ARG[$1]"
+      #send:Enter
+      #expect:RC[loaded] ARG[myarg]
+      #expect-prompt
+      aliascheck
+      #send:Enter
+      #expect:ALIAS-EXPANDED
+      #expect-prompt
+      #send:Ctrl+D
+
+  # The negatives, which need no terminal: the same `--rcfile` must be ignored whenever
+  # the shell is not interactive, so the rc variable stays unset and the alias undefined.
+  - name: "the rc file is not loaded when -s reads from a pipe"
+    removed_default_args: ["--norc"]
+    ignore_stderr: true # only the "command not found" wording differs
+    args: ["--rcfile", "testrc", "-s", "myarg"]
+    stdin: |
+      echo "RC[$RC_MARKER] ARG[$1]"
+      aliascheck
+
+  - name: "the rc file is not loaded for a -c command"
+    removed_default_args: ["--norc"]
+    args: ["--rcfile", "testrc", "-c", 'echo "RC[$RC_MARKER]"']
+
+  - name: "the rc file is not loaded for a named script"
+    removed_default_args: ["--norc"]
+    args: ["--rcfile", "testrc", "rccheck.sh"]
+
+  #
+  # A named script wins over stdin: the script runs, and whatever is left on stdin is
+  # data for the script, never commands for the shell.
+  #
+
+  - name: "a named script runs and stdin is not read as commands"
+    args: ["announce.sh", "a", "b"]
+    stdin: |
+      echo STDIN-SHOULD-NOT-RUN
+
+  - name: "-i with a named script still runs the script"
+    ignore_stderr: true
+    args: ["-i", "announce.sh"]
+    stdin: |
+      echo STDIN-SHOULD-NOT-RUN
+
+  - name: "a script sees stdin as data, not commands"
+    args: ["reader.sh"]
+    stdin: |
+      first-line
+      second-line
+
+  #
+  # `-c` wins over everything, including `-s` and a named script.
+  #
+
+  - name: "-c runs its command and stdin is not read as commands"
+    args: ["-c", "echo from-c"]
+    stdin: |
+      echo STDIN-SHOULD-NOT-RUN
+
+  - name: "-s followed by -c runs the -c command"
+    args: ["-s", "-c", "echo from-c"]
+    stdin: |
+      echo STDIN-SHOULD-NOT-RUN
+
+  - name: "-c with -i is interactive but still runs the -c command"
+    ignore_stderr: true
+    args: ["-i", "-c", 'echo from-c; case $- in *i*) echo interactive;; *) echo not-interactive;; esac']
+    stdin: |
+      echo STDIN-SHOULD-NOT-RUN
+
+  #
+  # `--` and `-` as end-of-options markers. brush presently keeps them as ordinary
+  # positional words instead of consuming them, so these are pinned as known failures
+  # -- they document the gap and will flag the day it gets fixed.
+  #
+
+  - name: "-s with -- before positional args"
+    known_failure: true
+    args: ["-s", "--", "myarg"]
+    stdin: |
+      echo "count=[$#] one=[$1] all=[$@]"
+
+  - name: "-s with a lone --"
+    known_failure: true
+    args: ["-s", "--"]
+    stdin: |
+      echo "count=[$#] one=[$1] all=[$@]"
+
+  - name: "-s with a lone -"
+    known_failure: true
+    args: ["-s", "-"]
+    stdin: |
+      echo "count=[$#] one=[$1] all=[$@]"
+
+  - name: "-- before a script path"
+    known_failure: true
+    ignore_stderr: true
+    args: ["--", "announce.sh"]
+
+  - name: "- before a script path"
+    known_failure: true
+    ignore_stderr: true
+    args: ["-", "announce.sh"]
+
+  # After the `-c` command string, every remaining word is a positional parameter --
+  # even one that looks like an option. brush still parses these as options.
+  - name: "-c with an option-like word as $0"
+    known_failure: true
+    args: ["-c", 'echo "0=[$0] 1=[$1]"', "-s"]
+
+  - name: "-c with -i as $0"
+    known_failure: true
+    ignore_stderr: true
+    args: ["-c", 'echo "0=[$0] 1=[$1]"', "-i"]
+
+  # Repeating a boolean option is harmless in bash; brush's parser rejects it.
+  - name: "repeated -s"
+    known_failure: true
+    ignore_stderr: true
+    args: ["-s", "-s"]
+    stdin: |
+      echo "count=[$#] all=[$@]"

--- a/brush-shell/tests/interactive_tests.rs
+++ b/brush-shell/tests/interactive_tests.rs
@@ -142,6 +142,35 @@ fn login_shell_via_argv0_shows_prompt() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn dash_s_with_positional_args_is_interactive() -> anyhow::Result<()> {
+    // With `-s`, trailing words are positional parameters and commands still come from
+    // stdin -- so at a terminal the shell is interactive, and `PROMPT_COMMAND` runs.
+    let mut session = start_shell_session_with(|cmd| {
+        cmd.args(["-s", "myarg"]);
+    })?;
+
+    session.expect_prompt()?;
+
+    // N.B. The markers are computed, so the echoed command line can't satisfy the assertion.
+    let output = session.exec_output(r#"echo "FLAGS[${-//[!i]/}] ARG[$1]""#)?;
+    assert!(
+        output.contains("FLAGS[i] ARG[myarg]"),
+        "expected an interactive shell with $1 set; got: {output}"
+    );
+
+    session.exec_output("PROMPT_COMMAND='echo PC-RAN'")?;
+    let output = session.exec_output("echo done")?;
+    assert!(
+        output.contains("PC-RAN"),
+        "PROMPT_COMMAND didn't run: {output}"
+    );
+
+    session.exit()?;
+
+    Ok(())
+}
+
 //
 // Helpers
 //


### PR DESCRIPTION
bash only lets non-option arguments disqualify a shell from being interactive when `-s` is absent; brush disqualified them unconditionally, so `brush -s myarg` at a terminal skipped its rc file, didn't expand aliases, and reported `$-` as `hBs` where bash reports `himBHs`.

Route the decision through a single `will_read_commands_from_stdin` helper, replacing three separately-spelled copies of the same predicate. The unit test now goes through brush's own parser rather than clap's, which is what the shell actually uses.

Adds 30 YAML compat cases over the `-c`/script/stdin matrix, including two pty cases verified to fail against a pre-fix build. Eight are marked `known_failure` for pre-existing `--`/`-` option-terminator gaps, confirmed to fail identically on origin/main.

Assisted-By: Claude Opus 5