### PR TITLE
feat(interactive): iterate on zsh-style hooks

### DIFF
--- a/brush-interactive/src/interactive_shell.rs
+++ b/brush-interactive/src/interactive_shell.rs
@@ -33,13 +33,16 @@ impl From<&InteractiveExecutionResult> for i32 {
 pub struct InteractiveOptions {
     /// Whether terminal shell integration is enabled.
     pub terminal_shell_integration: bool,
-    /// Whether or not to run zsh-style exec/cmd functions (e.g., `preexec_functions`,
-    /// `precmd_functions`).
-    pub run_cmd_exec_funcs: bool,
+    /// Whether to run zsh-style `precmd_functions`/`preexec_functions` hooks. Inert on its
+    /// own: the embedder must also call [`init_zsh_style_hooks`](crate::init_zsh_style_hooks)
+    /// before the shell loads its profile and rc files.
+    pub zsh_style_hooks: bool,
 }
 
 /// Reads `PROMPT_COMMAND` as bash does: a string is a single command, an indexed array is one
-/// command per element, and any other type runs nothing at all.
+/// command per element, and any other type runs nothing at all. Deliberately *not* read as a
+/// word list the way the hook registries are: bash gives `PROMPT_COMMAND` its own handling
+/// rather than expanding it as `"${PROMPT_COMMAND[@]}"`.
 fn read_prompt_commands<SE: brush_core::ShellExtensions>(
     shell: &brush_core::Shell<SE>,
 ) -> Vec<String> {
@@ -56,8 +59,8 @@ pub struct InteractiveShell<'a, IB: InputBackend, SE: brush_core::ShellExtension
     shell: crate::ShellRef<SE>,
     /// The input backend to use.
     input: &'a mut IB,
-    /// Terminal integration utility, if any.
-    terminal_integration: Option<crate::term_integration::TerminalIntegration>,
+    /// Terminal integration utility; inert if integration is off or unsupported.
+    terminal_integration: crate::term_integration::TerminalIntegration,
     /// Terminal-control guard, held for the lifetime of the interactive shell.
     _terminal_control: Option<brush_core::terminal::TerminalControl>,
     /// Options.
@@ -86,17 +89,13 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             None
         };
 
-        // Set up terminal integration if enabled *and* if stdin is a terminal.
+        // Set up terminal integration if enabled *and* if stdin is a terminal. Otherwise a
+        // switched-off one, which every call site below can report events to unconditionally.
         let terminal_integration = if options.terminal_shell_integration && stdin_is_terminal {
             let terminfo = crate::term_detection::get_terminal_info(&HostEnvironment);
-            let terminal_integration = crate::term_integration::TerminalIntegration::new(terminfo);
-
-            print!("{}", terminal_integration.initialize().as_ref());
-            std::io::stdout().flush()?;
-
-            Some(terminal_integration)
+            crate::term_integration::TerminalIntegration::init(terminfo)?
         } else {
-            None
+            crate::term_integration::TerminalIntegration::disabled()
         };
 
         Ok(Self {
@@ -123,10 +122,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
         loop {
             let result = self.run_interactively_once().await?;
             match result {
-                InteractiveExecutionResult::Executed(brush_core::ExecutionResult {
-                    next_control_flow: brush_core::results::ExecutionControlFlow::ExitShell,
-                    ..
-                }) => {
+                InteractiveExecutionResult::Executed(result) if result.is_exit() => {
                     break;
                 }
                 InteractiveExecutionResult::Executed(brush_core::ExecutionResult {
@@ -198,7 +194,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             }
 
             // Compose the prompt.
-            Self::compose_prompt(&mut shell, self.terminal_integration.as_ref()).await?
+            Self::compose_prompt(&mut shell, &self.terminal_integration).await?
         } else {
             InteractivePrompt::default()
         };
@@ -234,7 +230,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
 
     async fn compose_prompt(
         shell: &mut brush_core::Shell<SE>,
-        terminal_integration: Option<&crate::term_integration::TerminalIntegration>,
+        terminal_integration: &crate::term_integration::TerminalIntegration,
     ) -> Result<InteractivePrompt, ShellError> {
         // Now that we've done that, compose the prompt.
         let mut prompt = InteractivePrompt {
@@ -243,19 +239,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             continuation_prompt: shell.compose_continuation_prompt().await?,
         };
 
-        if let Some(terminal_integration) = terminal_integration {
-            let pre_prompt = terminal_integration.pre_prompt();
-            let working_dir = terminal_integration.report_cwd(shell.working_dir());
-            let post_prompt = terminal_integration.post_prompt();
-
-            prompt.prompt = [
-                pre_prompt.as_ref(),
-                working_dir.as_ref(),
-                prompt.prompt.as_str(),
-                post_prompt.as_ref(),
-            ]
-            .concat();
-        }
+        prompt.prompt = terminal_integration.decorate_prompt(prompt.prompt, shell.working_dir());
 
         Ok(prompt)
     }
@@ -287,19 +271,24 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
         };
 
         // If the line came from direct user input (as opposed to a key binding, say), then we
-        // need to do a few more things before executing it.
-        if user_input {
-            Self::run_pre_exec_actions(
-                &mut shell,
-                read_result.as_str(),
-                &self.options,
-                self.terminal_integration.as_ref(),
-            )
-            .await?;
+        // need to do a few more things before executing it. A hook that exited the shell
+        // stands in for the command: the line never runs, and neither does the bookkeeping
+        // below, which only matters to a shell that goes on to read another line.
+        if user_input
+            && let ControlFlow::Break(exit) =
+                Self::run_pre_exec_actions(&mut shell, read_result.as_str(), &self.options).await?
+        {
+            return Ok(InteractiveExecutionResult::Executed(exit));
         }
 
         // Count the command's lines.
         let line_count = read_result.lines().count().max(1);
+
+        // Terminal integration brackets the command with a matched pair of markers, so both
+        // are emitted here, around the one call that runs it: no failure between them can
+        // leave a started command unclosed, and nothing below this writes to the terminal.
+        self.terminal_integration
+            .on_pre_exec_command(&read_result)?;
 
         // Execute the command.
         let params = shell.default_exec_params();
@@ -308,6 +297,9 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             Ok(result) => Ok(InteractiveExecutionResult::Executed(result)),
             Err(e) => Ok(InteractiveExecutionResult::Failed(e)),
         };
+
+        self.terminal_integration
+            .on_post_exec_command(result.as_ref().map_or(1, i32::from))?;
 
         // Update cumulative line counter based on actual lines in the command.
         shell.increment_interactive_line_offset(line_count);
@@ -328,16 +320,6 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             self.input.set_read_buffer(updated_buffer, updated_cursor);
         }
 
-        // Invoke terminal integration.
-        if let Some(terminal_integration) = &self.terminal_integration {
-            let exit_code = result.as_ref().map_or(1, i32::from);
-            print!(
-                "{}",
-                terminal_integration.post_exec_command(exit_code).as_ref()
-            );
-            std::io::stdout().flush()?;
-        }
-
         result
     }
 
@@ -346,7 +328,12 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
         shell: &mut brush_core::Shell<SE>,
         options: &InteractiveOptions,
     ) -> Result<ControlFlow<brush_core::ExecutionResult>, ShellError> {
-        // If there's a variable called PROMPT_COMMAND, then run it first.
+        // precmd hooks first: bash-preexec prepends its dispatcher to PROMPT_COMMAND.
+        if let ControlFlow::Break(exit) = crate::zsh_hooks::run_precmd(shell, options).await? {
+            return Ok(ControlFlow::Break(exit));
+        }
+
+        // Next, if there's a variable called PROMPT_COMMAND, then run it.
         for prompt_cmd in read_prompt_commands(shell) {
             if let ControlFlow::Break(exit) =
                 Self::run_pre_prompt_command(shell, prompt_cmd).await?
@@ -355,36 +342,21 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
             }
         }
 
-        // Next, run any zsh-style `precmd_functions`.
-        // TODO(precmd_functions): verify if we need to save/restore exit results.
-        if options.run_cmd_exec_funcs {
-            // If there's a variable called precmd_functions, then call them.
-            if let Some(brush_core::ShellValue::IndexedArray(precmd_funcs)) = shell
-                .env_var("precmd_functions")
-                .map(|var| var.value())
-                .cloned()
-            {
-                for func_name in precmd_funcs.values() {
-                    let _ = shell
-                        .invoke_function(
-                            func_name,
-                            std::iter::empty::<&str>(),
-                            shell.default_exec_params(),
-                        )
-                        .await;
-                }
-            }
-        }
-
         Ok(ControlFlow::Continue(()))
     }
 
+    /// Runs pre-exec actions. Breaks with the result of a hook that exited the shell.
+    ///
+    /// # Arguments
+    ///
+    /// * `shell` - The shell to run the actions in.
+    /// * `command_line` - The line as entered by the user.
+    /// * `options` - The options the interactive loop is running with.
     async fn run_pre_exec_actions(
         shell: &mut brush_core::Shell<SE>,
         command_line: &str,
         options: &InteractiveOptions,
-        terminal_integration: Option<&crate::term_integration::TerminalIntegration>,
-    ) -> Result<(), ShellError> {
+    ) -> Result<ControlFlow<brush_core::ExecutionResult>, ShellError> {
         // Display the pre-command prompt on stderr (if there is one). Like the other prompts,
         // this is expanded only by a shell that's interactive in the `$-` sense.
         if shell.options().interactive {
@@ -398,33 +370,9 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
         // Update history (if applicable).
         shell.add_to_history(command_line.trim_end_matches('\n'))?;
 
-        // Next, run any zsh-style `preexec_functions`.
-        // TODO(preexec_functions): verify if we need to save/restore exit results.
-        if options.run_cmd_exec_funcs {
-            // If there's a variable called preexec_functions, then call them.
-            if let Some(brush_core::ShellValue::IndexedArray(preexec_funcs)) = shell
-                .env_var("preexec_functions")
-                .map(|var| var.value())
-                .cloned()
-            {
-                for func_name in preexec_funcs.values() {
-                    let _ = shell
-                        .invoke_function(func_name, &[command_line], shell.default_exec_params())
-                        .await;
-                }
-            }
-        }
-
-        // Invoke terminal integration.
-        if let Some(terminal_integration) = terminal_integration {
-            print!(
-                "{}",
-                terminal_integration.pre_exec_command(command_line).as_ref()
-            );
-            std::io::stdout().flush()?;
-        }
-
-        Ok(())
+        // preexec hooks get the line as entered; they are the last thing before it runs, so
+        // their break is this function's.
+        crate::zsh_hooks::run_preexec(shell, options, command_line).await
     }
 
     /// Runs one `PROMPT_COMMAND` entry. Breaks with its result if it exited the shell.

--- a/brush-interactive/src/lib.rs
+++ b/brush-interactive/src/lib.rs
@@ -6,6 +6,9 @@ pub use error::ShellError;
 mod interactive_shell;
 pub use interactive_shell::{InteractiveExecutionResult, InteractiveOptions, InteractiveShell};
 
+mod zsh_hooks;
+pub use zsh_hooks::init as init_zsh_style_hooks;
+
 mod input_backend;
 pub use input_backend::{InputBackend, InteractivePrompt, ReadResult};
 

--- a/brush-interactive/src/options.rs
+++ b/brush-interactive/src/options.rs
@@ -22,7 +22,7 @@ impl From<&UIOptions> for crate::InteractiveOptions {
     fn from(options: &UIOptions) -> Self {
         Self {
             terminal_shell_integration: options.terminal_shell_integration,
-            run_cmd_exec_funcs: options.zsh_style_hooks,
+            zsh_style_hooks: options.zsh_style_hooks,
         }
     }
 }

--- a/brush-interactive/src/term_integration.rs
+++ b/brush-interactive/src/term_integration.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 use std::fmt::Write;
+use std::io::Write as _;
 
 use crate::term_detection;
 
 /// Utility for integrating with terminal emulators.
-#[derive(Default)]
 pub(crate) struct TerminalIntegration {
     /// Info about the hosting terminal.
     term: term_detection::TerminalInfo,
@@ -12,13 +12,58 @@ pub(crate) struct TerminalIntegration {
 
 #[allow(dead_code)]
 impl TerminalIntegration {
-    /// Creates a new terminal integration utility.
+    /// Starts terminal integration, emitting the sequence that announces it, and returns the
+    /// utility the interactive loop reports events to.
     ///
     /// # Arguments
     ///
     /// * `term_info` - Information about the terminal capabilities.
-    pub const fn new(term_info: term_detection::TerminalInfo) -> Self {
-        Self { term: term_info }
+    pub fn init(term_info: term_detection::TerminalInfo) -> std::io::Result<Self> {
+        let integration = Self { term: term_info };
+        Self::write(integration.initialize().as_ref())?;
+        Ok(integration)
+    }
+
+    /// Returns a utility that integrates with nothing: it reports no capabilities, so every
+    /// event handler below does nothing and every sequence it composes is empty. This is what
+    /// a shell gets when integration is switched off, so it need not ask whether it has one.
+    pub fn disabled() -> Self {
+        Self {
+            term: term_detection::TerminalInfo::default(),
+        }
+    }
+
+    //
+    // Event handlers: these are called at the points in the interactive loop that the
+    // terminal wants to know about; each does what the event calls for. A terminal that
+    // reports no support has nothing to say at any of them, so every handler is inert.
+    //
+
+    /// Called after a command line has been read and before it runs.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - The command that is about to be executed.
+    pub fn on_pre_exec_command(&self, command: &str) -> std::io::Result<()> {
+        Self::write(self.pre_exec_command(command).as_ref())
+    }
+
+    /// Called after a command has run.
+    ///
+    /// # Arguments
+    ///
+    /// * `exit_code` - The exit code the command left behind.
+    pub fn on_post_exec_command(&self, exit_code: i32) -> std::io::Result<()> {
+        Self::write(self.post_exec_command(exit_code).as_ref())
+    }
+
+    /// Writes a sequence to standard output, flushing so the terminal sees it before whatever
+    /// the shell does next. Writing nothing still flushes; that costs nothing and keeps the
+    /// inert case from being a separate path.
+    fn write(seq: &str) -> std::io::Result<()> {
+        let mut stdout = std::io::stdout();
+        stdout.write_all(seq.as_bytes())?;
+        stdout.flush()
     }
 
     /// Returns the terminal escape sequence that should be emitted to initialize terminal
@@ -29,6 +74,29 @@ impl TerminalIntegration {
         } else {
             "".into()
         }
+    }
+
+    /// Returns a composed prompt bracketed with the sequences that mark where a prompt starts
+    /// and ends, and that report the working directory -- or the prompt as given, when there is
+    /// nothing to add. Returned rather than composed in place so the untouched prompt costs
+    /// nothing, not even the copy that concatenating three empty strings onto it would make.
+    ///
+    /// # Arguments
+    ///
+    /// * `prompt` - The prompt as composed by the shell.
+    /// * `working_dir` - The shell's current working directory.
+    pub fn decorate_prompt(&self, prompt: String, working_dir: &std::path::Path) -> String {
+        if !self.term.supports_osc_633 {
+            return prompt;
+        }
+
+        [
+            self.pre_prompt().as_ref(),
+            self.report_cwd(working_dir).as_ref(),
+            prompt.as_str(),
+            self.post_prompt().as_ref(),
+        ]
+        .concat()
     }
 
     /// Returns the terminal escape sequence that should be emitted before the prompt.

--- a/brush-interactive/src/zsh_hooks.rs
+++ b/brush-interactive/src/zsh_hooks.rs
@@ -1,0 +1,323 @@
+//! A bash-native adaptation of zsh's `precmd`/`preexec` hooks.
+//!
+//! zsh defines the hooks; [bash-preexec] is the adaptation of them to bash that the ecosystem
+//! actually builds on, so it is what settles the details zsh leaves open for a bash shell.
+//! brush implements the hooks in the shell itself rather than in shell script, and
+//! interoperates with bash-preexec only as far as an interlock needs to: it claims
+//! bash-preexec's inclusion guards, so a copy sourced later stands down instead of layering
+//! its `DEBUG`-trap emulation on top of the real thing.
+//!
+//! Setup ([`init`]) runs once, before the shell loads its profile and rc files; dispatch
+//! ([`run_precmd`] and [`run_preexec`]) runs from the interactive loop. The contract as a
+//! whole is documented in `docs/reference/zsh-hooks.md`.
+//!
+//! [bash-preexec]: https://github.com/rcaloras/bash-preexec
+
+use std::ops::ControlFlow;
+
+use brush_core::variables::{ArrayLiteral, ShellValueLiteral};
+
+use crate::InteractiveOptions;
+use crate::ShellError;
+
+/// The registry naming the hooks that run before each prompt.
+const PRECMD_FUNCTIONS: &str = "precmd_functions";
+
+/// The registry naming the hooks that run before each command line.
+const PREEXEC_FUNCTIONS: &str = "preexec_functions";
+
+/// The bash-preexec inclusion guards, current and legacy. Sourcing bash-preexec is a no-op
+/// while either holds a non-empty value, so brush claims both.
+const BASH_PREEXEC_GUARDS: [&str; 2] = ["bash_preexec_imported", "__bp_imported"];
+
+/// Prepares a shell for zsh-style `precmd`/`preexec` hooks.
+///
+/// Seeds the hook registries and claims the [bash-preexec] inclusion guards, so a copy sourced
+/// later stands down and leaves the hooks to us. Documented in `docs/reference/zsh-hooks.md`.
+///
+/// Call before profile and rc files load, so they observe the state -- and only for a shell
+/// that will go on to read commands interactively, since only such a shell ever reaches
+/// dispatch and so only such a shell may claim the contract. Whether the hooks are wanted at
+/// all is decided here, by the same predicate dispatch uses, so the two cannot disagree.
+///
+/// A rejected assignment is fatal: a contract claimed only partway advertises hooks brush
+/// never registered.
+///
+/// [bash-preexec]: https://github.com/rcaloras/bash-preexec
+///
+/// # Arguments
+///
+/// * `shell` - The shell to prepare.
+/// * `options` - The options the interactive loop will run with.
+pub fn init<SE: brush_core::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
+    options: &InteractiveOptions,
+) -> Result<(), ShellError> {
+    if !enabled(shell, options) {
+        return Ok(());
+    }
+
+    // No export attribute is added, so a child bash still gets the real thing.
+    for guard_name in BASH_PREEXEC_GUARDS {
+        assign_global(
+            shell,
+            guard_name,
+            ShellValueLiteral::Scalar("defined".into()),
+        )?;
+    }
+
+    // Seeded with the bare hook names, as bash-preexec seeds them -- but by assignment, not
+    // `+=`, because this runs before rc files rather than after them.
+    for (array_name, hook_name) in [(PRECMD_FUNCTIONS, "precmd"), (PREEXEC_FUNCTIONS, "preexec")] {
+        let value = ShellValueLiteral::Array(ArrayLiteral(vec![(None, hook_name.into())]));
+        assign_global(shell, array_name, value)?;
+    }
+
+    Ok(())
+}
+
+/// Runs the `precmd` hooks. Breaks with the result of one that exited the shell.
+///
+/// # Arguments
+///
+/// * `shell` - The shell to run the hooks in.
+/// * `options` - The options the interactive loop is running with.
+pub(crate) async fn run_precmd<SE: brush_core::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
+    options: &InteractiveOptions,
+) -> Result<ControlFlow<brush_core::ExecutionResult>, ShellError> {
+    let Some(hook_names) = pending_hooks(shell, options, PRECMD_FUNCTIONS) else {
+        return Ok(ControlFlow::Continue(()));
+    };
+
+    dispatch(shell, PRECMD_FUNCTIONS, hook_names, None).await
+}
+
+/// Runs the `preexec` hooks for a line the user entered. Breaks with the result of one that
+/// exited the shell.
+///
+/// # Arguments
+///
+/// * `shell` - The shell to run the hooks in.
+/// * `options` - The options the interactive loop is running with.
+/// * `command_line` - The line as entered by the user; passed to each hook as `$1`.
+pub(crate) async fn run_preexec<SE: brush_core::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
+    options: &InteractiveOptions,
+    command_line: &str,
+) -> Result<ControlFlow<brush_core::ExecutionResult>, ShellError> {
+    // The registry is consulted ahead of `line_runs_a_command`, which parses: with no hook to
+    // run there is nothing to decide, and every typed line would pay for the answer.
+    let Some(hook_names) = pending_hooks(shell, options, PREEXEC_FUNCTIONS) else {
+        return Ok(ControlFlow::Continue(()));
+    };
+
+    if !line_runs_a_command(shell, command_line) {
+        return Ok(ControlFlow::Continue(()));
+    }
+
+    dispatch(
+        shell,
+        PREEXEC_FUNCTIONS,
+        hook_names,
+        Some(command_line.trim_end_matches('\n')),
+    )
+    .await
+}
+
+/// Whether zsh-style hooks are live for this shell: enabled by the options, and interactive
+/// in the `$-` sense (`script | brush -s` reads commands through the interactive loop but
+/// isn't). Setup and dispatch share this so they can't disagree.
+fn enabled<SE: brush_core::ShellExtensions>(
+    shell: &brush_core::Shell<SE>,
+    options: &InteractiveOptions,
+) -> bool {
+    options.zsh_style_hooks && shell.options().interactive
+}
+
+/// The entries `array_var_name` names, read once as `"${name[@]}"` would expand it -- or
+/// `None` when a dispatch would run nothing, so the caller can skip the rest of its work.
+/// The registries are seeded non-empty, so an entry naming a `precmd`/`preexec` nobody
+/// defined is the ordinary case, not an unusual one.
+fn pending_hooks<SE: brush_core::ShellExtensions>(
+    shell: &brush_core::Shell<SE>,
+    options: &InteractiveOptions,
+    array_var_name: &str,
+) -> Option<Vec<String>> {
+    if !enabled(shell, options) {
+        return None;
+    }
+
+    // Reads a shell variable as the list of words `"${name[@]}"` would expand to. An unset
+    // variable yields nothing; a scalar yields itself, since a scalar *is* element 0 in bash.
+    let hook_names = shell
+        .env_var(array_var_name)
+        .map(|var| var.value().element_values(shell))
+        .unwrap_or_default();
+
+    hook_names
+        .iter()
+        .any(|name| shell.funcs().get(name).is_some())
+        .then_some(hook_names)
+}
+
+/// Whether the line runs any command: blank, comment-only, and unparseable lines run none,
+/// and so dispatch no `preexec` -- matching the `DEBUG` trap bash-preexec dispatches from.
+/// Parsing is what answers this; a text test for "blank or all comment" would still miss the
+/// syntax error. So a shell with a `preexec` hook registered pays a parse of the line here and
+/// another in `run_string` moments later. (`parse_string` is cached, which often makes the
+/// second one free, but it's a bounded cache and nothing here should lean on a hit.)
+fn line_runs_a_command<SE: brush_core::ShellExtensions>(
+    shell: &brush_core::Shell<SE>,
+    line: &str,
+) -> bool {
+    shell
+        .parse_string(line)
+        .is_ok_and(|program| !program.complete_commands.is_empty())
+}
+
+/// Invokes the named hooks. Each sees what the last command left in `$?`, `PIPESTATUS`, and
+/// `$_`, restored before every hook and again afterwards. Breaks with the result of a hook
+/// that exited the shell. The full contract is in `docs/reference/zsh-hooks.md`.
+///
+/// # Arguments
+///
+/// * `shell` - The shell to run the hooks in.
+/// * `array_var_name` - The registry the names came from; used only in diagnostics.
+/// * `hook_names` - The registry's entries, already read.
+/// * `arg` - Optional argument to pass to each hook.
+async fn dispatch<SE: brush_core::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
+    array_var_name: &str,
+    hook_names: Vec<String>,
+    arg: Option<&str>,
+) -> Result<ControlFlow<brush_core::ExecutionResult>, ShellError> {
+    let saved_status = shell.save_command_status();
+
+    for hook_name in hook_names {
+        // Asked here rather than inferred from a `FunctionNotFound` error, which a hook body
+        // could raise on its own. Asked per entry, not once up front, so a hook that defines
+        // a later one in the same dispatch is honored -- as it is under bash-preexec, whose
+        // `type -t` guard also sits inside the loop.
+        if shell.funcs().get(&hook_name).is_none() {
+            tracing::debug!("{array_var_name}: skipping '{hook_name}'; not a function");
+            continue;
+        }
+
+        // Each hook sees the same status, whatever an earlier hook ran.
+        shell.restore_command_status(saved_status.clone());
+
+        // A failing hook is reported and the rest still run. (PROMPT_COMMAND differs: an
+        // error that escapes `run_string` there ends the interactive loop.)
+        match shell
+            .invoke_function(&hook_name, arg, shell.default_exec_params())
+            .await
+        {
+            // Returned without restoring: the shell is exiting, and `$?` belongs to the hook
+            // that exited it.
+            Ok(result) if result.is_exit() => return Ok(ControlFlow::Break(result)),
+            Ok(_) => {}
+            Err(e) => {
+                let mut stderr = shell.stderr();
+                let _ = shell.display_error(&mut stderr, &e);
+            }
+        }
+    }
+
+    shell.restore_command_status(saved_status);
+
+    Ok(ControlFlow::Continue(()))
+}
+
+/// Assigns to a global variable as `name=value` would: an existing variable keeps its
+/// attributes, and a readonly one rejects the assignment with an error.
+fn assign_global<SE: brush_core::ShellExtensions>(
+    shell: &mut brush_core::Shell<SE>,
+    name: &str,
+    value: ShellValueLiteral,
+) -> Result<(), brush_core::Error> {
+    shell.env_mut().update_or_add(
+        name,
+        value,
+        |_| Ok(()),
+        brush_core::env::EnvironmentLookup::Anywhere,
+        brush_core::env::EnvironmentScope::Global,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::panic_in_result_fn, reason = "assertions in a fallible test")]
+mod tests {
+    use super::*;
+
+    /// Builds a shell that zsh-style hooks would dispatch for, with `guard_readonly` marked
+    /// readonly beforehand so the assignments in [`init`] must fail.
+    async fn shell_with_readonly(
+        interactive: bool,
+        guard_readonly: &str,
+    ) -> Result<brush_core::Shell<brush_core::extensions::DefaultShellExtensions>, ShellError> {
+        let mut shell = brush_core::Shell::builder()
+            .interactive(interactive)
+            .profile(brush_core::ProfileLoadBehavior::Skip)
+            .rc(brush_core::RcLoadBehavior::Skip)
+            .build()
+            .await?;
+
+        let mut var = brush_core::ShellVariable::new("inherited");
+        var.set_readonly();
+        shell.env_mut().set_global(guard_readonly, var)?;
+
+        Ok(shell)
+    }
+
+    fn hooks_enabled() -> InteractiveOptions {
+        InteractiveOptions {
+            zsh_style_hooks: true,
+            ..Default::default()
+        }
+    }
+
+    /// Claiming the contract only partway would advertise hooks brush never registered, so
+    /// all four assignments are load-bearing and a rejection is fatal. Unit-tested because
+    /// only an embedder assigning before us can reach this state. The error kind is pinned
+    /// too: a bare `is_err()` would also pass on a panic or an unrelated failure.
+    #[tokio::test]
+    async fn init_fails_if_any_state_is_readonly() -> Result<(), ShellError> {
+        for name in [
+            "bash_preexec_imported",
+            "__bp_imported",
+            PRECMD_FUNCTIONS,
+            PREEXEC_FUNCTIONS,
+        ] {
+            let mut shell = shell_with_readonly(true, name).await?;
+            let result = init(&mut shell, &hooks_enabled());
+            assert!(
+                matches!(&result, Err(ShellError::ShellError(e))
+                    if matches!(e.kind(), brush_core::ErrorKind::ReadonlyVariable)),
+                "readonly '{name}' should have failed initialization as a readonly \
+                 violation; got: {result:?}"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// A shell the hooks won't dispatch for is left completely alone -- the readonly state
+    /// that would otherwise fail the assignments proves nothing was written. (A shell that
+    /// never reads commands interactively is the caller's business, and the `-c` and script
+    /// cases are covered end to end by `tests/cases/brush/zsh_hooks.yaml`.)
+    #[tokio::test]
+    async fn init_is_inert_when_hooks_are_off() -> Result<(), ShellError> {
+        // Enabled, but the shell isn't interactive in the `$-` sense.
+        let mut shell = shell_with_readonly(false, "bash_preexec_imported").await?;
+        init(&mut shell, &hooks_enabled())?;
+        assert!(shell.env_var(PRECMD_FUNCTIONS).is_none());
+
+        // Interactive, but the option is off.
+        let mut shell = shell_with_readonly(true, "bash_preexec_imported").await?;
+        init(&mut shell, &InteractiveOptions::default())?;
+        assert!(shell.env_var(PRECMD_FUNCTIONS).is_none());
+
+        Ok(())
+    }
+}

--- a/brush-shell/src/entry.rs
+++ b/brush-shell/src/entry.rs
@@ -336,6 +336,16 @@ async fn run_in_shell(
     let read_commands_from_stdin = args.will_read_commands_from_stdin();
     let interactive_options: brush_interactive::InteractiveOptions = ui_options.into();
 
+    // Before config files run, so they (and what they source) observe it -- and only for a
+    // shell that goes on to read commands interactively below, since only such a shell
+    // dispatches hooks.
+    if read_commands_from_stdin {
+        brush_interactive::init_zsh_style_hooks(
+            &mut *shell_ref.lock().await,
+            &interactive_options,
+        )?;
+    }
+
     // Load profile and rc files as appropriate.
     initialize_shell(shell_ref, &args).await?;
 

--- a/brush-shell/tests/cases/brush/zsh_hooks.yaml
+++ b/brush-shell/tests/cases/brush/zsh_hooks.yaml
@@ -1,0 +1,566 @@
+name: "zsh-style hook tests"
+# An interactive shell writes "exit" to stderr on the way out, so `expected_stderr` is
+# asserted only where stderr is itself the thing under test -- a case claiming a hook is
+# skipped "quietly", or one pinning a diagnostic. Elsewhere it is left off, and the
+# harness ignores it.
+cases:
+  # The hooks only fire from the interactive read loop. A shell reading commands from a
+  # pipe does *not* qualify, even though it reads them from stdin the same way -- so the
+  # bash-preexec inclusion guards must stay unclaimed and the arrays undeclared. Claiming
+  # them here would tell an integration that hooks are handled while nothing runs them,
+  # and firing hooks here lets a hook that reads stdin consume the script itself.
+  - name: "zsh hooks stay inert in a non-interactive shell"
+    args:
+      - "--enable-zsh-hooks"
+      - "-s"
+    stdin: |
+      preexec() { echo "PREEXEC-FIRED"; }
+      precmd() { echo "PRECMD-FIRED"; }
+      echo "guard=[${bash_preexec_imported:-unset}]"
+      echo "legacy=[${__bp_imported:-unset}]"
+      echo "precmds=[${precmd_functions[*]:-unset}]"
+      echo "preexecs=[${preexec_functions[*]:-unset}]"
+    expected_exit_code: 0
+    expected_stdout: |
+      guard=[unset]
+      legacy=[unset]
+      precmds=[unset]
+      preexecs=[unset]
+
+  # A hook that reads stdin must not be able to eat the script being piped in.
+  - name: "non-interactive zsh hooks cannot consume piped script lines"
+    args:
+      - "--enable-zsh-hooks"
+      - "-s"
+    stdin: |
+      precmd() { read -r junk; echo "ATE[$junk]"; }
+      precmd_functions=(precmd)
+      echo one
+      echo two
+      echo three
+    expected_exit_code: 0
+    expected_stdout: |
+      one
+      two
+      three
+
+  # `-i` makes the shell interactive in the `$-` sense, but a script still runs instead of
+  # the interactive loop; nothing may be claimed.
+  - name: "zsh hooks stay inert when -i runs a script"
+    args:
+      - "--enable-zsh-hooks"
+      - "-i"
+      - "script.sh"
+    test_files:
+      - path: "script.sh"
+        contents: |
+          echo "guard=[${bash_preexec_imported:-unset}] arrays=[${precmd_functions[*]:-unset}|${preexec_functions[*]:-unset}]"
+    expected_exit_code: 0
+    expected_stdout: |
+      guard=[unset] arrays=[unset|unset]
+
+  # `-c` runs a command instead of the interactive loop; nothing may be claimed.
+  - name: "zsh hooks stay inert when -c runs a command"
+    args:
+      - "--enable-zsh-hooks"
+      - "-c"
+      - 'echo "guard=[${bash_preexec_imported:-unset}] arrays=[${precmd_functions[*]:-unset}|${preexec_functions[*]:-unset}]"'
+    expected_exit_code: 0
+    expected_stdout: |
+      guard=[unset] arrays=[unset|unset]
+
+  # Without `-s` a shell fed by a pipe reads commands the same way; still not interactive.
+  - name: "zsh hooks stay inert reading a pipe without -s"
+    args:
+      - "--enable-zsh-hooks"
+    stdin: |
+      precmd() { echo "PRECMD-FIRED"; }
+      echo "guard=[${bash_preexec_imported:-unset}] arrays=[${precmd_functions[*]:-unset}]"
+    expected_exit_code: 0
+    expected_stdout: |
+      guard=[unset] arrays=[unset]
+
+  # `-i` makes a pipe-fed shell interactive, and that is the whole test: the contract is
+  # claimed before the first line runs, both hooks fire (precmd ahead of every prompt,
+  # including the one for EOF), each sees the last command's status, and neither hook's
+  # own non-zero return leaks into the next command's `$?` or `PIPESTATUS`.
+  - name: "zsh hooks fire when -i makes a pipe-fed shell interactive"
+    args:
+      - "--enable-zsh-hooks"
+      - "-i"
+      - "-s"
+    stdin: |
+      echo "guard=[${bash_preexec_imported:-unset}] arrays=[${precmd_functions[*]}|${preexec_functions[*]}]"
+      preexec() { echo "PREEXEC[$1]"; return 8; }; precmd() { echo "PRECMD[$?][${PIPESTATUS[*]}]"; return 9; }
+      (exit 4) | (exit 5)
+      echo "AFTER[$?][${PIPESTATUS[*]}]"
+    expected_exit_code: 0
+    expected_stdout: |
+      guard=[defined] arrays=[precmd|preexec]
+      PRECMD[0][0]
+      PREEXEC[(exit 4) | (exit 5)]
+      PRECMD[5][4 5]
+      PREEXEC[echo "AFTER[$?][${PIPESTATUS[*]}]"]
+      AFTER[5][4 5]
+      PRECMD[0][0]
+    expected_stderr: |
+      exit
+
+  # The guards and hook arrays are assigned the way `name=value` assigns, so a variable
+  # that already exists -- inherited from the environment, say -- keeps its attributes
+  # while taking the new value. It is not replaced wholesale.
+  - name: "zsh hook state is assigned without clobbering attributes"
+    args:
+      - "--enable-zsh-hooks"
+      - "-i"
+      - "-s"
+    env:
+      bash_preexec_imported: stale
+      precmd_functions: stale
+    stdin: |
+      declare -p bash_preexec_imported precmd_functions
+    expected_exit_code: 0
+    expected_stdout: |
+      declare -x bash_preexec_imported="defined"
+      declare -ax precmd_functions=([0]="precmd")
+
+  # `$?` and `PIPESTATUS` are restored before every hook, not just the first: a hook that
+  # runs a pipeline of its own doesn't change what the next one sees. There is no
+  # `BP_PIPESTATUS` copy; bash-preexec offers one only because it can't restore the original.
+  - name: "zsh hooks each see the command's own status and PIPESTATUS"
+    args:
+      - "--enable-zsh-hooks"
+      - "-i"
+      - "-s"
+    stdin: |
+      first() { echo "FIRST[$?][${PIPESTATUS[*]}][${BP_PIPESTATUS-unset}]"; true | false | true; }
+      second() { echo "SECOND[$?][${PIPESTATUS[*]}]"; }
+      precmd_functions=(first second); preexec_functions=(first second)
+      (exit 3) | (exit 4)
+    expected_exit_code: 4
+    expected_stdout: |
+      FIRST[0][0][unset]
+      SECOND[0][0]
+      FIRST[0][0][unset]
+      SECOND[0][0]
+      FIRST[4][3 4][unset]
+      SECOND[4][3 4]
+
+  # The command has already been entered into history when preexec runs. Integrations that
+  # inline bash-preexec commonly recover the command this way instead of trusting `$1`.
+  - name: "zsh preexec sees the command in history"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      preexec() { echo "HISTORY[$(history 1 | sed 's/^ *[0-9]* *//')]"; }
+      echo from-history
+    expected_exit_code: 0
+    expected_stdout: |
+      HISTORY[echo from-history]
+      from-history
+
+  # Hook errors are reported but do not abort the shell, overwrite the previous status, or
+  # prevent later hooks from running.
+  - name: "zsh precmd failures are non-fatal and preserve status"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      precmd() { local -r ro=1; ro=2; }; later() { echo LATER-RAN; }; precmd_functions=(precmd later)
+      (exit 6)
+      echo "AFTER[$?]"
+    expected_exit_code: 0
+    expected_stdout: |
+      LATER-RAN
+      LATER-RAN
+      AFTER[6]
+      LATER-RAN
+    expected_stderr: |
+      error: cannot mutate readonly variable
+      error: cannot mutate readonly variable
+      error: cannot mutate readonly variable
+      exit
+
+  - name: "zsh preexec failures are non-fatal"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      preexec() { local -r ro=1; ro=2; }
+      echo STILL-RAN
+    expected_exit_code: 0
+    expected_stdout: |
+      STILL-RAN
+    expected_stderr: |
+      error: cannot mutate readonly variable
+      exit
+
+  # A name that resolves to nothing is quiet, so a hook may be registered before it is
+  # defined -- matching bash-preexec, which guards each entry with `type -t`.
+  - name: "zsh hook registries skip names that resolve to nothing"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      precmd_functions=(not_defined)
+      not_defined() { echo LATE-RAN; }
+      echo QUIET
+    expected_exit_code: 0
+    expected_stdout: |
+      LATE-RAN
+      QUIET
+      LATE-RAN
+    # Asserted, because "quietly" is the whole claim: nothing but the interactive
+    # shell's own farewell may reach stderr.
+    expected_stderr: |
+      exit
+
+  # Every non-function entry is ignored the same way, whatever it happens to name: nothing
+  # at all, a directory, a file without the execute bit. There is no category that gets a
+  # diagnostic, so stderr is asserted rather than waved past -- and with no message there
+  # is no OS-specific errno text to make the expectation unportable.
+  - name: "zsh hook names that are not functions are skipped quietly"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    test_files:
+      - path: "not-executable"
+        contents: |
+          #!/bin/sh
+          echo SHOULD-NOT-RUN
+      - path: "a-directory/keep"
+        contents: "placeholder so the directory exists\n"
+    stdin: |
+      later() { echo LATER-RAN; }; precmd_functions=(./not-executable ./a-directory later)
+      echo REAL
+    expected_exit_code: 0
+    expected_stdout: |
+      LATER-RAN
+      REAL
+      LATER-RAN
+    expected_stderr: |
+      exit
+
+  # Only shell functions are dispatched -- as zsh does, and deliberately unlike bash-preexec,
+  # whose `type -t` guard also admits builtins and externals. Rationale in
+  # docs/reference/zsh-hooks.md, under `Differences`.
+  - name: "zsh hooks run shell functions only, ignoring builtins and programs"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    test_files:
+      - path: "external-hook"
+        executable: true
+        contents: |
+          #!/bin/sh
+          echo "EXTERNAL-RAN[$#][$1]"
+    stdin: |
+      real() { echo "FUNCTION-RAN[$#][$1]"; }; precmd_functions=(./external-hook echo true real); preexec_functions=(./external-hook echo true real)
+      echo REAL
+    expected_exit_code: 0
+    expected_stdout: |
+      FUNCTION-RAN[0][]
+      FUNCTION-RAN[1][echo REAL]
+      REAL
+      FUNCTION-RAN[0][]
+    expected_stderr: |
+      exit
+
+  # A function shadowing a builtin name is still dispatched: the rule is "look the name up as
+  # a function", not "reject names that are builtins". zsh behaves the same way.
+  - name: "zsh hooks dispatch a function that shadows a builtin"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      true() { echo SHADOWING-FUNCTION-RAN; }; precmd_functions=(true)
+      echo REAL
+    expected_exit_code: 0
+    expected_stdout: |
+      SHADOWING-FUNCTION-RAN
+      REAL
+      SHADOWING-FUNCTION-RAN
+    expected_stderr: |
+      exit
+
+  # A hook name is invoked as a single already-expanded word, so a name holding spaces or
+  # glob characters is looked up verbatim -- and, finding nothing, skipped quietly. This is
+  # bash-preexec's behavior too: it invokes `"$precmd_function"`, quoted.
+  - name: "zsh hook names are not re-expanded"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    test_files:
+      - path: "hook with space"
+        executable: true
+        contents: |
+          #!/bin/sh
+          echo SHOULD-NOT-RUN
+    stdin: |
+      precmd_functions=("echo hi" "*")
+      echo QUIET
+    expected_exit_code: 0
+    expected_stdout: |
+      QUIET
+    expected_stderr: |
+      exit
+
+  # Additional array entries receive the preexec command line, and both registries run in
+  # array order. Replacing the array removes the seeded bare hook like any other entry.
+  - name: "zsh hook arrays pass arguments and preserve order"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      preexec() { echo BARE-PREEXEC; }; precmd() { echo BARE-PRECMD; }; pre_a() { echo "PRE-A[$1]"; }; pre_b() { echo "PRE-B[$1]"; }; post_a() { echo "POST-A[$?]"; }; post_b() { echo "POST-B[$?]"; }; preexec_functions=(pre_a pre_b); precmd_functions=(post_a post_b)
+      (exit 7)
+    expected_exit_code: 7
+    expected_stdout: |
+      POST-A[0]
+      POST-B[0]
+      PRE-A[(exit 7)]
+      PRE-B[(exit 7)]
+      POST-A[7]
+      POST-B[7]
+
+  # Each registry is read once per dispatch, so a hook that edits it is heeded from the next
+  # dispatch on -- never mid-loop. `added` is appended during the second dispatch but doesn't
+  # run until the third.
+  - name: "zsh hook registry edits take effect on the next dispatch"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      grower() { echo GROWER; precmd_functions+=(added); }; added() { echo ADDED; }; precmd_functions=(grower)
+      echo COMMAND
+    expected_exit_code: 0
+    expected_stdout: |
+      GROWER
+      COMMAND
+      GROWER
+      ADDED
+
+  # Claiming the inclusion guards makes a subsequently sourced bash-preexec implementation
+  # return before installing its own dispatch machinery. The preamble below is verbatim
+  # from bash-preexec v0.7.0 (MIT; https://github.com/rcaloras/bash-preexec), so this
+  # exercises the real bail-out path rather than a hand-written approximation of it --
+  # including the two version checks that run *ahead* of the guard, which brush must also
+  # satisfy for the guard to matter at all. Everything after it stands in for the ~500
+  # lines that install the `DEBUG` trap and rewrite `PROMPT_COMMAND`; none of it may run.
+  - name: "sourcing bash-preexec after initialization is a no-op"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    test_files:
+      - path: "bash-preexec.sh"
+        contents: |
+          # Make sure this is bash that's running and return otherwise.
+          # Use POSIX syntax for this line:
+          if [ -z "${BASH_VERSION-}" ]; then
+              return 1
+          fi
+
+          # We only support Bash 3.1+.
+          # Note: BASH_VERSINFO is first available in Bash-2.0.
+          if [[ -z "${BASH_VERSINFO-}" ]] || (( BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1) )); then
+              return 1
+          fi
+
+          # Avoid duplicate inclusion
+          if [[ -n "${bash_preexec_imported:-}" || -n "${__bp_imported:-}" ]]; then
+              return 0
+          fi
+          bash_preexec_imported="defined"
+
+          # WARNING: This variable is no longer used and should not be relied upon.
+          # Use ${bash_preexec_imported} instead.
+          # shellcheck disable=SC2034
+          __bp_imported="${bash_preexec_imported}"
+
+          echo BASH-PREEXEC-INSTALLED
+          trap 'echo BASH-PREEXEC-DEBUG-TRAP' DEBUG
+    stdin: |
+      source ./bash-preexec.sh
+      echo "SOURCED[$?] GUARDS[$bash_preexec_imported|$__bp_imported]"
+    expected_exit_code: 0
+    expected_stdout: |
+      SOURCED[0] GUARDS[defined|defined]
+    expected_stderr: |
+      exit
+
+  # `exit` from a hook terminates the shell immediately. Later hooks, PROMPT_COMMAND, and the
+  # pending user command do not run.
+  - name: "exit from zsh precmd stops remaining prompt actions"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      first() { exit 7; }; never() { echo NEVER-HOOK; }; precmd_functions=(first never); PROMPT_COMMAND='echo NEVER-PROMPT'
+      echo NEVER-COMMAND
+    expected_exit_code: 7
+    expected_stdout: ""
+    expected_stderr: |
+      exit
+
+  - name: "exit from zsh preexec stops the command"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      preexec() { exit 5; }
+      echo NEVER-COMMAND
+    expected_exit_code: 5
+    expected_stdout: ""
+    expected_stderr: |
+      exit
+
+  - name: "exit from PROMPT_COMMAND exits the interactive shell"
+    args: ["-i", "-s"]
+    stdin: |
+      PROMPT_COMMAND='exit 3'
+      echo NEVER-COMMAND
+    expected_exit_code: 3
+    expected_stdout: ""
+    expected_stderr: |
+      exit
+
+  # Hook state belongs to this shell only. Exporting it would incorrectly tell a child bash
+  # that bash-preexec is installed there too.
+  - name: "zsh hook guards and registries are not exported"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      case "$(export -p)" in *bash_preexec_imported*|*__bp_imported*|*precmd_functions*|*preexec_functions*) echo EXPORTED;; *) echo NOT-EXPORTED;; esac
+      echo "guards=[$bash_preexec_imported|$__bp_imported]"
+    expected_exit_code: 0
+    expected_stdout: |
+      NOT-EXPORTED
+      guards=[defined|defined]
+
+  # A line that runs no command doesn't invoke preexec: bash-preexec dispatches from the
+  # DEBUG trap, which fires per command, so blank lines, whitespace, and comment-only lines
+  # produce nothing. A comment *after* a command is still a command line, so it does.
+  - name: "zsh preexec skips lines that run no command"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: "preexec() { echo \"PREEXEC[$1]\"; }\n\n   \n# just a comment\n   # indented comment\necho REAL # trailing comment\n"
+    expected_exit_code: 0
+    expected_stdout: |
+      PREEXEC[echo REAL # trailing comment]
+      REAL
+
+  # A line that doesn't parse runs no command either, so it invokes no preexec.
+  - name: "zsh preexec skips a syntax error"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      preexec() { echo "PREEXEC[$1]"; }
+      echo )
+      echo REAL
+    expected_exit_code: 0
+    expected_stdout: |
+      PREEXEC[echo REAL]
+      REAL
+    expected_stderr: |
+      error: main: syntax error at line 1 col 6
+      exit
+
+  # `$_` is restored alongside `$?` and `PIPESTATUS`: before every hook, so each one sees the
+  # last *user* command's last argument rather than an earlier hook's, and again afterwards,
+  # so the next command does too. The hooks report only when `$_` holds the sentinel, which
+  # keeps the earlier dispatches -- whose `$_` is the shell's own path -- out of the
+  # expectation.
+  - name: "zsh hooks preserve the last argument in $_"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      precmd() { case $_ in USER-ARG) echo "PRECMD-SEES[$_]";; esac; true PRECMD-ARG; }; preexec() { case $_ in USER-ARG) echo "PREEXEC-SEES[$_]";; esac; true PREEXEC-ARG; }
+      true USER-ARG
+      echo "UNDERSCORE[$_]"
+    expected_exit_code: 0
+    expected_stdout: |
+      PRECMD-SEES[USER-ARG]
+      PREEXEC-SEES[USER-ARG]
+      UNDERSCORE[USER-ARG]
+
+  # With the feature disabled, neither the contract nor dispatch is active even in an
+  # interactive shell.
+  - name: "zsh hooks are inert when disabled"
+    args: ["-i", "-s"]
+    stdin: |
+      precmd() { echo PRECMD-RAN; }; preexec() { echo PREEXEC-RAN; }
+      echo "state=[${bash_preexec_imported:-unset}|${__bp_imported:-unset}|${precmd_functions[*]:-unset}|${preexec_functions[*]:-unset}]"
+    expected_exit_code: 0
+    expected_stdout: |
+      state=[unset|unset|unset|unset]
+
+  # Native precmd dispatch occurs before PROMPT_COMMAND, matching bash-preexec's dispatcher.
+  - name: "zsh precmd runs before PROMPT_COMMAND"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      precmd() { echo PRECMD-FIRST; }; PROMPT_COMMAND='echo PROMPT-SECOND'
+      echo COMMAND
+    expected_exit_code: 0
+    expected_stdout: |
+      PRECMD-FIRST
+      PROMPT-SECOND
+      COMMAND
+      PRECMD-FIRST
+      PROMPT-SECOND
+
+  # The status snapshot is put back after the last precmd hook too, not just between hooks,
+  # so PROMPT_COMMAND -- which bash-preexec reaches through the same dispatcher -- sees what
+  # the user's command left behind rather than what a hook did.
+  - name: "zsh precmd leaves no trace in what PROMPT_COMMAND sees"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      precmd() { true | false; return 3; }; PROMPT_COMMAND='echo "PC[$?][${PIPESTATUS[*]}][$_]"'
+      true PROMPT-ARG
+      (exit 9) | (exit 8)
+    expected_exit_code: 8
+    expected_stdout: |
+      PC[0][0][]
+      PC[0][0][PROMPT-ARG]
+      PC[8][9 8][PROMPT-ARG]
+
+  # A hook registry that ended up a scalar still dispatches. bash-preexec iterates
+  # `"${precmd_functions[@]}"`, and in bash a scalar *is* element 0, so it runs the hook;
+  # skipping it here would silently drop hooks from a registry that still expands and
+  # prints exactly as the user wrote it.
+  - name: "zsh hook registry is read as a word list, scalar included"
+    args:
+      - "--enable-zsh-hooks"
+      - "-i"
+      - "-s"
+    stdin: |
+      my_precmd() { echo "SCALAR-PRECMD"; }; my_preexec() { echo "SCALAR-PREEXEC[$1]"; }; unset precmd_functions preexec_functions; precmd_functions=my_precmd; preexec_functions=my_preexec
+      declare -p precmd_functions
+    expected_exit_code: 0
+    expected_stdout: |
+      SCALAR-PRECMD
+      SCALAR-PREEXEC[declare -p precmd_functions]
+      declare -- precmd_functions="my_precmd"
+      SCALAR-PRECMD
+
+  # preexec gets the command line as entered, newlines included. (bash-preexec reads
+  # `history 1` instead, which with `cmdhist` is the same command joined onto one line.)
+  - name: "zsh preexec receives a multi-line command verbatim"
+    args:
+      - "--enable-zsh-hooks"
+      - "-i"
+      - "-s"
+    stdin: |
+      preexec() { echo "PREEXEC<$1>"; }
+      for i in 1 2; do
+        echo "loop $i"
+      done
+    expected_exit_code: 0
+    expected_stdout: |
+      PREEXEC<for i in 1 2; do
+        echo "loop $i"
+      done>
+      loop 1
+      loop 2
+
+  # `errexit` applies to a hook the way bash applies it to the PROMPT_COMMAND that
+  # bash-preexec dispatches from: a hook that returns non-zero exits the shell, and the
+  # remaining hooks don't run. Without `set -e` (see the failure cases above) the same
+  # non-zero return is ignored. Both dispatch sites are checked because they sit on
+  # different paths -- one ahead of the prompt, one ahead of the command.
+  - name: "zsh precmd obeys errexit like PROMPT_COMMAND"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      precmd() { echo PRECMD; false; }; later() { echo LATER; }; precmd_functions=(precmd later)
+      set -e
+      echo NEVER
+    expected_exit_code: 1
+    expected_stdout: |
+      PRECMD
+      LATER
+      PRECMD
+    expected_stderr: |
+      exit
+
+  - name: "zsh preexec obeys errexit and stops the command"
+    args: ["--enable-zsh-hooks", "-i", "-s"]
+    stdin: |
+      preexec() { echo PREEXEC; false; }
+      set -e
+      echo NEVER
+    expected_exit_code: 1
+    expected_stdout: |
+      PREEXEC
+      PREEXEC
+    expected_stderr: |
+      exit

