### PR TITLE
perf(*): extend over for loop

### DIFF
--- a/brush-core/src/completion.rs
+++ b/brush-core/src/completion.rs
@@ -315,11 +315,11 @@ impl Spec {
                 shell, &params, word_list, &options,
             )
             .await?;
-            for word in words {
-                if word.starts_with(context.token_to_complete) {
-                    candidates.push(word);
-                }
-            }
+            candidates.extend(
+                words
+                    .into_iter()
+                    .filter(|word| word.starts_with(context.token_to_complete)),
+            );
         }
 
         if let Some(glob_pattern) = &self.glob_pattern {
@@ -335,9 +335,7 @@ impl Spec {
                 )?
                 .into_paths();
 
-            for expansion in expansions {
-                candidates.push(expansion);
-            }
+            candidates.extend(expansions);
         }
         if let Some(function_name) = &self.function_name {
             let call_result = self

--- a/brush-core/src/wellknownvars.rs
+++ b/brush-core/src/wellknownvars.rs
@@ -741,9 +741,7 @@ fn get_bash_argv_value(shell: &dyn ShellState) -> variables::ShellValue {
     for frame in shell.call_stack().iter() {
         if let Some(args) = frame_bash_args(frame, extdebug) {
             // Push args in reverse order per frame (last arg at lowest index = top of stack)
-            for arg in args.iter().rev() {
-                argv.push(arg.clone());
-            }
+            argv.extend(args.iter().cloned().rev());
         }
     }
 

--- a/brush-parser/src/parser/peg.rs
+++ b/brush-parser/src/parser/peg.rs
@@ -19,7 +19,7 @@ peg::parser! {
         rule complete_command() -> ast::CompleteCommand =
             first:and_or() remainder:(s:separator_op() l:and_or() { (s, l) })* last_sep:separator_op()? {
                 let mut and_ors = vec![first];
-                let mut seps = vec![];
+                let mut seps = Vec::with_capacity(remainder.len());
 
                 for (sep, ao) in remainder {
                     seps.push(sep);
@@ -29,10 +29,7 @@ peg::parser! {
                 // N.B. We default to synchronous if no separator op is given.
                 seps.push(last_sep.unwrap_or(SeparatorOperator::Sequence));
 
-                let mut items = vec![];
-                for (i, ao) in and_ors.into_iter().enumerate() {
-                    items.push(ast::CompoundListItem(ao, seps[i].clone()));
-                }
+                let items = and_ors.into_iter().enumerate().map(|(i, ao)| ast::CompoundListItem(ao, seps[i].clone())).collect();
 
                 ast::CompoundList(items)
             }
@@ -146,7 +143,7 @@ peg::parser! {
         rule compound_list() -> ast::CompoundList =
             linebreak() first:and_or() remainder:(s:separator() l:and_or() { (s, l) })* last_sep:separator()? {
                 let mut and_ors = vec![first];
-                let mut seps = vec![];
+                let mut seps = Vec::with_capacity(remainder.len());
 
                 for (sep, ao) in remainder {
                     seps.push(sep.unwrap_or(SeparatorOperator::Sequence));
@@ -157,10 +154,7 @@ peg::parser! {
                 let last_sep = last_sep.unwrap_or(None);
                 seps.push(last_sep.unwrap_or(SeparatorOperator::Sequence));
 
-                let mut items = vec![];
-                for (i, ao) in and_ors.into_iter().enumerate() {
-                    items.push(ast::CompoundListItem(ao, seps[i].clone()));
-                }
+                let items = and_ors.into_iter().enumerate().map(|(i, ao)| ast::CompoundListItem(ao, seps[i].clone())).collect();
 
                 ast::CompoundList(items)
             }
@@ -379,10 +373,8 @@ peg::parser! {
 
         rule else_part() -> Vec<ast::ElseClause> =
             cs:_conditional_else_part()+ u:_unconditional_else_part()? {
-                let mut parts = vec![];
-                for c in cs {
-                    parts.push(c);
-                }
+                let mut parts = Vec::with_capacity(cs.len() + 1);
+                parts.extend(cs);
 
                 if let Some(uncond) = u {
                     parts.push(uncond);

--- a/brush-parser/src/tokenizer.rs
+++ b/brush-parser/src/tokenizer.rs
@@ -426,9 +426,9 @@ impl TokenParseState {
                 let completed_here_tag = cross_token_state.current_here_tags.remove(0);
 
                 // First queue the redirection operator and (start) here-tag.
-                for here_token in completed_here_tag.tokens {
-                    cross_token_state.queued_tokens.push(here_token);
-                }
+                cross_token_state
+                    .queued_tokens
+                    .extend(completed_here_tag.tokens);
 
                 // Leave a hint that we are about to start a here-document.
                 cross_token_state.queued_tokens.push(TokenizeResult {
@@ -456,9 +456,9 @@ impl TokenParseState {
 
                 // Now we're ready to queue up any tokens that came between the completed
                 // here tag and the next here tag (or newline after it if it was the last).
-                for pending_token in completed_here_tag.pending_tokens_after {
-                    cross_token_state.queued_tokens.push(pending_token);
-                }
+                cross_token_state
+                    .queued_tokens
+                    .extend(completed_here_tag.pending_tokens_after);
 
                 if cross_token_state.current_here_tags.is_empty() {
                     cross_token_state.here_state = HereState::None;


### PR DESCRIPTION
A couple for loops can easily be condensed to `.extend`s, and a couple can potentially trigger resizes when they aren't needed, so I fixed those.

These are probably micro-optimizations so feel free to close if you don't want them; I just think they're more idiomatic.