### PR TITLE
fix(parser): correct bracket expression edge cases

### DIFF
--- a/brush-core/src/regex.rs
+++ b/brush-core/src/regex.rs
@@ -157,18 +157,35 @@ fn add_missing_escape_chars_to_regex(s: &str) -> Cow<'_, str> {
     // to escape that character.
     let mut in_escape = false;
     let mut in_brackets = false;
+    // A ']' in the first member position of a bracket expression (immediately after the
+    // opening '[' or after the leading '^' that negates it) is a member of the
+    // expression, not its terminator.
+    let mut at_first_member = false;
     let mut insertion_positions = vec![];
 
     let mut peekable = s.char_indices().peekable();
     while let Some((byte_offset, c)) = peekable.next() {
         let next_is_colon = peekable.peek().is_some_and(|(_, c)| *c == ':');
+        let was_at_first_member = at_first_member;
+        at_first_member = false;
 
         match c {
             '[' if !in_escape && !in_brackets => {
                 in_brackets = true;
+                // A '^' here negates the expression; it isn't a member itself, so the
+                // first member position is the one after it. Any later '^' is an
+                // ordinary member.
+                let _ = peekable.next_if(|(_, c)| *c == '^');
+                at_first_member = true;
             }
             '[' if !in_escape && in_brackets && !next_is_colon => {
                 // Need to escape.
+                insertion_positions.push(byte_offset);
+            }
+            ']' if !in_escape && in_brackets && was_at_first_member => {
+                // `fancy_regex` doesn't implement the rule that this ']' is a member;
+                // escape it so it's a member there too, and so it can be the low end
+                // of a range (e.g. `[]-a]`).
                 insertion_positions.push(byte_offset);
             }
             ']' if !in_escape && in_brackets => {
@@ -229,5 +246,32 @@ mod tests {
         // Positive case -- where we need to escape.
         assert_eq!(add_missing_escape_chars_to_regex(r"a[b[]"), r"a[b\[]");
         assert_eq!(add_missing_escape_chars_to_regex(r"a[[]"), r"a[\[]");
+    }
+
+    #[test]
+    fn test_leading_close_bracket_in_bracket_expression() {
+        // A ']' in the first member position (after any '^') is a member of the bracket
+        // expression, not its terminator, so the expression is still open after it.
+        // It's escaped as well, since `fancy_regex` doesn't implement that rule; that
+        // also makes it the low end of a range in `[]-a]`, as it is in a shell pattern.
+        assert_eq!(add_missing_escape_chars_to_regex("[]]"), r"[\]]");
+        assert_eq!(add_missing_escape_chars_to_regex("[^]]"), r"[^\]]");
+        assert_eq!(add_missing_escape_chars_to_regex("[][]"), r"[\]\[]");
+        assert_eq!(add_missing_escape_chars_to_regex("[^][]"), r"[^\]\[]");
+        assert_eq!(add_missing_escape_chars_to_regex("[]a[]"), r"[\]a\[]");
+        assert_eq!(add_missing_escape_chars_to_regex("[]-a]"), r"[\]-a]");
+
+        // The rule only applies in the first member position: the ']' in `[a]` and the
+        // already-escaped one in `[\]]` both close their expressions.
+        assert_eq!(add_missing_escape_chars_to_regex("[a][]x]"), r"[a][\]x]");
+        assert_eq!(add_missing_escape_chars_to_regex(r"[\]][]x]"), r"[\]][\]x]");
+
+        // Only the '^' that negates the expression is skipped over; a later one is an
+        // ordinary member, so the ']' after it terminates the expression.
+        assert_eq!(add_missing_escape_chars_to_regex("[^^][ab]"), "[^^][ab]");
+        assert_eq!(add_missing_escape_chars_to_regex("[^^][b[]"), r"[^^][b\[]");
+
+        // A '^' outside a bracket expression doesn't open one.
+        assert_eq!(add_missing_escape_chars_to_regex("^[a[]"), r"^[a\[]");
     }
 }

--- a/brush-parser/src/pattern.rs
+++ b/brush-parser/src/pattern.rs
@@ -31,6 +31,19 @@ pub fn pattern_to_regex_str(
     Ok(regex_str)
 }
 
+/// Formats a range between two bracket expression members, returning `None` if the
+/// range is reversed (and therefore matches nothing).
+fn bracket_range(from: (String, char), to: (String, char)) -> Option<String> {
+    let (from_str, from_c) = from;
+    let (to_str, to_c) = to;
+
+    if from_c <= to_c {
+        Some(std::format!("{from_str}-{to_str}"))
+    } else {
+        None
+    }
+}
+
 peg::parser! {
     grammar pattern_to_regex_translator(enable_extended_globbing: bool) for str {
         pub(crate) rule pattern() -> String =
@@ -55,8 +68,12 @@ peg::parser! {
             ['\\'] [c] { c.to_string() }
 
         rule bracket_expression() -> String =
-            "[" invert:(invert_char()?) members:bracket_member()+ "]" {
-                let mut members = members.into_iter().flatten().collect::<Vec<_>>();
+            "[" invert:(invert_char()?) leading:(leading_bracket_member()?) members:bracket_member()* "]" {
+                let mut members = leading
+                    .into_iter()
+                    .chain(members)
+                    .flatten()
+                    .collect::<Vec<_>>();
 
                 // If we completed the parse but ended up with no valid members
                 // of the bracket expression, then return a regex that matches nothing.
@@ -75,6 +92,18 @@ peg::parser! {
                     std::format!("[{}]", members.join(""))
                 }
             }
+
+        // A ']' first in the expression (after any '!' or '^') is a member, not the end.
+        // It may also be the low end of a range, so it goes through the same range
+        // validation as any other member.
+        rule leading_bracket_member() -> Option<String> =
+            from:close_bracket_member() "-" to:single_char_bracket_member() {
+                bracket_range(from, to)
+            } /
+            from:close_bracket_member() { Some(from.0) }
+
+        rule close_bracket_member() -> (String, char) =
+            "]" { (String::from(r"\]"), ']') }
 
         rule invert_char() -> bool =
             ['!' | '^'] { true }
@@ -95,22 +124,16 @@ peg::parser! {
 
         rule char_range() -> Option<String> =
             from:single_char_bracket_member() "-" to:single_char_bracket_member() {
-                let (from_str, from_c) = from;
-                let (to_str, to_c) = to;
-
-                // Evaluate if the range is valid.
-                if from_c <= to_c {
-                    Some(std::format!("{from_str}-{to_str}"))
-                } else {
-                    None
-                }
+                bracket_range(from, to)
             }
 
         rule single_char_bracket_member() -> (String, char) =
             // Preserve escaped characters as-is.
             ['\\'] [c] { (std::format!("\\{c}"), c) } /
-            // Escape opening bracket.
-            ['['] { (String::from(r"\["), '[') } /
+            // Escape the characters that are special inside a regex character class;
+            // left bare, a '^' first in the class would negate it and a '-' would be
+            // read as a range separator.
+            [c if matches!(c, '[' | '^' | '-')] { (std::format!("\\{c}"), c) } /
             // Any other character except closing bracket gets added as-is.
             [c if c != ']'] { (c.to_string(), c) }
 
@@ -234,10 +257,41 @@ mod tests {
         assert_eq!(pattern_to_regex_str(r"[\(]", true)?, r"[\(]");
         assert_eq!(pattern_to_regex_str(r"[(]", true)?, "[(]");
         assert_eq!(pattern_to_regex_str("[[:digit:]]", true)?, "[[:digit:]]");
-        assert_eq!(pattern_to_regex_str(r"[-(),!]*", true)?, r"[-(),!].*");
-        assert_eq!(pattern_to_regex_str(r"[-\(\),\!]*", true)?, r"[-\(\),\!].*");
+        assert_eq!(pattern_to_regex_str(r"[-(),!]*", true)?, r"[\-(),!].*");
+        assert_eq!(
+            pattern_to_regex_str(r"[-\(\),\!]*", true)?,
+            r"[\-\(\),\!].*"
+        );
         assert_eq!(pattern_to_regex_str(r"[a\-b]", true)?, r"[a\-b]");
         assert_eq!(pattern_to_regex_str(r"[a\-\*]", true)?, r"[a\-\*]");
+
+        // A ']' in the first member position (after any '!' or '^') is a member of the
+        // bracket expression, not its terminator.
+        assert_eq!(pattern_to_regex_str("[]]", true)?, r"[\]]");
+        assert_eq!(pattern_to_regex_str("[][]", true)?, r"[\]\[]");
+        assert_eq!(pattern_to_regex_str("[]abc[]", true)?, r"[\]abc\[]");
+        assert_eq!(pattern_to_regex_str("[]]]", true)?, r"[\]]\]");
+        assert_eq!(pattern_to_regex_str("[!]]", true)?, r"[^\]]");
+        assert_eq!(pattern_to_regex_str("[^][]", true)?, r"[^\]\[]");
+
+        // A range starting at that ']' is validated like any other range.
+        assert_eq!(pattern_to_regex_str("[]-a]", true)?, r"[\]-a]");
+        assert_eq!(pattern_to_regex_str("[]-a[]", true)?, r"[\]-a\[]");
+        assert_eq!(pattern_to_regex_str("[]-A]", true)?, "(?!)");
+        assert_eq!(pattern_to_regex_str("[!]-A]", true)?, ".");
+
+        // '^' and '-' are escaped as members, so a '^' left first by a dropped
+        // range can't negate the class and a '-' endpoint can't be read as a
+        // range separator.
+        assert_eq!(pattern_to_regex_str("[9-0^a]", true)?, r"[\^a]");
+        assert_eq!(pattern_to_regex_str("[z-a^]", true)?, r"[\^]");
+        assert_eq!(pattern_to_regex_str("[+--]", true)?, r"[+-\-]");
+        assert_eq!(pattern_to_regex_str("[--/]", true)?, r"[\--/]");
+
+        // An unterminated bracket expression is still just literal text.
+        assert_eq!(pattern_to_regex_str("[]", true)?, r"\[\]");
+        assert_eq!(pattern_to_regex_str("[!]", true)?, r"\[!\]");
+
         Ok(())
     }
 
@@ -289,6 +343,11 @@ mod tests {
         assert!(pattern_has_glob_metacharacters("[a-z]", false));
         assert!(pattern_has_glob_metacharacters("[!a]", false));
 
+        // A leading ']' is a member, so these are bracket expressions too.
+        assert!(pattern_has_glob_metacharacters("[]]", false));
+        assert!(pattern_has_glob_metacharacters("[][]", false));
+        assert!(pattern_has_glob_metacharacters("[!]]", false));
+
         // Lone `]` is NOT a glob metacharacter.
         assert!(!pattern_has_glob_metacharacters("]", false));
         assert!(!pattern_has_glob_metacharacters("foo]", false));
@@ -296,6 +355,8 @@ mod tests {
 
         // Lone `[` without matching `]` is NOT a glob metacharacter.
         assert!(!pattern_has_glob_metacharacters("[", false));
+        assert!(!pattern_has_glob_metacharacters("[]", false));
+        assert!(!pattern_has_glob_metacharacters("[!]", false));
         assert!(!pattern_has_glob_metacharacters("[abc", false));
         assert!(!pattern_has_glob_metacharacters("a[b", false));
 

--- a/brush-shell/tests/cases/compat/extended_tests.yaml
+++ b/brush-shell/tests/cases/compat/extended_tests.yaml
@@ -234,6 +234,61 @@ cases:
       [[ a =~ ^(a|b)$ ]] && echo "4. Pass"
       [[ a =~ c ]]       && echo "5. Pass"
 
+  # A ']' in the first member position (after any '^') is a member of the bracket
+  # expression, not its terminator.
+  - name: "Regex with leading ] in bracket expression"
+    stdin: |
+      [[ "]" =~ ^[]]$   ]] && echo "1. Matched"
+      [[ "a" =~ ^[]a]$  ]] && echo "2. Matched"
+      [[ "[" =~ ^[][]$  ]] && echo "3. Matched"
+      [[ "]" =~ ^[][]$  ]] && echo "4. Matched"
+      [[ "a" =~ ^[][]$  ]] || echo "5. Not matched"
+      [[ "[" =~ ^[^][]$ ]] || echo "6. Not matched"
+      [[ "a" =~ ^[^][]$ ]] && echo "7. Matched"
+      [[ "[" =~ ^[]a[]$ ]] && echo "8. Matched"
+      # Only the first '^' negates; the second is an ordinary member, so the ']'
+      # that follows it does terminate the expression.
+      [[ "xa" =~ ^[^^][ab]$ ]] && echo "9. Matched"
+      [[ "x[" =~ ^[^^][ab]$ ]] || echo "10. Not matched"
+      [[ "x]" =~ ^[^^]]$    ]] && echo "11. Matched"
+      # That leading ']' can also be the low end of a range.
+      [[ "^" =~ ^[]-a]$ ]] && echo "12. Matched"
+      [[ "]" =~ ^[]-a]$ ]] && echo "13. Matched"
+      [[ "-" =~ ^[]-a]$ ]] || echo "14. Not matched"
+      [[ "b" =~ ^[]-a]$ ]] || echo "15. Not matched"
+      echo "done"
+
+  # `fancy_regex` and POSIX ERE disagree on how a '-' range endpoint binds, and
+  # brush passes the user's bracket expression through without normalizing it.
+  - name: "Regex with '-' as a range endpoint"
+    known_failure: true
+    stdin: |
+      for s in '+' ',' '-' '.' '/' 'a'; do
+        [[ "$s" =~ ^[+--]$ ]] && echo "1. matched: $s"
+      done
+      for s in '+' ',' '-' '.' '/' 'a'; do
+        [[ "$s" =~ ^[--/]$ ]] && echo "2. matched: $s"
+      done
+      echo "done"
+
+  # A reversed range is rejected by both shells, but bash reports a bad regex as
+  # a usage error (status 2) while brush treats it as a failed match (status 1).
+  - name: "Regex with a reversed range"
+    known_failure: true
+    ignore_stderr: true
+    stdin: |
+      [[ x =~ ^[9-0]$ ]]
+      echo "status=$?"
+
+  # POSIX ERE reads '?*' as two stacked quantifiers; `fancy_regex` rejects the
+  # second as having no valid target.
+  - name: "Regex with stacked quantifiers"
+    known_failure: true
+    ignore_stderr: true
+    stdin: |
+      [[ "]" =~ ^[a]?*]$ ]]
+      echo "status=$?"
+
   - name: "Regex with case insensitivity"
     stdin: |
       shopt -u nocasematch

--- a/brush-shell/tests/cases/compat/patterns/patterns.yaml
+++ b/brush-shell/tests/cases/compat/patterns/patterns.yaml
@@ -172,3 +172,61 @@ cases:
   - name: "Pattern matching: quotes in character class"
     stdin: |
       [[ f == ['f'] ]] && echo "1. Matched"
+
+  # A ']' first in a bracket expression (after any '!' or '^') is a member,
+  # not the end of the expression.
+  - name: "Pattern matching: leading ] in bracket expression"
+    stdin: |
+      [[ "]" == [][] ]] && echo "1. Matched"
+      [[ "a" == [][a] ]] && echo "2. Matched"
+      [[ "[" == []abc[] ]] && echo "3. Matched"
+      [[ "x" == [^][] ]] && echo "4. Matched"
+      [[ "]" == [!]] ]] || echo "5. Not matched"
+      s="a]b[c"
+      echo "${s//[][]/_}"
+      # ble.sh strips function names out of `declare -F` output with this extglob;
+      # the bracket expression is meant to cover ']', '[', '{', '}', ':' and alnum.
+      shopt -s extglob
+      v=$'\nxxx is a function\nhello\n'
+      p=$'\n+([][{}:[:alnum:]]) is a function\n'
+      printf '[%s]\n' "${v//$p/|}"
+
+  # A range whose low end is that leading ']' is validated like any other range;
+  # a reversed one matches nothing (or, inverted, everything).
+  - name: "Pattern matching: ranges starting at a leading ] in bracket expression"
+    stdin: |
+      for s in ']' 'a' 'A' '^' '-'; do
+        [[ "$s" == []-a] ]] && echo "in-range: $s"
+      done
+      for s in ']' 'a' 'A' '^' '-'; do
+        [[ "$s" == []-A] ]] && echo "reversed range matched: $s"
+      done
+      for s in ']' 'a' 'A' '^' '-'; do
+        [[ "$s" == [!]-A] ]] && echo "inverted reversed range matched: $s"
+      done
+      echo "done"
+
+  # An invalid (reversed) range is dropped from the bracket expression, but the
+  # surviving members are still emitted in order. A '^' left first that way must
+  # not negate the generated regex character class.
+  - name: "Pattern matching: invalid range leaving a leading ^ member"
+    stdin: |
+      for s in '^' 'a' 'b'; do
+        [[ "$s" == [9-0^a] ]] && echo "1. matched: $s"
+      done
+      for s in '^' 'a' 'b'; do
+        [[ "$s" == [z-a^] ]] && echo "2. matched: $s"
+      done
+      echo "done"
+
+  # A '-' endpoint must be escaped in the generated regex, or the class becomes
+  # ambiguous and the range collapses to a set.
+  - name: "Pattern matching: '-' as a range endpoint"
+    stdin: |
+      for s in '+' ',' '-' '.' '/' 'a'; do
+        [[ "$s" == [+--] ]] && echo "1. matched: $s"
+      done
+      for s in '+' ',' '-' '.' '/' 'a'; do
+        [[ "$s" == [--/] ]] && echo "2. matched: $s"
+      done
+      echo "done"


### PR DESCRIPTION
A `]` right after `[` or `[^` is treated as a literal right-bracket character for matching rather than the end of the bracketed expression.

Fixes #1358. Adds YAML-based compat cases; a few additional tests are added but not resolved for other preexisting issues (marked as `known_failure`).

Assisted-By: Claude Opus 5