--- a/brush-shell/tests/interactive_tests.rs
+++ b/brush-shell/tests/interactive_tests.rs
@@ -130,7 +130,7 @@ fn run_pipeline_interactively() -> anyhow::Result<()> {
 #[test]
 fn login_shell_via_argv0_shows_prompt() -> anyhow::Result<()> {
     let mut session = start_shell_session_with(|cmd| {
-        cmd.arg0("-brush");
+        cmd.arg("--norc").arg0("-brush");
     })?;
 
     session.expect_prompt()?;
@@ -145,9 +145,10 @@ fn login_shell_via_argv0_shows_prompt() -> anyhow::Result<()> {
 #[test]
 fn dash_s_with_positional_args_is_interactive() -> anyhow::Result<()> {
     // With `-s`, trailing words are positional parameters and commands still come from
-    // stdin -- so at a terminal the shell is interactive, and `PROMPT_COMMAND` runs.
+    // stdin -- so at a terminal the shell is interactive, and `PROMPT_COMMAND` and the
+    // zsh-style hooks (which are gated on that) run.
     let mut session = start_shell_session_with(|cmd| {
-        cmd.args(["-s", "myarg"]);
+        cmd.args(["--norc", "-s", "myarg"]);
     })?;
 
     session.expect_prompt()?;
@@ -167,6 +168,83 @@ fn dash_s_with_positional_args_is_interactive() -> anyhow::Result<()> {
     );
 
     session.exit()?;
+
+    Ok(())
+}
+
+#[test]
+fn zsh_style_hook_state_is_visible_to_rc_files() -> anyhow::Result<()> {
+    // The generic YAML harness always passes --norc, so this ordering check must use a PTY
+    // session that can load a dedicated rc file.
+    let rc_file = temp_script(
+        r#"echo "RC-GUARD[${bash_preexec_imported:-unset}] RC-ARRAYS[${precmd_functions[*]:-unset}|${preexec_functions[*]:-unset}]"
+rc_precmd() { echo RC-PRECMD; }
+precmd_functions+=(rc_precmd)
+"#,
+    )?;
+
+    let mut session = start_shell_session_with(|cmd| {
+        cmd.arg("--enable-zsh-hooks")
+            .arg("--rcfile")
+            .arg(rc_file.path());
+    })?;
+
+    session.expect("RC-GUARD[defined] RC-ARRAYS[precmd|preexec]")?;
+    session.expect("RC-PRECMD")?;
+    session.expect_prompt()?;
+
+    let output = session.exec_output("echo trigger")?;
+    assert!(output.contains("RC-PRECMD"));
+
+    session.exit()?;
+
+    Ok(())
+}
+
+/// Terminal shell integration brackets each command with a matched pair of OSC 633 markers:
+/// `E`/`C` before it runs, `D` after. A `preexec` hook that exits the shell means the command
+/// never runs, so neither marker may be emitted -- a lone `D` desynchronizes a terminal's
+/// command tracking.
+#[test]
+fn osc_command_markers_stay_paired_when_preexec_exits() -> anyhow::Result<()> {
+    const COMMAND_STARTED: &str = "\x1b]633;C";
+    const COMMAND_FINISHED: &str = "\x1b]633;D";
+
+    let mut session = start_shell_session_with(|cmd| {
+        cmd.args([
+            "--norc",
+            "--enable-zsh-hooks",
+            "--enable-terminal-integration",
+        ]);
+        // OSC 633 is emitted only for terminals known to understand it.
+        cmd.env("TERM_PROGRAM", "vscode");
+    })?;
+    session.expect_prompt()?;
+
+    // A command that does run gets the full pair. (`preexec` isn't defined yet when this line
+    // is dispatched, so the hook doesn't fire for it.)
+    session.send_line("preexec() { case $1 in stop) exit 5;; esac; }")?;
+    session
+        .expect(COMMAND_STARTED)
+        .context("no command-started marker for a command that ran")?;
+    session
+        .expect(COMMAND_FINISHED)
+        .context("no command-finished marker for a command that ran")?;
+    session.expect_prompt()?;
+
+    // The hook exits before this line runs, so it gets neither marker.
+    session.send_line("stop")?;
+    // `Eof` matches the whole remaining buffer, so the bytes seen since the last prompt are
+    // the match itself; `before()` would be empty.
+    let captures = session
+        .expect(expectrl::Eof)
+        .context("shell did not exit")?;
+    let tail = String::from_utf8_lossy(captures.as_bytes()).into_owned();
+
+    assert!(
+        !tail.contains(COMMAND_STARTED) && !tail.contains(COMMAND_FINISHED),
+        "a command that never ran emitted markers: {tail:?}"
+    );
 
     Ok(())
 }
@@ -205,10 +283,22 @@ impl SessionExt for ShellSession {
     }
 }
 
-fn start_shell_session() -> anyhow::Result<ShellSession> {
-    start_shell_session_with(|_| {})
+/// Writes `contents` to a temporary file that is deleted on drop.
+fn temp_script(contents: &str) -> anyhow::Result<tempfile::NamedTempFile> {
+    use std::io::Write as _;
+
+    let mut file = tempfile::NamedTempFile::new()?;
+    file.write_all(contents.as_bytes())?;
+    Ok(file)
 }
 
+fn start_shell_session() -> anyhow::Result<ShellSession> {
+    start_shell_session_with(|cmd| _ = cmd.arg("--norc"))
+}
+
+/// Starts a shell session at a pty. `configure` is the only place arguments and environment
+/// come from beyond the fixed set below, so a session says for itself what it wants -- notably
+/// `--norc`, or the `--rcfile` that a session wanting an rc file passes instead.
 fn start_shell_session_with(
     configure: impl FnOnce(&mut std::process::Command),
 ) -> anyhow::Result<ShellSession> {
@@ -217,7 +307,6 @@ fn start_shell_session_with(
 
     let mut cmd = std::process::Command::new(shell_path);
     cmd.args([
-        "--norc",
         "--noprofile",
         "--no-config",
         "--disable-bracketed-paste",

--- a/brush-shell/tests/reedline_interactive_tests.rs
+++ b/brush-shell/tests/reedline_interactive_tests.rs
@@ -36,6 +36,10 @@ const PROMPT: &str = "brush> ";
 const DSR_QUERY: &str = "\x1b[6n";
 const DSR_REPLY: &str = "\x1b[1;1R";
 
+/// OSC 633 markers bracketing a command: emitted before it runs, and after.
+const COMMAND_STARTED: &str = "\x1b]633;C";
+const COMMAND_FINISHED: &str = "\x1b]633;D";
+
 /// A key bound with `bind -x` must run its command and leave the shell
 /// alive. Regression test for reedline >= 0.48 delivering such keys as
 /// `Signal::HostCommand`, which previously fell through to a fatal
@@ -62,6 +66,77 @@ fn bound_key_runs_command_and_shell_survives() -> anyhow::Result<()> {
     session
         .expect("STILL_42")
         .context("shell did not survive the bound command")?;
+
+    Ok(())
+}
+
+/// `preexec` fires for lines the user typed, not for a command a key binding ran. The
+/// hooks exist to observe what the user is about to run; bash-preexec has the same split,
+/// because a `bind -x` command runs from readline rather than from the command line.
+#[test]
+fn bound_key_command_does_not_fire_preexec() -> anyhow::Result<()> {
+    let mut session = start_reedline_session_with(|cmd| {
+        cmd.arg("--enable-zsh-hooks");
+    })?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // The hook counts its dispatches as well as reporting its argument, so a stray dispatch
+    // for the bound command can't hide between the markers below. Markers are split so the
+    // echoed keystrokes of the setup lines can't satisfy the expectations.
+    session.send_line(r#"preexec() { n=$((n+1)); echo "PRE_""EXEC[$1]"; }"#)?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // Dispatch 1, for this line.
+    session.send_line(r#"bind -x '"\C-t": echo BOUND_""FIRED'"#)?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // Ctrl+T. The bound command runs, but nothing was typed, so no dispatch.
+    session.send("\x14")?;
+    session
+        .expect("BOUND_FIRED")
+        .context("bound command did not run")?;
+    expect_next_prompt(&mut session, 0).context("no prompt after bound command")?;
+
+    // Dispatch 2, for this line -- `$n` expands after the hook has already run, so a third
+    // dispatch anywhere would show up here.
+    session.send_line("echo COUNT_$n")?;
+    session
+        .expect("PRE_EXEC[echo COUNT_$n]")
+        .context("preexec did not fire for a typed line")?;
+    session
+        .expect("COUNT_2")
+        .context("preexec fired for something other than the two typed lines")?;
+
+    Ok(())
+}
+
+/// A command a key binding runs is bracketed by the same OSC 633 marker pair as a typed one.
+/// Terminals track commands by that pair, so emitting only the closing marker -- as this path
+/// used to -- leaves one counting a command that never started.
+#[test]
+fn osc_command_markers_stay_paired_for_a_bound_command() -> anyhow::Result<()> {
+    let mut session = start_reedline_session_with(|cmd| {
+        cmd.arg("--enable-terminal-integration");
+        // OSC 633 is emitted only for terminals known to understand it.
+        cmd.env("TERM_PROGRAM", "vscode");
+    })?;
+    expect_next_prompt(&mut session, 0)?;
+
+    session.send_line(r#"bind -x '"\C-t": echo BOUND_""FIRED'"#)?;
+    expect_next_prompt(&mut session, 0)?;
+
+    // Ctrl+T. The bound command runs without the user typing a line, but it is still a
+    // command, so it gets both markers around it.
+    session.send("\x14")?;
+    session
+        .expect(COMMAND_STARTED)
+        .context("no command-started marker for the bound command")?;
+    session
+        .expect("BOUND_FIRED")
+        .context("bound command did not run")?;
+    session
+        .expect(COMMAND_FINISHED)
+        .context("no command-finished marker for the bound command")?;
 
     Ok(())
 }
@@ -142,6 +217,12 @@ fn expect_next_prompt(session: &mut ShellSession, mut withhold: usize) -> anyhow
 }
 
 fn start_reedline_session() -> anyhow::Result<ShellSession> {
+    start_reedline_session_with(|_| {})
+}
+
+fn start_reedline_session_with(
+    configure: impl FnOnce(&mut std::process::Command),
+) -> anyhow::Result<ShellSession> {
     let shell_path = assert_cmd::cargo::cargo_bin!("brush");
 
     let mut cmd = std::process::Command::new(shell_path);
@@ -155,6 +236,7 @@ fn start_reedline_session() -> anyhow::Result<ShellSession> {
     ]);
     cmd.env("PS1", PROMPT);
     cmd.env("TERM", "xterm-256color");
+    configure(&mut cmd);
 
     let session = expectrl::session::Session::spawn(cmd)?;
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,6 +4,7 @@ These documents serve as reference material for the `brush` project.
 
 * [Configuration file](configuration.md)
 * [Experimental features](experimental.md)
+* [zsh-style hooks](zsh-hooks.md)
 * [Integration testing](integration-testing.md)
 * [Minimum Supported Rust Version (MSRV) policy](msrv-policy.md)
 * [Compatibility](compatibility.md)

--- a/docs/reference/experimental.md
+++ b/docs/reference/experimental.md
@@ -110,20 +110,24 @@ terminal-shell-integration = true
 
 ### `zsh-hooks`
 
-Enables zsh-style `preexec` and `precmd` hook functions. When set:
+Enables zsh-style `precmd` and `preexec` hook functions, registered through
+the `precmd_functions` and `preexec_functions` arrays. This is what prompt
+frameworks, command timers, and history tools expect; in stock bash the
+same effect requires `DEBUG`/`PROMPT_COMMAND` plumbing.
 
-- A function named `preexec` (if defined) is invoked before each
-  interactively-entered command runs, with the command line as `$1`.
-- A function named `precmd` (if defined) is invoked just before each
-  prompt is displayed.
-
-This is convenient for prompt frameworks, command timing, and
-integrations that expect zsh-style hook conventions. Equivalent
-behavior in stock bash typically requires `DEBUG`/`PROMPT_COMMAND`
-plumbing.
+brush implements the hooks natively, with bash semantics, taking
+[bash-preexec](https://github.com/rcaloras/bash-preexec) as the reference for
+what the hooks mean in a bash shell. It also claims bash-preexec's inclusion
+guards, so an integration that sources bash-preexec (or inlines a copy of it,
+as atuin does) finds it already loaded and leaves the hooks to brush rather
+than dispatching them a second time.
 
 Enable persistently with `zsh-hooks = true` under `[experimental]` in
 `config.toml`, or per-invocation with `brush --enable-zsh-hooks`.
+
+See [zsh-style hooks](zsh-hooks.md) for the full contract: what each hook
+sees, which entries are dispatched, and where brush differs from zsh and
+from bash-preexec.
 
 ### `terminal-shell-integration`
 

--- a/docs/reference/zsh-hooks.md
+++ b/docs/reference/zsh-hooks.md
@@ -1,0 +1,112 @@
+# zsh-style hooks (`precmd` and `preexec`)
+
+An [experimental feature](experimental.md). Enable it persistently with
+`zsh-hooks = true` under `[experimental]` in `config.toml`, or per-invocation
+with `brush --enable-zsh-hooks`.
+
+zsh defines these hooks, and prompt frameworks, command timers, and history
+tools (atuin, starship, and friends) are built on them. brush provides a
+bash-native adaptation: the hooks live in the shell itself, with bash semantics,
+rather than in the `DEBUG`/`PROMPT_COMMAND` plumbing stock bash needs to
+approximate them.
+
+[bash-preexec](https://github.com/rcaloras/bash-preexec) is the adaptation of
+the same hooks the ecosystem already builds on, so it is what settles the
+details zsh leaves open for a bash shell, and what brush interoperates with —
+see [below](#relationship-to-bash-preexec).
+
+## The hooks
+
+| Registry | When it runs | Arguments |
+|----------|--------------|-----------|
+| `precmd_functions` | before each prompt is displayed, ahead of `PROMPT_COMMAND` | none |
+| `preexec_functions` | after a command line is read, before it runs | the command line, as `$1` |
+
+The two arrays start out as `(precmd)` and `(preexec)`, so defining a function by
+either name is enough. Register more by appending — `preexec_functions+=(my_fn)` —
+and they run in array order. Each array is read once per dispatch, so a hook that
+edits one is heeded from the next dispatch on.
+
+Every entry names a **shell function**. The name is looked up as a single,
+already-expanded word: never re-split, glob-expanded, or resolved against `PATH`.
+An entry that isn't a shell function is skipped quietly, so a hook may be
+registered before it is defined.
+
+Hooks are active only in interactive shells, in the `$-` sense that also decides
+whether rc files are loaded. `brush -s < script` does not qualify and claims none
+of the bash-preexec state below; `brush -i -s < script` does, so a hook that reads
+standard input there consumes the script's own lines.
+
+`preexec` fires only for a line that runs a command: blank lines, comment-only
+lines, and syntax errors dispatch nothing, matching the `DEBUG` trap bash-preexec
+dispatches from. Only lines the user typed dispatch it — a command run from a key
+binding does not.
+
+## What a hook sees
+
+- `$?`, `PIPESTATUS`, and `$_` hold what the last command left behind. All three
+  are restored before every hook and again afterwards, so nothing a hook runs is
+  visible to the next hook, to `PROMPT_COMMAND`, or to the next command.
+- A hook that fails has its error reported; the remaining hooks still run. Under `set -e` a
+  non-zero return exits the shell instead, exactly as it does from `PROMPT_COMMAND`.
+- A hook that calls `exit` exits the shell. Nothing after it runs: no later hook,
+  no `PROMPT_COMMAND`, and not the command line `preexec` was dispatched for.
+
+## Relationship to bash-preexec
+
+The two must not both be live: bash-preexec's `DEBUG` trap would dispatch the
+same hooks a second time. So brush claims bash-preexec's interlock as well as
+its behavior — the `bash_preexec_imported` and legacy `__bp_imported` inclusion
+guards, along with the two arrays, are set before profile and rc files load. A
+copy of bash-preexec sourced afterwards — including the one tools such as atuin inline into their
+`init` output — finds itself already loaded and returns, leaving the hooks to
+brush rather than installing its `DEBUG`-trap emulation.
+[ble.sh](https://github.com/akinomyoga/ble.sh) takes the same approach.
+
+All four are set the way `name=value` sets a variable: nothing is exported, so a
+child bash still gets the real implementation, but one that already existed keeps
+its attributes. A guard or registry inherited from the environment therefore stays
+exported.
+
+Because brush seeds the arrays before rc files rather than appending after them,
+an rc file that appends gets `(precmd mine)`, where sourcing bash-preexec after
+the same append would give `(mine precmd)`.
+
+Clearing the guards is not a supported way to hand the hooks back. brush keeps dispatching,
+so a bash-preexec sourced after they are cleared installs itself over the same registries and
+every hook runs twice. To use the real bash-preexec, leave this feature off.
+
+The claim covers bash-preexec's documented surface and no more: the two hook
+names, the two arrays, and the inclusion guards. None of its `__bp_*` internals
+exist, and `precmd` hooks are not reachable through `PROMPT_COMMAND` the way its
+dispatcher is.
+
+### `BP_PIPESTATUS` is not provided
+
+bash-preexec offers `BP_PIPESTATUS` because its hooks run from `PROMPT_COMMAND`,
+by which point the real `PIPESTATUS` is gone. brush restores `PIPESTATUS` itself,
+so a hook reads it directly. There is no copy, and none is planned. A hook that
+must work under both can fall back in one expansion:
+
+```bash
+statuses=("${BP_PIPESTATUS[@]:-${PIPESTATUS[@]}}")
+```
+
+## Differences
+
+| | brush | zsh | bash-preexec |
+|---|---|---|---|
+| `preexec` `$1` | the line as typed, interior newlines included (the trailing one is trimmed) | the same | what `history 1` reports, which under `cmdhist` joins the command onto one line |
+| `preexec` `$2` and `$3` | not passed | single-line and fully-expanded forms of the command | not passed |
+| entries that aren't shell functions | skipped | skipped | run, when `type -t` finds a builtin or a program |
+| `PIPESTATUS` inside a hook | the real one | n/a | gone; `BP_PIPESTATUS` holds a copy |
+
+brush matches zsh on `$1`: zsh passes the string the user typed, verbatim
+(verified against zsh 5.9). A hook that needs the command on one line can read
+`history 1` itself — it is already in the history when `preexec` runs.
+
+Only functions run because that is what zsh does and what bash-preexec's own
+usage notes tell you to register. Admitting programs would let a misspelled or
+not-yet-defined function name fall through to a same-named program on `PATH` and
+run it before every prompt. Wrap such a command in a function
+(`log_cmd() { logger "$1"; }`) and register that.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -67,6 +67,10 @@ context is `e2e/`, so it can `COPY shim /e2e/bin`) whose entrypoint:
    own knob for which shell to test (atuin's `ATUIN_TEST_BASH`), set that
    instead and skip the shim; a shim on `PATH` also captures test tooling
    written in bash (tmux, say), which must not run under the shell under test.
+   A suite that takes a shell *path* has nowhere to put a command-line flag; turn
+   the behavior on through brush's config file (`$HOME/.config/brush/config.toml`,
+   and `HOME` is `/tmp` in the container) instead, which bash ignores and so leaves
+   the baseline run alone.
 2. **Writes results** to `/results`: `log.txt` plus JUnit XML under
    `junit/`. Write whatever else helps debugging there too.
 3. **Exits non-zero** when any test fails. Entrypoints pipe the runner through
@@ -138,7 +142,7 @@ what they would otherwise each reinvent:
 | app | notes |
 |-----|-------|
 | fzf | upstream `test/test_shell_integration.rb`, `TestBash` only; minitest + tmux, JUnit via `minitest-ci` |
-| atuin | our own suite in `atuin/tests/` (pytest + tmux), written to be upstreamable |
+| atuin | our own suite in `atuin/tests/` (pytest + tmux), written to be upstreamable. atuin's bash integration is bash-preexec, so the adapter turns on brush's `zsh-hooks` through a config file to exercise the native hooks rather than the `DEBUG`-trap emulation |
 | blesh | upstream `ble.sh --test`, one pytest case per test section with a process-group timeout (`BLESH_TEST_TIMEOUT`, default 180s); sections are read from ble.sh's own build output, so a section added upstream runs rather than being missed; full output and leftover per-section artifacts are retained; args select sections: `cargo xtask test e2e blesh -- util`. Every section is currently expected to fail: ble.sh gets far enough to emit no section summary at all |
 | mise | selected upstream bash activation tests (pytest), run directly against the shell under test |
 | nvm | upstream `test/fast/Listing versions` suite (urchin) plus interactive regression coverage for [#1173](https://github.com/reubeno/brush/issues/1173) |

--- a/e2e/atuin/entrypoint.sh
+++ b/e2e/atuin/entrypoint.sh
@@ -3,6 +3,19 @@
 # (junit XML + full log); exit status = test status.
 set -uo pipefail
 source /e2e/lib/run_pytest.sh
+
+# atuin's bash integration is bash-preexec: `atuin init bash` inlines a copy of it and
+# registers into precmd_functions/preexec_functions. brush implements those hooks natively but
+# behind an experimental flag, so without it this suite only ever exercises bash-preexec's own
+# DEBUG-trap emulation. Turn it on through brush's config file rather than a command-line flag:
+# the suite takes a shell path with nowhere to put a flag, and bash ignores the file, so the
+# `--baseline` run is unaffected. Remove once the feature is on by default.
+mkdir -p "$HOME/.config/brush"
+cat >"$HOME/.config/brush/config.toml" <<'TOML'
+[experimental]
+zsh-hooks = true
+TOML
+
 # atuin's suite has its own knob for the shell to test, so it needs no PATH shim (the shim
 # would also capture tmux, which must not run under the shell under test).
 export ATUIN_TEST_BASH="${SHELL_UNDER_TEST:-bash}"


### PR DESCRIPTION
The existing `run_cmd_exec_funcs` support called whatever `precmd_functions` and `preexec_functions` happened to contain, with no setup and no status handling. Make it a real implementation of that contract, in a `brush-interactive::zsh_hooks` module of its own.

`init_zsh_style_hooks` seeds the two registries and claims the `bash_preexec_imported`/`__bp_imported` inclusion guards before profile and rc files load, so a copy of bash-preexec sourced later finds itself "already loaded" and leaves the hooks to us. The guards aren't exported, so a child bash still gets the real implementation. Calling it, and calling it before config files load, is a documented requirement of the feature.

Dispatch honors the rest: `precmd` runs ahead of `PROMPT_COMMAND`; every hook sees the last command's `$?`, `PIPESTATUS`, and `$_`, restored afterwards so neither `PROMPT_COMMAND` nor the next command sees a hook's leavings; a failing hook is reported and the rest still run; a hook that calls `exit` exits the shell. `preexec` fires only for a line that runs a command, matching the `DEBUG` trap it stands in for, and receives the line as typed.

Terminal integration now emits its OSC 633 command markers as a pair from the one path that runs the command. A line a `preexec` hook exited out of never runs and gets neither marker; a `bind -x` command does run and now gets both, where it previously emitted a lone `D`. The integration utility takes on the writing itself and is no longer optional: a shell without integration holds one that reports no capabilities, so every event reported to it does nothing.

The atuin e2e adapter turns the feature on, since `atuin init bash` inlines a copy of bash-preexec. Contract documented in docs/reference/zsh-hooks.md.

BREAKING CHANGE: `InteractiveOptions::run_cmd_exec_funcs` is renamed to `zsh_style_hooks`, and embedders must now call `init_zsh_style_hooks` before loading profile and rc files. Only shell functions are dispatched, matching zsh. Because a sourced bash-preexec now stands down rather than installing itself, the `BP_PIPESTATUS` copy it used to provide is gone; hooks read the real `PIPESTATUS`, which brush restores for them.

Assisted-By: Claude Opus 5